### PR TITLE
Agents update the clone first, and mine past submissions for methods

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,22 @@ every command in this file works either way.
 
 ## Before anything else
 
-Run this. It takes ten seconds and it is not optional:
+Two steps, in this order, and neither is optional.
+
+**First, bring the clone up to date:**
+
+```
+git pull --ff-only
+```
+
+The repository improves between sessions — fixed tools, new methods in `METHODS.md`, fresher
+measured lists, and everybody's merged submissions — so an assistant on a stale clone spends
+the night rediscovering what somebody already wrote down, with tools that may since have been
+fixed. If local changes block the pull, stash them (`git stash`) and pull rather than skip
+this. When a pull changes `src/`, the committed Windows binaries in `bin/windows/` were
+rebuilt to match; on Linux or macOS rebuild once with `cargo build --release`.
+
+**Then run preflight.** It takes ten seconds and it is not optional:
 
 ```
 cargo run --release --bin preflight
@@ -155,6 +170,13 @@ their vocabulary is the game's own.
 This is also why the search is self-feeding: every confirmed name is a new beginning, a new
 ending, and a new numbered family for the next pass to measure. **Run a pass, re-measure, run
 again.** Keep going until a round adds nothing.
+
+**Mine the past submissions too.** Every merged batch in `submissions/` records more than its
+names: the `about_*.md` beside them says which method found them and how long it ran. Read a
+few recent ones before choosing what to run — another machine's names are seed vocabulary for
+yours, and a method its notes prove worked is a better first pick than a guess. This is the
+snowball: every batch that lands makes the next assistant's first hour smarter, but only if
+the next assistant actually looks.
 
 ## Methods that work — a springboard, not a menu
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,22 @@ every command in this file works either way.
 
 ## Before anything else
 
-Run this. It takes ten seconds and it is not optional:
+Two steps, in this order, and neither is optional.
+
+**First, bring the clone up to date:**
+
+```
+git pull --ff-only
+```
+
+The repository improves between sessions — fixed tools, new methods in `METHODS.md`, fresher
+measured lists, and everybody's merged submissions — so an assistant on a stale clone spends
+the night rediscovering what somebody already wrote down, with tools that may since have been
+fixed. If local changes block the pull, stash them (`git stash`) and pull rather than skip
+this. When a pull changes `src/`, the committed Windows binaries in `bin/windows/` were
+rebuilt to match; on Linux or macOS rebuild once with `cargo build --release`.
+
+**Then run preflight.** It takes ten seconds and it is not optional:
 
 ```
 cargo run --release --bin preflight
@@ -155,6 +170,13 @@ their vocabulary is the game's own.
 This is also why the search is self-feeding: every confirmed name is a new beginning, a new
 ending, and a new numbered family for the next pass to measure. **Run a pass, re-measure, run
 again.** Keep going until a round adds nothing.
+
+**Mine the past submissions too.** Every merged batch in `submissions/` records more than its
+names: the `about_*.md` beside them says which method found them and how long it ran. Read a
+few recent ones before choosing what to run — another machine's names are seed vocabulary for
+yours, and a method its notes prove worked is a better first pick than a guess. This is the
+snowball: every batch that lands makes the next assistant's first hour smarter, but only if
+the next assistant actually looks.
 
 ## Methods that work — a springboard, not a menu
 

--- a/METHODS.md
+++ b/METHODS.md
@@ -209,6 +209,42 @@ its own right, and the correct one is often a fragment rather than the whole.
 **Spent when** the harvest has not grown. Like materials-to-images, it is derivative — it yields
 nothing on unchanged input.
 
+## 8. Cross-game known pairs, and the whole-tag sweep
+
+**Builds from** a sibling game that ships the same thing unhashed. Black Ops III ships its
+techsetdefs as plain files, and the newer games carry assets left over from it — so one material
+exported from two games pairs a plain name with the hash of whatever the newer game calls the
+same thing. Three such pairs turn a found transformation into a proof, because whatever maps one
+must map them all.
+
+**Reaches** the techset pools, which no other method touches. A techset name is
+`<base>#<8 hex>`, and the tag is a 32-bit compile stamp that cannot be predicted — but 32 bits
+is small enough to **sweep whole**: with per-digit hash-state reuse, all 4.29 billion tags for
+one base cost about two seconds. Unlike every other method here, a base name is therefore
+*proved or conclusively ruled out*, never merely unswept.
+
+**Run it with** `techset_probe` (a file of candidate bases; sweeps every tag against the
+configured game's techset pool) and `techset_pair` (known `target_hash,plain_name` pairs; tries
+separators and tag widths to crack a convention from specimens).
+
+What it established, 2026-08-18/19:
+
+- **Black Ops 4** `technique_set` (3,597 ids, zero previously named): names are
+  `<base>#<8hex>` with BO3's base vocabulary. Material-class sets carry `mc/`
+  (`mc/lit_backlit#f4b74e85`), screen/2d/compute sets are bare (`zombie_blood#a60c435b`).
+  Tags are per-permutation — one base can hold dozens — and `#a60c435b` is the commonest.
+  1,322 names fell in the first 53-minute sweep.
+- **BO4 simplified BO3's stems** — `lit_weapon` became `lit`, `lit_emissive_scroll` became
+  `lit_emissive` — so trailing-qualifier truncation of known stems is a real seed transform.
+- **Cold War** `techset` (7,096 unnamed): *not* reachable from BO3 stems under any 32-bit tag —
+  full sweeps of every stem × every tag came back empty, which is a conclusive no for that
+  shape. The vocabulary or convention changed again. The next lever is the same trick one
+  generation up: a BO4-leftover asset exported from Cold War pairs a now-known BO4 name with a
+  CW hash.
+
+**Spent when** the base vocabulary stops growing. New bases come from cross-game leftovers,
+stem transforms of confirmed names, and future def dumps — the tag side is never the problem.
+
 ---
 
 ## The unidentified pools

--- a/src/bin/techset_pair.rs
+++ b/src/bin/techset_pair.rs
@@ -1,0 +1,119 @@
+//! Known-pair cracker for techset naming conventions.
+//!
+//! Black Ops 4 carries assets left over from Black Ops III, so the same material exported from
+//! both games gives a known pair: BO3 shows the techset's plain name (`mc/lit_weapon#e6142445`)
+//! and BO4 shows only the hash of whatever BO4 calls the same thing
+//! (`techset_7164a9a402077437`). Whatever transformation connects them must connect every such
+//! pair consistently, so three pairs make a found answer a proof rather than a guess.
+//!
+//! Reads lines of `target_hex,bo3_name` and tries `<base><separator><hex tag>` for every
+//! separator in a small set, every tag width up to eight, and the base both with and without
+//! its directory. The whole tag space is swept at each width, so the original BO3 tag is
+//! covered as one candidate among all of them.
+
+use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Instant;
+
+use slasher::{feed, hash64, read_list, ID_MASK};
+
+const HEX: [u8; 16] = *b"0123456789abcdef";
+const SEPARATORS: [&str; 5] = ["#", "", "_", ".", "@"];
+
+#[inline(always)]
+fn step(hash: u64, byte: u8) -> u64 {
+    feed(hash, &[byte])
+}
+
+/// Every tag of every width up to eight, depth first so states are reused.
+fn sweep(seed: u64, target: u64, label: &str) {
+    let mut stack = [(seed, 0u8); 9];
+    let mut tag = [0u8; 8];
+
+    if seed & ID_MASK == target {
+        println!("  MATCH {label} with no tag at all");
+    }
+
+    let mut depth = 0usize;
+    loop {
+        let (state, digit) = stack[depth];
+        if digit as usize >= HEX.len() {
+            if depth == 0 {
+                break;
+            }
+            depth -= 1;
+            continue;
+        }
+        stack[depth].1 += 1;
+
+        let next = step(state, HEX[digit as usize]);
+        tag[depth] = HEX[digit as usize];
+
+        if next & ID_MASK == target {
+            let text: String = tag[..=depth].iter().map(|&b| b as char).collect();
+            println!("  MATCH {label} tag '{text}' (width {})", depth + 1);
+        }
+
+        if depth + 1 < 8 {
+            depth += 1;
+            stack[depth] = (next, 0);
+        }
+    }
+}
+
+fn main() {
+    let began = Instant::now();
+    assert_eq!(feed(hash64("mc/a"), b"bc#0"), hash64("mc/abc#0"));
+
+    let list = std::env::args().nth(1).expect("a file of target_hex,bo3_name lines");
+    let pairs: Vec<(u64, String, String)> = read_list(Path::new(&list))
+        .into_iter()
+        .filter_map(|line| {
+            let (hex, name) = line.split_once(',')?;
+            let target = u64::from_str_radix(hex.trim(), 16).ok()? & ID_MASK;
+            // The name with its original tag stripped: everything before the '#'.
+            let base = name.split('#').next().unwrap_or(name).trim().to_owned();
+            Some((target, base, name.trim().to_owned()))
+        })
+        .collect();
+
+    println!("{} known pairs", pairs.len());
+
+    // First the literal BO3 names, tag and all -- if BO4 kept them verbatim, done already.
+    for (target, _, original) in &pairs {
+        if hash64(original) & ID_MASK == *target {
+            println!("  MATCH: BO4 kept the BO3 name verbatim: {original}");
+        }
+    }
+
+    // Then every shape: each pair, base with and without its directory, every separator,
+    // every tag width. One work item per (pair, base form, separator).
+    let mut jobs: Vec<(u64, String, String)> = Vec::new();
+    for (target, base, _) in &pairs {
+        let mut forms = vec![base.clone()];
+        if let Some((_, stem)) = base.split_once('/') {
+            forms.push(stem.to_owned());
+        }
+
+        for form in forms {
+            for separator in SEPARATORS {
+                jobs.push((*target, format!("{form}{separator}"), format!("{form}<{separator}>")));
+            }
+        }
+    }
+
+    println!("{} shapes to sweep, all tag widths 0..=8 each", jobs.len());
+
+    let next = AtomicUsize::new(0);
+    std::thread::scope(|scope| {
+        for _ in 0..std::thread::available_parallelism().map(|n| n.get()).unwrap_or(8) {
+            scope.spawn(|| loop {
+                let index = next.fetch_add(1, Ordering::Relaxed);
+                let Some((target, prefix, label)) = jobs.get(index) else { break };
+                sweep(hash64(prefix), *target, label);
+            });
+        }
+    });
+
+    println!("done in {}", slasher::human_duration(began.elapsed()));
+}

--- a/src/bin/techset_probe.rs
+++ b/src/bin/techset_probe.rs
@@ -1,0 +1,182 @@
+//! Scratch probe: can Cold War techset names be reached as `<base>#<8 hex>`?
+//!
+//! Black Ops III ships its techsetdefs unhashed, and a techset's runtime name is the def name
+//! under a material-class directory with a 32-bit tag appended: `mc/lit_weapon_camo#e6142445`.
+//! The tag is derived from the compiled techset, so it cannot be predicted from the name -- but
+//! unlike a mesh entry's 26-character tail, 32 bits is small enough to sweep whole. If Cold War
+//! kept the convention, every BO3 base name can be proved or ruled out exactly, tag and all.
+//!
+//! Reads a list of candidate base names (already carrying any directory prefix), and for each
+//! one hashes all 4,294,967,296 possible tags against the unnamed techset ids. The per-digit
+//! hash states are reused down the eight positions, so a full sweep costs about 4.6 billion
+//! multiplies per base rather than 39 billion.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
+use std::time::Instant;
+
+use slasher::loader::{loaded_assets, unnamed_in};
+use slasher::{
+    expected_by_chance, feed, hash64, paths, pool_index, pool_label, read_list, table_keys,
+    Filter, Results, ID_MASK,
+};
+
+const HEX: [u8; 16] = *b"0123456789abcdef";
+
+#[inline(always)]
+fn step(hash: u64, byte: u8) -> u64 {
+    feed(hash, &[byte])
+}
+
+/// Every tag under one base name, against the filter. Returns `(id, full name)` hits.
+fn sweep(base: &str, filter: &Filter, wanted: &HashMap<u64, usize>) -> Vec<(u64, String)> {
+    let mut hits = Vec::new();
+    let seed = step(hash64(base), b'#');
+
+    for a in HEX {
+        let s1 = step(seed, a);
+        for b in HEX {
+            let s2 = step(s1, b);
+            for c in HEX {
+                let s3 = step(s2, c);
+                for d in HEX {
+                    let s4 = step(s3, d);
+                    for e in HEX {
+                        let s5 = step(s4, e);
+                        for f in HEX {
+                            let s6 = step(s5, f);
+                            for g in HEX {
+                                let s7 = step(s6, g);
+                                for h in HEX {
+                                    let id = step(s7, h) & ID_MASK;
+                                    if filter.may_hold(id) && wanted.contains_key(&id) {
+                                        let tag: String =
+                                            [a, b, c, d, e, f, g, h].iter().map(|&x| x as char).collect();
+                                        hits.push((id, format!("{base}#{tag}")));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    hits
+}
+
+fn main() {
+    let began = Instant::now();
+
+    // The streaming property the sweep depends on, checked rather than trusted.
+    assert_eq!(feed(hash64("mc/a"), b"bc#0"), hash64("mc/abc#0"));
+
+    let list = std::env::args().nth(1).expect("a file of candidate base names");
+    let bases = read_list(Path::new(&list));
+    println!("{} candidate base names from {list}", bases.len());
+
+    let (assets, _) = match loaded_assets() {
+        Ok(loaded) => loaded,
+        Err(reason) => {
+            eprintln!("{reason}");
+            return;
+        }
+    };
+
+    let known = table_keys();
+    // Cold War calls the pool `techset`; Black Ops 4 calls it `technique_set`.
+    let pool = pool_index("techset")
+        .or_else(|| pool_index("technique_set"))
+        .expect("the techset pool");
+    let label = pool_label(pool);
+    let wanted = unnamed_in(&assets, &known, pool);
+    println!(
+        "techset ids in the snapshot: {}, unnamed: {}",
+        assets.iter().filter(|(_, index)| *index == pool).count(),
+        wanted.len()
+    );
+
+    let candidates = bases.len() as u64 * (1u64 << 32);
+    println!(
+        "sweeping {candidates} candidates ({:.2}T); expected by chance: {:.6}",
+        candidates as f64 / 1e12,
+        expected_by_chance(candidates, wanted.len())
+    );
+
+    // Bare names first -- if Cold War dropped the tag, this is the whole answer, instantly.
+    let mut results = Results::load(paths::findings());
+    for base in &bases {
+        let id = hash64(base) & ID_MASK;
+        if wanted.contains_key(&id) {
+            println!("  HIT (no tag) {id:x},{base}");
+            results.add(&label, id, base.clone());
+        }
+    }
+
+    let filter = Filter::sized(wanted.keys(), wanted.len());
+    let next = AtomicUsize::new(0);
+    let found: Mutex<Vec<(u64, String)>> = Mutex::new(Vec::new());
+    let done = AtomicUsize::new(0);
+
+    std::thread::scope(|scope| {
+        for _ in 0..std::thread::available_parallelism().map(|n| n.get()).unwrap_or(8) {
+            scope.spawn(|| loop {
+                let index = next.fetch_add(1, Ordering::Relaxed);
+                let Some(base) = bases.get(index) else { break };
+
+                let hits = sweep(base, &filter, &wanted);
+                if !hits.is_empty() {
+                    let mut all = found.lock().unwrap();
+                    for (id, name) in &hits {
+                        println!("  HIT {id:x},{name}");
+                    }
+                    all.extend(hits);
+                }
+
+                let so_far = done.fetch_add(1, Ordering::Relaxed) + 1;
+                if so_far % 100 == 0 {
+                    let pace = so_far as f64 / began.elapsed().as_secs_f64();
+                    println!(
+                        "  {so_far}/{} bases swept, {:.1}/s, {:.0}s left",
+                        bases.len(),
+                        pace,
+                        (bases.len() - so_far) as f64 / pace
+                    );
+                }
+            });
+        }
+    });
+
+    let found = found.into_inner().unwrap();
+    println!(
+        "\n{} names found in {}",
+        found.len(),
+        slasher::human_duration(began.elapsed())
+    );
+
+    if !found.is_empty() {
+        for (id, name) in &found {
+            results.add(&label, *id, name.clone());
+        }
+    }
+
+    results.write(paths::findings()).expect("the results");
+    match results.write_run(paths::findings(), "techsets") {
+        Ok(Some(folder)) => {
+            println!("this run's own names: {}", folder.display());
+            let _ = Results::note_run(
+                &folder,
+                "BO3 techset tag sweep (techset_probe)",
+                "every Black Ops III techsetdef base name given every possible 32-bit tag -- \
+                 the tag space is small enough to sweep whole, so each base is proved or \
+                 ruled out exactly",
+                began.elapsed(),
+            );
+        }
+        Ok(None) => println!("this run found nothing new"),
+        Err(error) => eprintln!("the run folder could not be written: {error}"),
+    }
+}


### PR DESCRIPTION
Two additions to the assistant instructions (`AGENTS.md` + its byte-identical `CLAUDE.md` copy), both about making sessions compound instead of repeat. Stacked on #3 (whose run-notes feature is what makes the second half possible) — merge #1 → #3 → this, and the diff collapses to one commit.

## 1. Update the clone before anything else

New step zero, ahead of preflight:

```
git pull --ff-only
```

The repository improves between sessions — fixed tools, new METHODS.md entries, fresher measured lists, and everybody's merged submissions — so an assistant on a stale clone spends the night rediscovering what somebody already wrote down, possibly with tools that have since been fixed. (Tonight's sessions hit exactly this: two fresh-clone bugs and a stale local table clone, all invisible until compared against current upstream.) The instruction covers the stash-first case for local changes and the rebuild-on-pull rule for non-Windows.

## 2. Mine `submissions/` for methods, not just exclusions

Since #3, every submitted batch records *how it was found*: the `about_*.md` beside the names says which method ran and for how long. That turns the submissions folder into a growing, self-documenting library of proven methods and seed vocabulary from every contributing machine — but only if the next assistant actually reads it. The seeding-principle section now tells it to, explicitly, before choosing what to run.

Between the two: every machine pulls down what every other machine learned, every batch teaches its method to the next session, and the first hour of any new session starts from the current frontier instead of from the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)