### PR TITLE
The pools are all identified — remove the stale pool_NNN story

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,6 +258,7 @@ Filenames carry the date and time to the second, so nothing collides with a prev
 - `METHODS.md` — the methods in more detail, and what each reaches that nothing else does.
 - `src/lib.rs` — the hash, the filter, the results type.
 - `src/search.rs` — the peeling engine. Read the comments before changing anything here.
-- `snapshots/*.pools.txt` — every pool, with how many assets it holds. The unidentified ones are
-  named `pool_NNN`; **working out what any of them is, is a genuinely valuable contribution**,
-  because names in an unidentified pool cannot be submitted upstream until the type is known.
+- `snapshots/*.pools.txt` — every pool in both games, identified and counted. This is the map
+  of where the unnamed ids live. (Some *types* still lack a destination table upstream in
+  cod-name-db — a confirmed `technique_set` name has nowhere to land yet — and **giving such a
+  type a home upstream is a genuinely valuable contribution**.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,6 +258,7 @@ Filenames carry the date and time to the second, so nothing collides with a prev
 - `METHODS.md` — the methods in more detail, and what each reaches that nothing else does.
 - `src/lib.rs` — the hash, the filter, the results type.
 - `src/search.rs` — the peeling engine. Read the comments before changing anything here.
-- `snapshots/*.pools.txt` — every pool, with how many assets it holds. The unidentified ones are
-  named `pool_NNN`; **working out what any of them is, is a genuinely valuable contribution**,
-  because names in an unidentified pool cannot be submitted upstream until the type is known.
+- `snapshots/*.pools.txt` — every pool in both games, identified and counted. This is the map
+  of where the unnamed ids live. (Some *types* still lack a destination table upstream in
+  cod-name-db — a confirmed `technique_set` name has nowhere to land yet — and **giving such a
+  type a home upstream is a genuinely valuable contribution**.)

--- a/METHODS.md
+++ b/METHODS.md
@@ -247,28 +247,18 @@ stem transforms of confirmed names, and future def dumps — the tag side is nev
 
 ---
 
-## The unidentified pools
+## The pools are all identified
 
-This is the largest single piece of unfinished business in the project, and it is not a search
-problem at all.
+An earlier version of this file called 67 pools "unidentified", labelled `pool_NNN`, with
+`pool_184` alone holding 52,677 stuck names. That is no longer true and has not been for some
+time: the pool labels have since been completed, and `snapshots/*.pools.txt` names **every
+filled pool in both games** — 202 for Cold War, 156 for Black Ops 4 — with its asset type and
+count. There is nothing left to identify, and no findings are stuck for want of a type.
 
-Cold War has **67 pools holding confirmed names that are labelled `pool_NNN`**, because nobody has
-worked out what asset type they are. A name in an unidentified pool **cannot be submitted upstream
-until its type is known**, so these names are found, proven, and stuck.
-
-**`pool_184` alone holds 52,677 confirmed names — 57% of the entire current haul.** Its contents
-look like a streaming or stream-key pool, naming the assets it streams:
-
-```
-core_frontend.d0 stream tree mtlGroup 14
-rev/2020/2020_dodge_challenger_truck_dmg.mod.vl100.pc.all.snd_transient
-maps/wz/wz_forest.d3dbsp_s0__terrain_l00_n000770
-```
-
-Identifying the top few pool numbers converts the bulk of the haul into something submittable. It
-needs no grinding and no game — just someone working out what the enum index means. **This is the
-highest-value non-grinding contribution available**, and the best first task for a new
-contributor. Every pool with its count is in `snapshots/*.pools.txt`.
+What remains real is narrower. Some identified *types* have no destination table in
+cod-name-db yet — a confirmed `technique_set` name has no `fnv1a_techsets.csv` upstream to
+land in. Giving such types a home is the useful non-grinding contribution this section used to
+mis-describe.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -104,11 +104,12 @@ build a process-memory reader they cannot use.
 Findings arrive as pull requests, opened for you — you do not need to know git. They are
 checked automatically and reviewed by hand before going upstream.
 
-The most useful non-grinding contribution: **the unidentified pools**. A game holds assets in
-numbered pools, and only some of those numbers have known asset types. Cold War has 67 pools
-holding confirmed names that are labelled `pool_184` and the like, because nobody has worked out
-what they are — and a name in an unidentified pool cannot be submitted upstream until its type is
-known. `pool_184` alone holds over 52,000 confirmed names. See `snapshots/*.pools.txt`.
+The most useful non-grinding contribution: **a home for the types that have no table**. Every
+pool in both games is identified — `snapshots/*.pools.txt` is the complete map of every index,
+its asset type, and how many assets it holds. What some types still lack is a *destination*:
+cod-name-db carries tables for models, anims, images, materials and sounds, but a confirmed
+`technique_set` name, for example, has no csv upstream to land in yet. Proposing and seeding
+those tables is how whole pools' worth of findings become publishable.
 
 ## The hash tables
 


### PR DESCRIPTION
README line ~123, METHODS' "The unidentified pools" section, and the agent instructions all still claim Cold War has 67 unidentified `pool_NNN` pools with `pool_184` holding 52,677 stuck names — and pitch identifying them as the best first contribution for a newcomer.

Checked against the actual files: **zero** `pool_NNN` labels remain in either `snapshots/*.pools.txt`. Every filled pool in both games is identified and counted — 202 for Cold War, 156 for Black Ops 4, right up to index 220. The prose describes a labelling state that the `pool-counts` regeneration fixed, and an assistant (or person) reading it goes hunting for a job that no longer exists.

Replaced in all three places (plus the byte-identical `CLAUDE.md`) with what's actually true and actually useful: the pools file is the complete map, and the real remaining gap is that some identified **types** have no destination table upstream in cod-name-db yet — e.g. the 1,600+ `technique_set` names confirmed this week have no `fnv1a_techsets.csv` to land in. Proposing and seeding those tables is the genuine non-grinding contribution.

Stacked on the earlier chain (#1 → #3 → #5 → #8); merge in order and this collapses to one commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)