### PR TITLE
findings from eMoXMaNgA, 20260819-145551 (6 names)

### DIFF
--- a/submissions/eMoXMaNgA_20260819-145551/about_20260819-145551.md
+++ b/submissions/eMoXMaNgA_20260819-145551/about_20260819-145551.md
@@ -1,0 +1,17 @@
+# Submission 20260819-145551
+
+- from: eMoXMaNgA
+- names: 6
+- dropped as already published: 0
+- runs included: 1
+- searched: 4 pool(s): sound, sound_asset, sound_bank, sound_duck
+- expected coincidental matches: 0.000000
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260819-142133_swaps_unique_v2
+- method: sound token swaps, deduplicated
+- what it does: each token of a sound name was replaced with established game vocabulary; rows already present in contributor submissions were excluded before submission
+- ran for: 0m 34s

--- a/submissions/eMoXMaNgA_20260819-145551/sound_bank_20260819-145551.txt
+++ b/submissions/eMoXMaNgA_20260819-145551/sound_bank_20260819-145551.txt
@@ -1,0 +1,2 @@
+20a569249575473d,mp_common.all
+584e8a5a6934d645,zm_common.all

--- a/submissions/eMoXMaNgA_20260819-145551/sound_duck_20260819-145551.txt
+++ b/submissions/eMoXMaNgA_20260819-145551/sound_duck_20260819-145551.txt
@@ -1,0 +1,4 @@
+5e096ee43651d97b,mpl_final_killcam
+259976b936dae1a2,wpn_tank_fire
+148ff8b60faea8a,wz_death_circle
+187593a2cde27861,zmb_player_swiped


### PR DESCRIPTION
6 asset names, confirmed against the game's own loaded assets and checked against the tables immediately before sending.

- dropped as already published: 0
- submitted by: @eMoXMaNgA

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260819-142133_swaps_unique_v2
- method: sound token swaps, deduplicated
- what it does: each token of a sound name was replaced with established game vocabulary; rows already present in contributor submissions were excluded before submission
- ran for: 0m 34s
