### PR TITLE
[BLKOPSCW] findings from KingslayerKyle, 20260820-054028 (3 names)

### DIFF
--- a/submissions/KingslayerKyle_BLKOPSCW_20260820-054028/about_20260820-054028.md
+++ b/submissions/KingslayerKyle_BLKOPSCW_20260820-054028/about_20260820-054028.md
@@ -1,0 +1,29 @@
+# Submission 20260820-054028
+
+- game: **BLKOPSCW**
+- from: KingslayerKyle
+- names: 3
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 0 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260820-054025_list
+- method: blkopscw_edits_material
+- what it does: a candidate list generated outside the search and confirmed here
+- ran for: 57s
+- game: BLKOPSCW
+- candidates tested: 29916874
+- matched: 5
+- new: 3
+- ids hunted: 157589
+- throughput: 0.5M candidates/s
+- fingerprint: 0d2694fcb1f3e958
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/KingslayerKyle_BLKOPSCW_20260820-054028/material_20260820-054028.txt
+++ b/submissions/KingslayerKyle_BLKOPSCW_20260820-054028/material_20260820-054028.txt
@@ -1,0 +1,3 @@
+5e5aa070d2d8b79,mc/t8_lv8_mud_ground_dirt_01_light_blend
+68178ec872b0f1c1,mc/mtl_veh_t9_mil_boat_jetski_body_a_paint_b_dead_mpx_evil
+7e0e03c6d2fdf224,mc/mtl_veh_t9_mil_boat_jetski_body_a_paint_a_dead_mpx_evil


### PR DESCRIPTION
**BLKOPSCW** — 3 asset names, confirmed against that game's own loaded assets.

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @KingslayerKyle

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260820-054025_list
- method: blkopscw_edits_material
- what it does: a candidate list generated outside the search and confirmed here
- ran for: 57s
- game: BLKOPSCW
- candidates tested: 29916874
- matched: 5
- new: 3
- ids hunted: 157589
- throughput: 0.5M candidates/s
- fingerprint: 0d2694fcb1f3e958

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/token_edits.py`
- `scripts/contributed/image_siblings_20260819-190013.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.