### PR TITLE
[BLKOPSCW] findings from GoastcraftHD, 20260820-093342 (3 names)

### DIFF
--- a/submissions/GoastcraftHD_BLKOPSCW_20260820-093342/about_20260820-093342.md
+++ b/submissions/GoastcraftHD_BLKOPSCW_20260820-093342/about_20260820-093342.md
@@ -1,0 +1,33 @@
+# Submission 20260820-093342
+
+- game: **BLKOPSCW**
+- from: GoastcraftHD
+- names: 3
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 0 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260820-093307_soundfiles
+- method: sound files and aliases (confirm_cw --sounds)
+- what it does: every seed cut to pieces at its marks and recombined as beginning + stem + ending, each candidate hashed and looked up among the game's unnamed ids
+- ran for: 15m 45s
+- game: BLKOPSCW
+- pools searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- seed lines: 4683825
+- distinct pieces: 35456730
+- beginnings: 700
+- endings: 4800
+- ids hunted: 38940
+- matches: 63
+- distinct names reached: 15
+- new here: 3
+- fingerprint: 186fa15c08d9a1a6
+
+**Next:** this configuration is now exhausted. Re-measure the lists with `python scripts/derive_lists.py` so the confirmed names widen them, which changes the fingerprint and reopens the method -- or run a method that reaches somewhere else entirely (METHODS.md).

--- a/submissions/GoastcraftHD_BLKOPSCW_20260820-093342/sound_alias_20260820-093342.txt
+++ b/submissions/GoastcraftHD_BLKOPSCW_20260820-093342/sound_alias_20260820-093342.txt
@@ -1,0 +1,3 @@
+bec6920c3567d39,veh_jetfighter_missile_loop
+21db23e2e71933cc,evt_doa_pickup_weapon_upgraded
+2c4270e155a5159f,phy_toy_car_bounce


### PR DESCRIPTION
**BLKOPSCW** — 3 asset names, confirmed against that game's own loaded assets.

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @GoastcraftHD

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260820-093307_soundfiles
- method: sound files and aliases (confirm_cw --sounds)
- what it does: every seed cut to pieces at its marks and recombined as beginning + stem + ending, each candidate hashed and looked up among the game's unnamed ids
- ran for: 15m 45s
- game: BLKOPSCW
- pools searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
- seed lines: 4683825
- distinct pieces: 35456730
- beginnings: 700
- endings: 4800
- ids hunted: 38940
- matches: 63
- distinct names reached: 15
- new here: 3
- fingerprint: 186fa15c08d9a1a6

**Next:** this configuration is now exhausted. Re-measure the lists with `python scripts/derive_lists.py` so the confirmed names widen them, which changes the fingerprint and reopens the method -- or run a method that reaches somewhere else entirely (METHODS.md).


## Tooling this run leaves behind

- `scripts/contributed/soundxfer_20260820-022851.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.