### PR TITLE
[BLKOPSCW] findings from Naymmmm, 20260820-093706 (4 names)

### DIFF
--- a/submissions/Naymmmm_BLKOPSCW_20260820-093706/about_20260820-093706.md
+++ b/submissions/Naymmmm_BLKOPSCW_20260820-093706/about_20260820-093706.md
@@ -1,0 +1,33 @@
+# Submission 20260820-093706
+
+- game: **BLKOPSCW**
+- from: Naymmmm
+- names: 4
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 0 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260820-093645_seeds
+- method: general search, confirmed seeds only (confirm_cw seeds)
+- what it does: every seed cut to pieces at its marks and recombined as beginning + stem + ending, each candidate hashed and looked up among the game's unnamed ids
+- ran for: 45s
+- game: BLKOPSCW
+- pools searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- seed lines: 25
+- distinct pieces: 2010
+- beginnings: 700
+- endings: 4800
+- ids hunted: 113352
+- matches: 35
+- distinct names reached: 8
+- new here: 4
+- fingerprint: 2471ad67a11ef7b6
+
+**Next:** this configuration is now exhausted. Re-measure the lists with `python scripts/derive_lists.py` so the confirmed names widen them, which changes the fingerprint and reopens the method -- or run a method that reaches somewhere else entirely (METHODS.md).

--- a/submissions/Naymmmm_BLKOPSCW_20260820-093706/material_20260820-093706.txt
+++ b/submissions/Naymmmm_BLKOPSCW_20260820-093706/material_20260820-093706.txt
@@ -1,0 +1,1 @@
+287726725b982b90,mc/mtl_p8_wmd_inclinator_grating_frame

--- a/submissions/Naymmmm_BLKOPSCW_20260820-093706/xmodel_20260820-093706.txt
+++ b/submissions/Naymmmm_BLKOPSCW_20260820-093706/xmodel_20260820-093706.txt
@@ -1,0 +1,3 @@
+204f9a2ff9b857ef,clt/p9_zm_tmb_wood_wall_wet_64x96_dmg
+2106b897687a42bb,cltp/p9_zm_tmb_wood_wall_wet_64x96_dmg
+33da4dbc3f02e935,p9_zm_tmb_wood_wall_wet_64x96_dmg


### PR DESCRIPTION
**BLKOPSCW** — 4 asset names, confirmed against that game's own loaded assets.

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Naymmmm

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260820-093645_seeds
- method: general search, confirmed seeds only (confirm_cw seeds)
- what it does: every seed cut to pieces at its marks and recombined as beginning + stem + ending, each candidate hashed and looked up among the game's unnamed ids
- ran for: 45s
- game: BLKOPSCW
- pools searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
- seed lines: 25
- distinct pieces: 2010
- beginnings: 700
- endings: 4800
- ids hunted: 113352
- matches: 35
- distinct names reached: 8
- new here: 4
- fingerprint: 2471ad67a11ef7b6

**Next:** this configuration is now exhausted. Re-measure the lists with `python scripts/derive_lists.py` so the confirmed names widen them, which changes the fingerprint and reopens the method -- or run a method that reaches somewhere else entirely (METHODS.md).
