### PR TITLE
[BLKOPS04] findings from GoastcraftHD, 20260820-094017 (2 names)

### DIFF
--- a/submissions/GoastcraftHD_BLKOPS04_20260820-094017/about_20260820-094017.md
+++ b/submissions/GoastcraftHD_BLKOPS04_20260820-094017/about_20260820-094017.md
@@ -1,0 +1,29 @@
+# Submission 20260820-094017
+
+- game: **BLKOPS04**
+- from: GoastcraftHD
+- names: 2
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 2 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260820-093950_list
+- method: alias slot substitution, cap 400
+- what it does: alias slot substitution with the per-context alphabet effectively uncapped at 400 substitutes
+- ran for: 6s
+- game: BLKOPS04
+- candidates tested: 2897349
+- matched: 7014
+- new: 2
+- ids hunted: 194617
+- throughput: 1.1M candidates/s
+- fingerprint: ccbca8bc7ad35701
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/GoastcraftHD_BLKOPS04_20260820-094017/sound_alias_20260820-094017.txt
+++ b/submissions/GoastcraftHD_BLKOPS04_20260820-094017/sound_alias_20260820-094017.txt
@@ -1,0 +1,2 @@
+525a60fc83843311,fly_lstep_sprint_lt_npc_tallgrass
+7d71b0d24f6d481e,fly_lstep_run_lt_npc_tallgrass


### PR DESCRIPTION
**BLKOPS04** — 2 asset names, confirmed against that game's own loaded assets.

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @GoastcraftHD

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260820-093950_list
- method: alias slot substitution, cap 400
- what it does: alias slot substitution with the per-context alphabet effectively uncapped at 400 substitutes
- ran for: 6s
- game: BLKOPS04
- candidates tested: 2897349
- matched: 7014
- new: 2
- ids hunted: 194617
- throughput: 1.1M candidates/s
- fingerprint: ccbca8bc7ad35701

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/aliasswap.py`
- `scripts/contributed/soundxfer_20260820-022851.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.