### PR TITLE
[BLKOPSCW] findings from Naymmmm, 20260820-095500 (3 names)

### DIFF
--- a/submissions/Naymmmm_BLKOPSCW_20260820-095500/about_20260820-095500.md
+++ b/submissions/Naymmmm_BLKOPSCW_20260820-095500/about_20260820-095500.md
@@ -1,0 +1,33 @@
+# Submission 20260820-095500
+
+- game: **BLKOPSCW**
+- from: Naymmmm
+- names: 3
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 1
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 0 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260820-095426_all
+- method: general search (confirm_cw)
+- what it does: every seed cut to pieces at its marks and recombined as beginning + stem + ending, each candidate hashed and looked up among the game's unnamed ids
+- ran for: 4m 01s
+- game: BLKOPSCW
+- pools searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- seed lines: 3256600
+- distinct pieces: 31013417
+- beginnings: 700
+- endings: 4800
+- ids hunted: 113352
+- matches: 118
+- distinct names reached: 14
+- new here: 4
+- fingerprint: 86b1dfedf473cd35
+
+**Next:** this configuration is now exhausted. Re-measure the lists with `python scripts/derive_lists.py` so the confirmed names widen them, which changes the fingerprint and reopens the method -- or run a method that reaches somewhere else entirely (METHODS.md).

--- a/submissions/Naymmmm_BLKOPSCW_20260820-095500/material_20260820-095500.txt
+++ b/submissions/Naymmmm_BLKOPSCW_20260820-095500/material_20260820-095500.txt
@@ -1,0 +1,2 @@
+7797ce2dd612164a,mc/mtl_veh_t9_fav_light_decal_stain_01
+77ee606fa08fbfc1,el/gfx_desat_tracer_doa

--- a/submissions/Naymmmm_BLKOPSCW_20260820-095500/xanim_20260820-095500.txt
+++ b/submissions/Naymmmm_BLKOPSCW_20260820-095500/xanim_20260820-095500.txt
@@ -1,0 +1,1 @@
+27160c134f0e28a5,mc/mtl_uicon_/env/env_rain_drainage_metal_sml_lp_03.rr75_grating_frame_o


### PR DESCRIPTION
**BLKOPSCW** — 3 asset names, confirmed against that game's own loaded assets.

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 1
- submitted by: @Naymmmm

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260820-095426_all
- method: general search (confirm_cw)
- what it does: every seed cut to pieces at its marks and recombined as beginning + stem + ending, each candidate hashed and looked up among the game's unnamed ids
- ran for: 4m 01s
- game: BLKOPSCW
- pools searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
- seed lines: 3256600
- distinct pieces: 31013417
- beginnings: 700
- endings: 4800
- ids hunted: 113352
- matches: 118
- distinct names reached: 14
- new here: 4
- fingerprint: 86b1dfedf473cd35

**Next:** this configuration is now exhausted. Re-measure the lists with `python scripts/derive_lists.py` so the confirmed names widen them, which changes the fingerprint and reopens the method -- or run a method that reaches somewhere else entirely (METHODS.md).
