### PR TITLE
[BLKOPS04] findings from BrandonT01, 20260820-095512 (10 names)

### DIFF
--- a/submissions/BrandonT01_BLKOPS04_20260820-095512/about_20260820-095512.md
+++ b/submissions/BrandonT01_BLKOPS04_20260820-095512/about_20260820-095512.md
@@ -1,0 +1,29 @@
+# Submission 20260820-095512
+
+- game: **BLKOPS04**
+- from: BrandonT01
+- names: 10
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 1 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260820-095455_list
+- method: per-prefix continuations, depth 2 cap 24
+- what it does: a candidate list generated outside the search and confirmed here
+- ran for: 1m 01s
+- game: BLKOPS04
+- candidates tested: 39944425
+- matched: 10
+- new: 10
+- ids hunted: 192762
+- throughput: 0.7M candidates/s
+- fingerprint: 70fd706faa198221
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/BrandonT01_BLKOPS04_20260820-095512/image_20260820-095512.txt
+++ b/submissions/BrandonT01_BLKOPS04_20260820-095512/image_20260820-095512.txt
@@ -1,0 +1,2 @@
+75dd08ed15576502,i_mtl_veh_t8_mil_truck_att_body_front_int_n
+75dd09ed155766b5,i_mtl_veh_t8_mil_truck_att_body_front_int_o

--- a/submissions/BrandonT01_BLKOPS04_20260820-095512/material_20260820-095512.txt
+++ b/submissions/BrandonT01_BLKOPS04_20260820-095512/material_20260820-095512.txt
@@ -1,0 +1,3 @@
+47a328ecd3a2fd9,mc/mtl_p8_zm_vapor_altar_ra_head_copper
+62cfc891f2e1f93,mc/mtl_p8_zm_vapor_altar_odin_arms_copper
+34e3eebe554525aa,mc/mtl_p8_zm_vapor_altar_ra_head_gold

--- a/submissions/BrandonT01_BLKOPS04_20260820-095512/sound_alias_20260820-095512.txt
+++ b/submissions/BrandonT01_BLKOPS04_20260820-095512/sound_alias_20260820-095512.txt
@@ -1,0 +1,1 @@
+1662c44b5454b005,pfx_water_cannon_spray

--- a/submissions/BrandonT01_BLKOPS04_20260820-095512/xanim_20260820-095512.txt
+++ b/submissions/BrandonT01_BLKOPS04_20260820-095512/xanim_20260820-095512.txt
@@ -1,0 +1,1 @@
+3cb9fef1326f10ab,vm_zom_zhield_zpear_turret_fire

--- a/submissions/BrandonT01_BLKOPS04_20260820-095512/xmodel_20260820-095512.txt
+++ b/submissions/BrandonT01_BLKOPS04_20260820-095512/xmodel_20260820-095512.txt
@@ -1,0 +1,3 @@
+22cf6581c441016d,p8_zm_man_courtyard_column_post_02
+4b06c6402ce18020,p8_lv8_shrine_wall_trim_32
+670f1e0c48689612,p8_lv8_shrine_wall_trim_256


### PR DESCRIPTION
**BLKOPS04** — 10 asset names, confirmed against that game's own loaded assets.

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @BrandonT01

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260820-095455_list
- method: per-prefix continuations, depth 2 cap 24
- what it does: a candidate list generated outside the search and confirmed here
- ran for: 1m 01s
- game: BLKOPS04
- candidates tested: 39944425
- matched: 10
- new: 10
- ids hunted: 192762
- throughput: 0.7M candidates/s
- fingerprint: 70fd706faa198221

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/continuations.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.