### PR TITLE
[BLKOPSCW] findings from BrandonT01, 20260820-095645 (4 names)

### DIFF
--- a/submissions/BrandonT01_BLKOPSCW_20260820-095645/about_20260820-095645.md
+++ b/submissions/BrandonT01_BLKOPSCW_20260820-095645/about_20260820-095645.md
@@ -1,0 +1,29 @@
+# Submission 20260820-095645
+
+- game: **BLKOPSCW**
+- from: BrandonT01
+- names: 4
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 0 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260820-095636_list
+- method: per-prefix continuations, depth 2 cap 24
+- what it does: a candidate list generated outside the search and confirmed here
+- ran for: 1m 01s
+- game: BLKOPSCW
+- candidates tested: 39957213
+- matched: 4
+- new: 4
+- ids hunted: 150447
+- throughput: 0.7M candidates/s
+- fingerprint: f1b5f5a8bea17838
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/BrandonT01_BLKOPSCW_20260820-095645/material_20260820-095645.txt
+++ b/submissions/BrandonT01_BLKOPSCW_20260820-095645/material_20260820-095645.txt
@@ -1,0 +1,2 @@
+37ff70477e80e493,mc/mtl_veh_t9_mil_ru_helicopter_transport_door_paint_inner_a
+37ff71477e80e646,mc/mtl_veh_t9_mil_ru_helicopter_transport_door_paint_inner_b

--- a/submissions/BrandonT01_BLKOPSCW_20260820-095645/sound_alias_20260820-095645.txt
+++ b/submissions/BrandonT01_BLKOPSCW_20260820-095645/sound_alias_20260820-095645.txt
@@ -1,0 +1,2 @@
+9dbd105c3060c91,zmb_powerup_default_grabbed
+5d4791cbd4a77bbd,vox_zamr_vignette_fskn_10


### PR DESCRIPTION
**BLKOPSCW** — 4 asset names, confirmed against that game's own loaded assets.

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @BrandonT01

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260820-095636_list
- method: per-prefix continuations, depth 2 cap 24
- what it does: a candidate list generated outside the search and confirmed here
- ran for: 1m 01s
- game: BLKOPSCW
- candidates tested: 39957213
- matched: 4
- new: 4
- ids hunted: 150447
- throughput: 0.7M candidates/s
- fingerprint: f1b5f5a8bea17838

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/continuations.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.