### PR TITLE
[BLKOPS04] findings from KingslayerKyle, 20260820-111631 (1 names)

### DIFF
--- a/submissions/KingslayerKyle_BLKOPS04_20260820-111631/about_20260820-111631.md
+++ b/submissions/KingslayerKyle_BLKOPS04_20260820-111631/about_20260820-111631.md
@@ -1,0 +1,31 @@
+# Submission 20260820-111631
+
+- game: **BLKOPS04**
+- from: KingslayerKyle
+- names: 1
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- confirmed on: not recorded (run predates this field)
+- xmodel: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 0 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260820-111521_list
+- method: affix sweep
+- what it does: a candidate list generated outside the search and confirmed here
+- ran for: 8m 29s
+- game: BLKOPS04
+- candidates tested: 532497168
+- matched: 4
+- new: 1
+- ids hunted: 212555
+- throughput: 1.0M candidates/s
+- fingerprint: ce7845d0a270de39
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/KingslayerKyle_BLKOPS04_20260820-111631/xmodel_20260820-111631.txt
+++ b/submissions/KingslayerKyle_BLKOPS04_20260820-111631/xmodel_20260820-111631.txt
@@ -1,0 +1,1 @@
+3775fde1b973a8dc,c_t8_zmb_dlc3_mannequin_female_static_standpose_body_color_01


### PR DESCRIPTION
**BLKOPS04** — 1 asset names, confirmed against that game's own loaded assets.

- xmodel: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @KingslayerKyle

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260820-111521_list
- method: affix sweep
- what it does: a candidate list generated outside the search and confirmed here
- ran for: 8m 29s
- game: BLKOPS04
- candidates tested: 532497168
- matched: 4
- new: 1
- ids hunted: 212555
- throughput: 1.0M candidates/s
- fingerprint: ce7845d0a270de39

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/affix_sweep.py`
- `scripts/contributed/image_siblings_20260819-190013.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.