### PR TITLE
[BLKOPSCW] findings from droads, 20260820-132618 (5 names)

### DIFF
--- a/submissions/droads_BLKOPSCW_20260820-132618/about_20260820-132618.md
+++ b/submissions/droads_BLKOPSCW_20260820-132618/about_20260820-132618.md
@@ -1,0 +1,38 @@
+# Submission 20260820-132618
+
+- game: **BLKOPSCW**
+- from: droads
+- names: 5
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- sound_alias: 5
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 0 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260820-131233_soundfiles
+- method: sound files and aliases (confirm_cw --sounds)
+- what it does: every seed cut to pieces at its marks and recombined as beginning + stem + ending, each candidate hashed and looked up among the game's unnamed ids
+- ran for: 12m 53s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- pools searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- seed lines: 3256504
+- distinct pieces: 31012272
+- beginnings: 700
+- endings: 4800
+- ids hunted: 37631
+- matches: 6
+- distinct names reached: 5
+- new here: 5
+- fingerprint: ce8a4d05f1254e84
+
+**Next:** this configuration is now exhausted. Re-measure the lists with `python scripts/derive_lists.py` so the confirmed names widen them, which changes the fingerprint and reopens the method -- or run a method that reaches somewhere else entirely (METHODS.md).

--- a/submissions/droads_BLKOPSCW_20260820-132618/sound_alias_20260820-132618.txt
+++ b/submissions/droads_BLKOPSCW_20260820-132618/sound_alias_20260820-132618.txt
@@ -1,0 +1,5 @@
+8c162acb2120a99,fly_knife_loadout_first_raise_npc
+12472677759c3657,evt_execution_activation_oneshot
+55dc1289e1b96529,mus_matchend_lose_03_loop_0
+75d709e2b871130e,mus_matchend_win_03_loop_0
+777ebb44d10da482,mus_matchend_draw_03_loop_0


### PR DESCRIPTION
**BLKOPSCW** — 5 asset names, confirmed against that game's own loaded assets.

- sound_alias: 5

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @droads

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260820-131233_soundfiles
- method: sound files and aliases (confirm_cw --sounds)
- what it does: every seed cut to pieces at its marks and recombined as beginning + stem + ending, each candidate hashed and looked up among the game's unnamed ids
- ran for: 12m 53s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- pools searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
- seed lines: 3256504
- distinct pieces: 31012272
- beginnings: 700
- endings: 4800
- ids hunted: 37631
- matches: 6
- distinct names reached: 5
- new here: 5
- fingerprint: ce8a4d05f1254e84

**Next:** this configuration is now exhausted. Re-measure the lists with `python scripts/derive_lists.py` so the confirmed names widen them, which changes the fingerprint and reopens the method -- or run a method that reaches somewhere else entirely (METHODS.md).
