### PR TITLE
[BLKOPSCW] findings from KingslayerKyle, 20260820-151554 (2 names)

### DIFF
--- a/submissions/KingslayerKyle_BLKOPSCW_20260820-151554/about_20260820-151554.md
+++ b/submissions/KingslayerKyle_BLKOPSCW_20260820-151554/about_20260820-151554.md
@@ -1,0 +1,34 @@
+# Submission 20260820-151554
+
+- game: **BLKOPSCW**
+- from: KingslayerKyle
+- names: 2
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- xmodel: 2
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 0 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260820-151524_list
+- method: blkopscw_edits_model
+- what it does: a candidate list generated outside the search and confirmed here
+- ran for: 26s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- candidates tested: 13215538
+- matched: 2
+- new: 2
+- ids hunted: 150045
+- throughput: 0.5M candidates/s
+- fingerprint: 0e9ebc24a19aaf5c
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/KingslayerKyle_BLKOPSCW_20260820-151554/xmodel_20260820-151554.txt
+++ b/submissions/KingslayerKyle_BLKOPSCW_20260820-151554/xmodel_20260820-151554.txt
@@ -1,0 +1,2 @@
+2c97c0552ab2b40b,p9_rm_zoo2_relief_pentagram
+63aa56381bcfa86b,p9_dun_fuel_tank_01_crawler_cradle_03


### PR DESCRIPTION
**BLKOPSCW** — 2 asset names, confirmed against that game's own loaded assets.

- xmodel: 2

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @KingslayerKyle

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260820-151524_list
- method: blkopscw_edits_model
- what it does: a candidate list generated outside the search and confirmed here
- ran for: 26s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- candidates tested: 13215538
- matched: 2
- new: 2
- ids hunted: 150045
- throughput: 0.5M candidates/s
- fingerprint: 0e9ebc24a19aaf5c

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/token_edits.py`
- `scripts/contributed/image_siblings_20260819-190013.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.