### PR TITLE
[BLKOPSCW] findings from KingslayerKyle, 20260820-151807 (1 names)

### DIFF
--- a/submissions/KingslayerKyle_BLKOPSCW_20260820-151807/about_20260820-151807.md
+++ b/submissions/KingslayerKyle_BLKOPSCW_20260820-151807/about_20260820-151807.md
@@ -1,0 +1,34 @@
+# Submission 20260820-151807
+
+- game: **BLKOPSCW**
+- from: KingslayerKyle
+- names: 1
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- image: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 0 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260820-151705_list
+- method: blkopscw_edits_image
+- what it does: a candidate list generated outside the search and confirmed here
+- ran for: 58s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- candidates tested: 30538103
+- matched: 1
+- new: 1
+- ids hunted: 150045
+- throughput: 0.5M candidates/s
+- fingerprint: 9baaa7b9e57197bd
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/KingslayerKyle_BLKOPSCW_20260820-151807/image_20260820-151807.txt
+++ b/submissions/KingslayerKyle_BLKOPSCW_20260820-151807/image_20260820-151807.txt
@@ -1,0 +1,1 @@
+709149cdd29244e7,i_jun_ter_wood_burnt_n


### PR DESCRIPTION
**BLKOPSCW** — 1 asset names, confirmed against that game's own loaded assets.

- image: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @KingslayerKyle

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260820-151705_list
- method: blkopscw_edits_image
- what it does: a candidate list generated outside the search and confirmed here
- ran for: 58s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- candidates tested: 30538103
- matched: 1
- new: 1
- ids hunted: 150045
- throughput: 0.5M candidates/s
- fingerprint: 9baaa7b9e57197bd

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/token_edits.py`
- `scripts/contributed/image_siblings_20260819-190013.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.