### PR TITLE
[BLKOPSCW] findings from KingslayerKyle, 20260820-151954 (10 names)

### DIFF
--- a/submissions/KingslayerKyle_BLKOPSCW_20260820-151954/about_20260820-151954.md
+++ b/submissions/KingslayerKyle_BLKOPSCW_20260820-151954/about_20260820-151954.md
@@ -1,0 +1,37 @@
+# Submission 20260820-151954
+
+- game: **BLKOPSCW**
+- from: KingslayerKyle
+- names: 10
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- image: 3
+- xmodel: 3
+- material: 2
+- sound_alias: 2
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 0 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260820-151949_list
+- method: blkopscw_gaps
+- what it does: a candidate list generated outside the search and confirmed here
+- ran for: 1s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- candidates tested: 65542
+- matched: 10
+- new: 10
+- ids hunted: 150045
+- throughput: 1.0M candidates/s
+- fingerprint: e862ab5b164a8546
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/KingslayerKyle_BLKOPSCW_20260820-151954/image_20260820-151954.txt
+++ b/submissions/KingslayerKyle_BLKOPSCW_20260820-151954/image_20260820-151954.txt
@@ -1,0 +1,3 @@
+28dbe7f8d383ffe4,i_p9_zm_platinum_sign_grocery_04_c
+49fbf61fe202e0bf,i_p9_zm_platinum_sign_safety_04_c
+7d863af8baf723ed,i_p9_zm_platinum_sign_grocery_03_c

--- a/submissions/KingslayerKyle_BLKOPSCW_20260820-151954/material_20260820-151954.txt
+++ b/submissions/KingslayerKyle_BLKOPSCW_20260820-151954/material_20260820-151954.txt
@@ -1,0 +1,2 @@
+5e3b20cdef292b68,mc/mtl_p9_zm_platinum_sign_safety_04
+778def5c8bdf0e45,mc/mtl_p9_zm_platinum_sign_grocery_04

--- a/submissions/KingslayerKyle_BLKOPSCW_20260820-151954/sound_alias_20260820-151954.txt
+++ b/submissions/KingslayerKyle_BLKOPSCW_20260820-151954/sound_alias_20260820-151954.txt
@@ -1,0 +1,2 @@
+27dc99b77968e3b5,evt_exec_118_laststand_exert
+5ce3004a7375d30e,evt_exec_120_laststand_exert

--- a/submissions/KingslayerKyle_BLKOPSCW_20260820-151954/xmodel_20260820-151954.txt
+++ b/submissions/KingslayerKyle_BLKOPSCW_20260820-151954/xmodel_20260820-151954.txt
@@ -1,0 +1,3 @@
+a26fd19762acb91,p9_zm_platinum_sign_safety_04
+55d63bd436e56796,p9_zm_platinum_sign_grocery_04
+76f2dfb1748c03b3,p9_rm_hjk_pipes_blackout_128_04


### PR DESCRIPTION
**BLKOPSCW** — 10 asset names, confirmed against that game's own loaded assets.

- image: 3
- xmodel: 3
- material: 2
- sound_alias: 2

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @KingslayerKyle

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260820-151949_list
- method: blkopscw_gaps
- what it does: a candidate list generated outside the search and confirmed here
- ran for: 1s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- candidates tested: 65542
- matched: 10
- new: 10
- ids hunted: 150045
- throughput: 1.0M candidates/s
- fingerprint: e862ab5b164a8546

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/families.py`
- `scripts/contributed/image_siblings_20260819-190013.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.