### PR TITLE
[BLKOPS04] findings from droads, 20260820-172705 (2 names)

### DIFF
--- a/submissions/droads_BLKOPS04_20260820-172705/about_20260820-172705.md
+++ b/submissions/droads_BLKOPS04_20260820-172705/about_20260820-172705.md
@@ -1,0 +1,34 @@
+# Submission 20260820-172705
+
+- game: **BLKOPS04**
+- from: droads
+- names: 2
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- xanim: 2
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 16 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260820-172631_list
+- method: adjacent-token-order-anim
+- what it does: a candidate list generated outside the search and confirmed here
+- ran for: 1s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- candidates tested: 136243
+- matched: 2
+- new: 2
+- ids hunted: 189472
+- throughput: 1.5M candidates/s
+- fingerprint: 27c5daa8146a6339
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/droads_BLKOPS04_20260820-172705/xanim_20260820-172705.txt
+++ b/submissions/droads_BLKOPS04_20260820-172705/xanim_20260820-172705.txt
@@ -1,0 +1,2 @@
+54768efb60d57314,pb_death_stand_neckdeath_thrash
+58e3c2785a3caac4,pb_death_stand_headchest_topple


### PR DESCRIPTION
**BLKOPS04** — 2 asset names, confirmed against that game's own loaded assets.

- xanim: 2

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @droads

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260820-172631_list
- method: adjacent-token-order-anim
- what it does: a candidate list generated outside the search and confirmed here
- ran for: 1s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- candidates tested: 136243
- matched: 2
- new: 2
- ids hunted: 189472
- throughput: 1.5M candidates/s
- fingerprint: 27c5daa8146a6339

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/token_order.py`
- `scripts/contributed/sound_asset_context.py`
- `scripts/contributed/token_blocks.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.