### PR TITLE
[BLKOPSCW] findings from droads, 20260820-172935 (2 names)

### DIFF
--- a/submissions/droads_BLKOPSCW_20260820-172935/about_20260820-172935.md
+++ b/submissions/droads_BLKOPSCW_20260820-172935/about_20260820-172935.md
@@ -1,0 +1,34 @@
+# Submission 20260820-172935
+
+- game: **BLKOPSCW**
+- from: droads
+- names: 2
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- xmodel: 2
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 18 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260820-172857_list
+- method: adjacent-token-order-model
+- what it does: a candidate list generated outside the search and confirmed here
+- ran for: 2s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- candidates tested: 882680
+- matched: 2
+- new: 2
+- ids hunted: 148685
+- throughput: 1.1M candidates/s
+- fingerprint: 41f6fcc27500c8ed
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/droads_BLKOPSCW_20260820-172935/xmodel_20260820-172935.txt
+++ b/submissions/droads_BLKOPSCW_20260820-172935/xmodel_20260820-172935.txt
@@ -1,0 +1,2 @@
+4f610f58ef978d10,attach_t9_foregrip_01_armored_pro_view
+4f6d9579ca829f2b,attach_t9_foregrip_01_armored_pro_world


### PR DESCRIPTION
**BLKOPSCW** — 2 asset names, confirmed against that game's own loaded assets.

- xmodel: 2

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @droads

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260820-172857_list
- method: adjacent-token-order-model
- what it does: a candidate list generated outside the search and confirmed here
- ran for: 2s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- candidates tested: 882680
- matched: 2
- new: 2
- ids hunted: 148685
- throughput: 1.1M candidates/s
- fingerprint: 41f6fcc27500c8ed

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/token_order.py`
- `scripts/contributed/sound_asset_context.py`
- `scripts/contributed/token_blocks.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.