### PR TITLE
[BLKOPSCW] findings from BrandonT01, 20260820-221841 (3 names)

### DIFF
--- a/submissions/BrandonT01_BLKOPSCW_20260820-221841/about_20260820-221841.md
+++ b/submissions/BrandonT01_BLKOPSCW_20260820-221841/about_20260820-221841.md
@@ -1,0 +1,28 @@
+# Submission 20260820-221841
+
+- game: **BLKOPSCW**
+- from: BrandonT01
+- names: 3
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- material: 2
+- xmodel: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 0 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260820-221838_images
+- method: images derived from materials (images_from_materials)
+- what it does: each confirmed material name stripped of mtl_ and retried as an image name with every semantic suffix, both prefixed and bare
+- ran for: 2h 38m 49s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- fingerprint: 461bc7dc8ca5b1a9

--- a/submissions/BrandonT01_BLKOPSCW_20260820-221841/material_20260820-221841.txt
+++ b/submissions/BrandonT01_BLKOPSCW_20260820-221841/material_20260820-221841.txt
@@ -1,0 +1,2 @@
+10c27d511407dce2,ei/gfx9_smk_wispy_swirl_loop_soft_zf
+2b0170d5c05a23b3,ei/gfx9_smk_wispy_swirl_loop_soft_lit_high_lite_st20

--- a/submissions/BrandonT01_BLKOPSCW_20260820-221841/xmodel_20260820-221841.txt
+++ b/submissions/BrandonT01_BLKOPSCW_20260820-221841/xmodel_20260820-221841.txt
@@ -1,0 +1,1 @@
+214238eee42d5eb9,p9_ame_light_pole_top_lightrig


### PR DESCRIPTION
**BLKOPSCW** — 3 asset names, confirmed against that game's own loaded assets.

- material: 2
- xmodel: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @BrandonT01

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260820-221838_images
- method: images derived from materials (images_from_materials)
- what it does: each confirmed material name stripped of mtl_ and retried as an image name with every semantic suffix, both prefixed and bare
- ran for: 2h 38m 49s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- fingerprint: 461bc7dc8ca5b1a9
