### PR TITLE
[BLKOPS04] findings from KingslayerKyle, 20260821-003212 (5 names)

### DIFF
--- a/submissions/KingslayerKyle_BLKOPS04_20260821-003212/about_20260821-003212.md
+++ b/submissions/KingslayerKyle_BLKOPS04_20260821-003212/about_20260821-003212.md
@@ -1,0 +1,38 @@
+# Submission 20260821-003212
+
+- game: **BLKOPS04**
+- from: KingslayerKyle
+- names: 5
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- sound_alias: 5
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 0 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260820-235858_soundfiles
+- method: sound files and aliases (confirm_cw --sounds)
+- what it does: every seed cut to pieces at its marks and recombined as beginning + stem + ending, each candidate hashed and looked up among the game's unnamed ids
+- ran for: 29m 20s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- pools searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- seed lines: 3359567
+- distinct pieces: 31299439
+- beginnings: 700
+- endings: 4800
+- ids hunted: 87750
+- matches: 266
+- distinct names reached: 54
+- new here: 5
+- fingerprint: 0afc23c029e6dd43
+
+**Next:** this configuration is now exhausted. Re-measure the lists with `python scripts/derive_lists.py` so the confirmed names widen them, which changes the fingerprint and reopens the method -- or run a method that reaches somewhere else entirely (METHODS.md).

--- a/submissions/KingslayerKyle_BLKOPS04_20260821-003212/sound_alias_20260821-003212.txt
+++ b/submissions/KingslayerKyle_BLKOPS04_20260821-003212/sound_alias_20260821-003212.txt
@@ -1,0 +1,5 @@
+2089db592618e8e3,veh_suv_siren
+2d5cdc03d392d5ec,mpl_veh_recon_exp
+6580ecf2237bca43,evt_missile_hose_1
+6580edf2237bcbf6,evt_missile_hose_2
+6c25fa68e4be20bc,veh_atv_siren


### PR DESCRIPTION
**BLKOPS04** — 5 asset names, confirmed against that game's own loaded assets.

- sound_alias: 5

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @KingslayerKyle

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260820-235858_soundfiles
- method: sound files and aliases (confirm_cw --sounds)
- what it does: every seed cut to pieces at its marks and recombined as beginning + stem + ending, each candidate hashed and looked up among the game's unnamed ids
- ran for: 29m 20s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- pools searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
- seed lines: 3359567
- distinct pieces: 31299439
- beginnings: 700
- endings: 4800
- ids hunted: 87750
- matches: 266
- distinct names reached: 54
- new here: 5
- fingerprint: 0afc23c029e6dd43

**Next:** this configuration is now exhausted. Re-measure the lists with `python scripts/derive_lists.py` so the confirmed names widen them, which changes the fingerprint and reopens the method -- or run a method that reaches somewhere else entirely (METHODS.md).


## Tooling this run leaves behind

- `scripts/contributed/image_siblings_20260819-190013.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.