### PR TITLE
[BLKOPS04] findings from KingslayerKyle, 20260821-055147 (1 names)

### DIFF
--- a/submissions/KingslayerKyle_BLKOPS04_20260821-055147/about_20260821-055147.md
+++ b/submissions/KingslayerKyle_BLKOPS04_20260821-055147/about_20260821-055147.md
@@ -1,0 +1,38 @@
+# Submission 20260821-055147
+
+- game: **BLKOPS04**
+- from: KingslayerKyle
+- names: 1
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 79
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- sound_alias: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 3 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260821-052141_soundfiles
+- method: sound files and aliases (confirm_cw --sounds)
+- what it does: every seed cut to pieces at its marks and recombined as beginning + stem + ending, each candidate hashed and looked up among the game's unnamed ids
+- ran for: 29m 32s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- pools searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- seed lines: 3393850
+- distinct pieces: 31371018
+- beginnings: 700
+- endings: 4800
+- ids hunted: 87705
+- matches: 1468
+- distinct names reached: 272
+- new here: 80
+- fingerprint: dc3895514928de79
+
+**Next:** this configuration is now exhausted. Re-measure the lists with `python scripts/derive_lists.py` so the confirmed names widen them, which changes the fingerprint and reopens the method -- or run a method that reaches somewhere else entirely (METHODS.md).

--- a/submissions/KingslayerKyle_BLKOPS04_20260821-055147/sound_alias_20260821-055147.txt
+++ b/submissions/KingslayerKyle_BLKOPS04_20260821-055147/sound_alias_20260821-055147.txt
@@ -1,0 +1,1 @@
+2f08dd132d9f05b5,zmb_prima_gear_stop


### PR DESCRIPTION
**BLKOPS04** — 1 asset names, confirmed against that game's own loaded assets.

- sound_alias: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 79
- submitted by: @KingslayerKyle

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260821-052141_soundfiles
- method: sound files and aliases (confirm_cw --sounds)
- what it does: every seed cut to pieces at its marks and recombined as beginning + stem + ending, each candidate hashed and looked up among the game's unnamed ids
- ran for: 29m 32s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- pools searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
- seed lines: 3393850
- distinct pieces: 31371018
- beginnings: 700
- endings: 4800
- ids hunted: 87705
- matches: 1468
- distinct names reached: 272
- new here: 80
- fingerprint: dc3895514928de79

**Next:** this configuration is now exhausted. Re-measure the lists with `python scripts/derive_lists.py` so the confirmed names widen them, which changes the fingerprint and reopens the method -- or run a method that reaches somewhere else entirely (METHODS.md).


## Tooling this run leaves behind

- `scripts/contributed/image_siblings_20260819-190013.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.