### PR TITLE
[BLKOPSCW] findings from KingslayerKyle, 20260821-064222 (3 names)

### DIFF
--- a/submissions/KingslayerKyle_BLKOPSCW_20260821-064222/about_20260821-064222.md
+++ b/submissions/KingslayerKyle_BLKOPSCW_20260821-064222/about_20260821-064222.md
@@ -1,0 +1,38 @@
+# Submission 20260821-064222
+
+- game: **BLKOPSCW**
+- from: KingslayerKyle
+- names: 3
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- sound_alias: 3
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 1 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260821-060726_soundfiles
+- method: sound files and aliases (confirm_cw --sounds)
+- what it does: every seed cut to pieces at its marks and recombined as beginning + stem + ending, each candidate hashed and looked up among the game's unnamed ids
+- ran for: 13m 39s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- pools searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- seed lines: 3385782
+- distinct pieces: 31375541
+- beginnings: 700
+- endings: 4800
+- ids hunted: 37494
+- matches: 1595
+- distinct names reached: 207
+- new here: 3
+- fingerprint: ce3df0d5ff93e3c9
+
+**Next:** this configuration is now exhausted. Re-measure the lists with `python scripts/derive_lists.py` so the confirmed names widen them, which changes the fingerprint and reopens the method -- or run a method that reaches somewhere else entirely (METHODS.md).

--- a/submissions/KingslayerKyle_BLKOPSCW_20260821-064222/sound_alias_20260821-064222.txt
+++ b/submissions/KingslayerKyle_BLKOPSCW_20260821-064222/sound_alias_20260821-064222.txt
@@ -1,0 +1,3 @@
+355be7f0a2a508a8,zmb_ai_hellhound_molotov_spawn_bolt_lfe
+563c113bffdea98c,zmb_ai_hellhound_plague_spawn_bolt_lfe
+6a92dcbeeb64893d,wpn_dogfight_rocket_impact_2_swt


### PR DESCRIPTION
**BLKOPSCW** — 3 asset names, confirmed against that game's own loaded assets.

- sound_alias: 3

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @KingslayerKyle

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260821-060726_soundfiles
- method: sound files and aliases (confirm_cw --sounds)
- what it does: every seed cut to pieces at its marks and recombined as beginning + stem + ending, each candidate hashed and looked up among the game's unnamed ids
- ran for: 13m 39s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- pools searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
- seed lines: 3385782
- distinct pieces: 31375541
- beginnings: 700
- endings: 4800
- ids hunted: 37494
- matches: 1595
- distinct names reached: 207
- new here: 3
- fingerprint: ce3df0d5ff93e3c9

**Next:** this configuration is now exhausted. Re-measure the lists with `python scripts/derive_lists.py` so the confirmed names widen them, which changes the fingerprint and reopens the method -- or run a method that reaches somewhere else entirely (METHODS.md).


## Tooling this run leaves behind

- `scripts/contributed/image_siblings_20260819-190013.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.