### PR TITLE
[BLKOPS04] findings from Dreadbread76, 20260821-065040 (2 names)

### DIFF
--- a/submissions/Dreadbread76_BLKOPS04_20260821-065040/about_20260821-065040.md
+++ b/submissions/Dreadbread76_BLKOPS04_20260821-065040/about_20260821-065040.md
@@ -1,0 +1,33 @@
+# Submission 20260821-065040
+
+- game: **BLKOPS04**
+- from: Dreadbread76
+- names: 2
+- dropped as already published: 304
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 2 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260821-034028_all
+- method: general search (confirm_cw)
+- what it does: every seed cut to pieces at its marks and recombined as beginning + stem + ending, each candidate hashed and looked up among the game's unnamed ids
+- ran for: 1h 00m 41s
+- game: BLKOPS04
+- pools searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- seed lines: 3257412
+- distinct pieces: 31018417
+- beginnings: 700
+- endings: 4800
+- ids hunted: 108351
+- matches: 1149
+- distinct names reached: 306
+- new here: 306
+- fingerprint: 3ddf717a46e9b5bc
+
+**Next:** this configuration is now exhausted. Re-measure the lists with `python scripts/derive_lists.py` so the confirmed names widen them, which changes the fingerprint and reopens the method -- or run a method that reaches somewhere else entirely (METHODS.md).

--- a/submissions/Dreadbread76_BLKOPS04_20260821-065040/material_20260821-065040.txt
+++ b/submissions/Dreadbread76_BLKOPS04_20260821-065040/material_20260821-065040.txt
@@ -1,0 +1,2 @@
+218e6088eaa14da4,mc/mtl_p8_wz_moving_truck_semi_trailer_damaged_floor_01_metal_aluminum
+409449629c2d70eb,mc/mtl_p8_wz_moving_truck_semi_trailer_damaged_floor_02_metal_aluminum


### PR DESCRIPTION
**BLKOPS04** — 2 asset names, confirmed against that game's own loaded assets.

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 304
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Dreadbread76

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260821-034028_all
- method: general search (confirm_cw)
- what it does: every seed cut to pieces at its marks and recombined as beginning + stem + ending, each candidate hashed and looked up among the game's unnamed ids
- ran for: 1h 00m 41s
- game: BLKOPS04
- pools searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
- seed lines: 3257412
- distinct pieces: 31018417
- beginnings: 700
- endings: 4800
- ids hunted: 108351
- matches: 1149
- distinct names reached: 306
- new here: 306
- fingerprint: 3ddf717a46e9b5bc

**Next:** this configuration is now exhausted. Re-measure the lists with `python scripts/derive_lists.py` so the confirmed names widen them, which changes the fingerprint and reopens the method -- or run a method that reaches somewhere else entirely (METHODS.md).
