### PR TITLE
[BLKOPSCW] findings from GoastcraftHD, 20260821-070445 (2 names)

### DIFF
--- a/scripts/contributed/aliasswap_20260821-070445.py
+++ b/scripts/contributed/aliasswap_20260821-070445.py
@@ -1,0 +1,149 @@
+"""Sound alias names, one token at a time, from the alias vocabulary rather than the path one.
+
+A method, not a report. Pipe it into `confirm_list` -- folded, like everything that is not a
+Black Ops 4 sound *file*:
+
+    python scripts/aliasswap.py | ./bin/windows/confirm_list.exe - \
+        --label "alias slot substitution" --script scripts/aliasswap.py
+
+## The problem it solves
+
+`sound_alias` is the second largest unnamed ground in the project -- 43,603 unnamed of 50,890 in
+Cold War, 23,370 of 50,043 in Black Ops 4 -- and until 2026-08-20 nothing on this machine hunted
+it at all, because `config.toml` listed five pools and this was not one of them.
+
+Turning it on is not enough. The sound pass hunts aliases with the vocabulary measured from the
+sound *file* tables, and the two are not the same language:
+
+    zmb\ai\blightfather\maggot\flying\maggot_fly_loop_02.ln100.pc.snd   a sound file
+    amb_computer_loop_1                                                     an alias
+
+Files are deep paths with dotted tails. Aliases are short underscore-joined names -- half of them
+six tokens or fewer, from only 23 distinct leading tokens -- with no slash and no tail anywhere in
+them. A beginning or ending measured on one is close to useless against the other. Run against
+Cold War with the file vocabulary, the whole sound pass returned **3** aliases.
+
+## Why both games seed one corpus
+
+An alias carries no slash, so there is no fold to get wrong and the id is the plain hash of the
+name in either title. That makes the two games' alias corpora a single pool of seed material --
+53,956 known names against 39,707 still unnamed -- and it is the reason this is worth running even
+though `soundxfer.py` found the *file* route between the games closed.
+
+## How it generates
+
+For every known alias and every token in it, the token's context is its left and right neighbour,
+with `^` and `$` at the ends so first and last tokens have one too. Every alias votes on what may
+stand in a given context:
+
+    (`amb`, `loop`) -> {computer, fire, water, machine, ...}
+
+and each is offered to every other alias sharing that context. Nothing is invented: every token
+written into a slot was measured in that slot, in a name known to be real.
+
+## What it is spent by
+
+Measured 2026-08-20 against 39,707 unnamed ids: slot substitution reaches **318** from 1,844,165
+candidates. Two neighbours were tried and are not worth carrying -- *continuations*, offering each
+prefix the tokens measured to follow it, reached **3** from 3,311,242, and *truncations*, cutting
+a known alias short, reached **0** from 197,726. Aliases are evidently authored as whole names
+rather than grown or abbreviated, so the productive move is to vary a word, not the length.
+"""
+import collections
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import snapshot
+
+# The alias tables. `fnv1a_strings` is not a sound table but carries about as many alias names as
+# the alias table does, and dropping it would throw away half the vocabulary.
+TABLES = ("fnv1a_soundbanks_aliases", "fnv1a_strings")
+
+
+def option(argv, flag, default):
+    return int(argv[argv.index(flag) + 1]) if flag in argv else default
+
+
+def word(argv, flag, default):
+    return argv[argv.index(flag) + 1] if flag in argv else default
+
+
+def context_of(tokens, i, which):
+    """The neighbours that define a slot. `^` and `$` so the ends have a context too.
+
+    Keying on one neighbour is looser -- the alphabets are larger and the candidates less certain
+    -- but it is the only way to reach a name whose *other* neighbour is itself unknown, which is
+    most of a family nobody has named yet.
+    """
+    left = tokens[i - 1] if i else "^"
+    right = tokens[i + 1] if i + 1 < len(tokens) else "$"
+    if which == "left":
+        return (left, "*")
+    if which == "right":
+        return ("*", right)
+    return (left, right)
+
+
+def alias_ids():
+    """Every `sound_alias` id in either game. An alias has no slash, so one hash serves both."""
+    out = set()
+    for name in ("blkops04", "blkopscw"):
+        path = os.path.join(snapshot.ROOT, "snapshots", name + ".ids")
+        if not os.path.exists(path):
+            continue
+        snap = snapshot.read(path)
+        if "sound_alias" not in snap.pools:
+            continue
+        index = snap.pools.index("sound_alias")
+        out |= {asset for asset, pool in snap.records if pool == index}
+    return out
+
+
+def known_aliases(ids):
+    """Names from the tables and from everything confirmed that land on an alias id."""
+    out = set()
+    for name in list(snapshot.table_names(*TABLES)) + list(snapshot.confirmed_names("sound_alias")):
+        name = name.strip().lower()
+        if name and (snapshot.fnv1a(name) & snapshot.ID_MASK) in ids:
+            out.add(name)
+    return out
+
+
+def main(argv):
+    cap = option(argv, "--cap", 24)
+    min_seen = option(argv, "--min-seen", 1)
+    which = word(argv, "--context", "both")
+
+    known = known_aliases(alias_ids())
+    if not known:
+        raise SystemExit("no known aliases found; are the tables fetched?")
+
+    contexts = collections.defaultdict(collections.Counter)
+    for name in known:
+        tokens = name.split("_")
+        for i, token in enumerate(tokens):
+            contexts[context_of(tokens, i, which)][token] += 1
+
+    if "--count" in argv:
+        total = sum(
+            min(cap, len(contexts[context_of(t, i, which)]))
+            for t in (n.split("_") for n in known)
+            for i in range(len(t))
+        )
+        print("%d known aliases, %d contexts, about %d candidates" % (len(known), len(contexts), total))
+        return
+
+    out = sys.stdout
+    for name in known:
+        tokens = name.split("_")
+        for i, token in enumerate(tokens):
+            for alt, seen in contexts[context_of(tokens, i, which)].most_common(cap):
+                if alt == token or seen < min_seen:
+                    continue
+                out.write("_".join(tokens[:i] + [alt] + tokens[i + 1:]) + "\n")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/scripts/contributed/borrow_old_titles_20260821-070445.py
+++ b/scripts/contributed/borrow_old_titles_20260821-070445.py
@@ -1,0 +1,95 @@
+"""Fills the `[paths] borrowed` folder with the three older-title tables nothing else here reads.
+
+    python scripts/borrow_old_titles.py            writes borrowed/ and says what to add to config
+    python scripts/borrow_old_titles.py --where X  writes somewhere else
+
+Infrastructure, not a generator. It writes a folder of `.txt` names; the *general* search picks
+them up as stems and applies all 700 measured beginnings and 4,800 endings to them through the
+peeling engine.
+
+## Why this exists
+
+`config.toml` has shipped a `[paths] borrowed` key on every clone since the beginning --
+"names borrowed from another title, used as candidates but never measured for conventions" -- and
+`confirm_cw` prints `borrowed from the earlier game: 0` at the top of every pass. It has been zero
+on every machine, because nothing ever said what to put in it.
+
+`scripts/old_titles.py` measured what is worth putting in it: Black Ops 2's 24,565 ipak image
+names return **1 new name per 19,591 candidates**, against 1 per 94,000 for the best method
+METHODS.md ranks. That script can only afford a short ending list in Python. This mechanism gets
+the same vocabulary the full lists and the peeling engine, which is where the rest of the seam is.
+
+Reads the tables and nothing else. Writes only inside the folder it is given.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import snapshot
+
+BS = chr(92)
+DEFAULT = "borrowed"
+
+# The three tables whose keys are meaningless to these two games -- ipak entry ids and SDBM -- and
+# whose *names* are therefore skipped by every hash-driven step in the repository. See
+# docs/HASHES.md for why each is keyed the way it is.
+TABLES = ("bo2_ipak", "bo2_sab", "bo3_sab")
+
+
+def clean(name):
+    """Lowercased, with the engine built-ins dropped."""
+    name = name.strip().lower()
+    if not name or name.startswith("$") or name.startswith("~"):
+        return None
+    return name
+
+
+def main():
+    where = DEFAULT
+    if "--where" in sys.argv:
+        where = sys.argv[sys.argv.index("--where") + 1]
+
+    root = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), where)
+    root = where if os.path.isabs(where) else root
+    os.makedirs(root, exist_ok=True)
+
+    total = 0
+    for table in TABLES:
+        names = set()
+
+        for raw in snapshot.table_names(table):
+            name = clean(raw)
+            if not name:
+                continue
+
+            names.add(name)
+
+            # A SAB name is a path with an encoding tail. The whole path, the path without its
+            # tail and the bare basename are three different stems and the search wants all of
+            # them: the first two are what a sound id is hashed from, the third is the shape a
+            # `sound_alias` has.
+            if table.endswith("_sab"):
+                stem = name.replace("/", BS)
+                cut = stem.find(".")
+                if cut > 0:
+                    names.add(stem[:cut])
+                    names.add(stem[:cut].replace(BS, "/"))
+                names.add(stem.split(BS)[-1])
+
+        path = os.path.join(root, table + ".txt")
+        with open(path, "w", encoding="utf-8") as handle:
+            for name in sorted(names):
+                handle.write(name + "\n")
+
+        total += len(names)
+        print("%-10s %7d names -> %s" % (table, len(names), path))
+
+    print("\n%d names borrowed in total." % total)
+    print("Add this to config.toml if it is not there already:\n")
+    print("[paths]")
+    print('borrowed = "%s"' % where)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/contributed/cross_game_20260821-070445.py
+++ b/scripts/contributed/cross_game_20260821-070445.py
@@ -1,0 +1,104 @@
+"""Every name we already hold, tried verbatim against the other title -- in both slash spellings.
+
+A method, not a report. Pipe it into `confirm_list`:
+
+    python scripts/cross_game.py | ./bin/windows/confirm_list.exe - \
+        --label "whole-name cross-game transfer" --script scripts/cross_game.py
+
+Run it a second time with `--no-fold` to reach the ids that are hashed with their backslashes
+intact; the two halves land on different ids and neither is a superset of the other. See below.
+
+## The problem it solves
+
+`confirm_cw` seeds *pieces* across the two games -- it says so at startup, "confirmed in BLKOPSCW
+and worth trying here" -- and then recombines them as `beginning + stem + ending`. Nothing tries a
+name **whole**. That sounds like it should be covered by the recombination, and mostly it is:
+measured below, 38,692 of Black Ops 4's unnamed ids are reachable this way and 38,673 of them had
+already been confirmed on this machine by ordinary passes.
+
+The 19 that were left are the point. A whole name needs no beginning in `data/prefixes.txt` and no
+ending in `data/suffixes.txt`, so it reaches the names those lists cannot express -- and
+`reach.py` measures that gap at 4-16% of every table, with `xsounds` endings the worst at 77.1%.
+This is the cheapest possible way to collect what falls through it: no generation at all, just
+hashing a list that already exists.
+
+## The two slash spellings, which is why this is not a one-liner
+
+Black Ops 4's SAB sound names keep their literal backslashes and their ids are the hash of exactly
+that, where every table stores forward slashes. `AGENTS.md` records it as absolute -- 8,385 of
+8,385 known names reproduce unfolded, 0 folded -- but measured over the whole corpus that is true
+of the *SAB-injected* ids only. Both spellings return names here, on different ids:
+
+    zmb/ai/hellhounds/step/fly_hellhound_step_08.ln100.pc.snd     folded
+    zmb\ai\hellhounds\step\fly_hellhound_step_00.ln100.pc.snd     unfolded
+
+Same family, same directory, adjacent numbers, two conventions. So this emits both spellings of
+every path-shaped name and lets `confirm_list` decide which lands. Offering only one silently
+halves the method, and it is the half nobody would notice missing.
+
+## What it reaches, measured 2026-08-21
+
+2,469,429 whole names -- every non-`_v2` table plus everything confirmed here -- against Black Ops
+4's 212,562 unnamed ids in the five wanted types:
+
+| pool | ids reached |
+|---|---|
+| `sound_alias` | 12,990 |
+| `image` | 12,025 |
+| `material` | 8,363 |
+| `xmodel` | 3,075 |
+| `xanim` | 2,126 |
+| `sound_asset` | 113 |
+
+**19 of them were new**, every one a `sound_asset`. That is the shape of this method and it is
+worth being honest about: it is a gap-filler, not a producer. It costs a couple of minutes, it
+needs no lists, and it collects exactly what the end-first passes structurally cannot.
+
+## What it is spent by
+
+An ordinary general pass on the same game, which reaches the same ids by recombination and will
+have taken the vast majority of them already. Run this *after* a general pass rather than instead
+of one, and re-run it whenever the other game's confirmed corpus has grown -- that corpus is the
+input, so a grown corpus is a genuinely different search.
+"""
+import glob
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import settings
+import snapshot
+
+BS = chr(92)
+
+# The `_v2` tables are the IW era and use a different offset; their names teach the wrong
+# conventions and docs/HASHES.md records reading them for vocabulary as a known dead end. The
+# Black Ops 2 and 3 SAB tables are a different era's sound scheme and are handled by sabpaths.py.
+def wanted(table):
+    return not (table.endswith("_v2") or table.startswith("bo2") or table.startswith("bo3"))
+
+
+def main():
+    names = set()
+
+    for path in sorted(glob.glob(os.path.join(settings.tables_csv(), "*.csv"))):
+        table = os.path.splitext(os.path.basename(path))[0]
+        if wanted(table):
+            names.update(snapshot.table_names(table))
+
+    names.update(snapshot.confirmed_names())
+
+    out = sys.stdout
+    for name in names:
+        out.write(name + "\n")
+        # The same name spelled the other way. Only path-shaped names have a second spelling, and
+        # emitting it unconditionally would just double the candidate count for nothing.
+        if "/" in name:
+            out.write(name.replace("/", BS) + "\n")
+        elif BS in name:
+            out.write(name.replace(BS, "/") + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/contributed/old_titles_20260821-070445.py
+++ b/scripts/contributed/old_titles_20260821-070445.py
@@ -1,0 +1,146 @@
+"""Black Ops 2's own asset names, respelled as Black Ops 4 and Cold War spell theirs.
+
+A method, not a report. Pipe it into `confirm_list`:
+
+    python scripts/old_titles.py | ./bin/windows/confirm_list.exe - \
+        --label "older-title vocabulary" --script scripts/old_titles.py
+
+## The problem it solves
+
+Every method here recombines vocabulary, and all of them draw on the same vocabulary: the
+published tables for these two games, plus what this project has confirmed. That corpus is large
+and it is thoroughly picked over -- which is why `reach.py` reports 84-96% and yields keep falling.
+The way to move it is not another recombination rule, it is **a source of real names nobody has
+read**.
+
+There are exactly three such tables in cod-name-db, and until 2026-08-21 nothing in this
+repository touched any of them:
+
+| table | what it holds | why it was invisible |
+|---|---|---|
+| `bo2_ipak.csv` | **24,565 Black Ops 2 image names** | keyed by native ipak entry ids, which are *not a hash of the name* -- so every hash-based step here skips the file entirely |
+| `bo2_sab.csv` | 370,081 Black Ops 2 SAB audio paths | SDBM-hashed, so likewise invisible |
+| `bo3_sab.csv` | 30,734 Black Ops 3 SAB audio paths | SDBM-hashed |
+
+They are invisible to the *exclusion* logic for a good reason -- their keys mean nothing to these
+games -- and the mistake was letting that carry over to the *seeding* logic, where the keys do not
+matter and only the names do. Treyarch reuses its texture library across titles, so a Black Ops 2
+image name is a real name in the family we are hunting.
+
+## What it is measured at
+
+Against all 360,461 unnamed ids in the five wanted types, both games, 2026-08-21:
+
+| source | candidates | new names |
+|---|---|---|
+| `bo2_ipak` image names | 1,038,336 | **53** |
+| `bo2_sab` basenames | 9,476,256 | 3 |
+| `bo3_sab` basenames | 1,697,952 | 0 |
+
+**1 new name per 19,591 candidates** for the ipak half. For scale, METHODS.md ranks `token_edits`
+the best measured method in the project at 1 per 94,000, and a blind `affix_sweep` at 1 per
+532,000,000. This is the densest seam anybody here has measured, and it is dense for the obvious
+reason: 24,565 names is a very small corpus, and it had never been asked once.
+
+48 of the 53 were Black Ops 4 images and 12 Cold War, on names that read exactly like shared
+Treyarch library art -- `i_stone_floor_granite_tile01_cream_n`,
+`i_decal_signage_stripe_yellow_rect_n`, `i_p6_monitor_back_small_n`.
+
+The Black Ops 2 SAB half is thin by comparison and the Black Ops 3 half is empty; both are kept
+because they cost nothing beside the ipak half, and because their basenames land on `sound_alias`
+rather than on images, which nothing else reaches from this direction.
+
+## How it generates
+
+An image is its material's core with a beginning and a map suffix, so each borrowed core is
+offered:
+
+1. the six beginnings an image carries (`i_`, bare, `i_mtl_`, `mtl_`, `c_`, `i_c_`) crossed with
+   the map suffixes a Treyarch image uses (`_c`, `_n`, `_g`, `_o`, `_m`, `_s`, `_r` and the rest);
+2. the twelve material directories crossed with the `mtl_` and bare spellings, since a name that
+   is an image here was often a material there;
+3. SAB basenames bare, which is the shape a `sound_alias` has.
+
+## What it is spent by
+
+Its own size -- there are only 24,565 ipak names and one pass asks all of them. Re-running it
+unchanged will return nothing. **The wider version of this method is `[paths] borrowed` in
+`config.toml`**, which feeds a folder of names into the general search as stems and so applies all
+700 measured beginnings and 4,800 endings through the peeling engine, rather than the short lists
+this script can afford in Python. That mechanism ships on every clone and was empty on all of
+them; `scripts/borrow_old_titles.py` fills it from these same three tables.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import snapshot
+
+BS = chr(92)
+
+# The beginnings an image carries, as `images_from_materials` measured them.
+OPENINGS = ("i_", "", "i_mtl_", "mtl_", "c_", "i_c_")
+
+# The map suffixes a Treyarch image name ends in.
+ENDINGS = ("", "_c", "_n", "_g", "_o", "_m", "_s", "_r", "_a", "_d",
+           "_e", "_h", "_l", "_t", "_v", "_x", "_nml", "_spc", "_msk")
+
+# Material names are paths, and there are twelve directories rather than one. See AGENTS.md.
+DIRECTORIES = ("mc/", "wc/", "clt/", "splm/", "vd/", "mcs/",
+               "ei/", "cltp/", "vdd/", "el/", "mcp/", "ec/")
+
+
+def cores():
+    """Every borrowed name reduced to the part another title would share."""
+    out = set()
+
+    for raw in snapshot.table_names("bo2_ipak"):
+        core = raw.strip().lower()
+        # `$white`, `~-gdefaultvehicle` and friends are engine built-ins, not content.
+        if core and not core.startswith("$") and not core.startswith("~"):
+            out.add(core)
+
+    return out
+
+
+def sab_basenames():
+    """The last path segment of every Black Ops 2 and 3 SAB name, which is the alias-shaped part."""
+    out = set()
+
+    for table in ("bo2_sab", "bo3_sab"):
+        for raw in snapshot.table_names(table):
+            stem = raw.replace("/", BS)
+            cut = stem.find(".")
+            if cut > 0:
+                stem = stem[:cut]
+            base = stem.split(BS)[-1].strip().lower()
+            if base:
+                out.add(base)
+
+    return out
+
+
+def main():
+    out = sys.stdout
+    seen = set()
+
+    def emit(name):
+        if name not in seen:
+            seen.add(name)
+            out.write(name + "\n")
+
+    for core in cores():
+        for opening in OPENINGS:
+            for ending in ENDINGS:
+                emit(opening + core + ending)
+        for directory in DIRECTORIES:
+            emit(directory + "mtl_" + core)
+            emit(directory + core)
+
+    for base in sab_basenames():
+        emit(base)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/contributed/sabpaths_20260821-070445.py
+++ b/scripts/contributed/sabpaths_20260821-070445.py
@@ -1,0 +1,215 @@
+"""Black Ops 4 SAB sound names, rebuilt from the path structure its own known names carry.
+
+A method, not a report. Pipe it into `confirm_list`, and it must be `--no-fold`:
+
+    python scripts/sabpaths.py | ./bin/windows/confirm_list.exe - --no-fold \
+        --label "SAB directory and basename recombination" --script scripts/sabpaths.py
+
+## The problem it solves
+
+`sound_asset` in Black Ops 4 is the largest unnamed ground in either game -- 70,876 of 79,263 --
+and the general sound pass reaches almost none of it. The reason is structural, not incidental:
+a general pass composes `beginning + stem + ending`, and its beginnings are the 700 measured in
+`data/sound.prefixes.txt`. A Black Ops 4 sound name is a *deep path* --
+`amb\environment\wind\gusts\gust_leaves\...`, five and six segments -- and no 700-entry beginning
+list can express one. METHODS.md records the consequence: a dedicated sound pass returns ~169.
+
+## What it learns first
+
+Every sound-shaped name in every table, plus everything confirmed here, is hashed *unfolded* and
+kept only if it reproduces an id the Black Ops 4 snapshot actually holds in `sound_asset`. That
+is 8,446 names, and they are the only description of the convention that exists. Measured on them:
+
+* **2,267 distinct directories**, **7,689 distinct basenames**, path depth 3-6 segments.
+* Six tails cover 8,409 of them: `ln100` 6,761, `ll100` 932, `sn100` 346, `sl100` 181,
+  `pn100` 169, `pl100` 20 -- each `.pc.snd`.
+* Fifteen top-level heads: `wpn` 1,572, `zmb` 1,474, `fly` 1,391, `amb` 1,214, `prj` 538,
+  `mpl` 443, `veh` 391, `uin` 303, `phy` 237, `exp`, `pfx`, `chr`, `blk`, `dst`, `mus`.
+
+The names average 3.7 per directory, so a directory known to exist is a directory whose other
+members are overwhelmingly unnamed. That is the ground this reaches.
+
+## Where the extra directories come from
+
+`bo2_sab.csv` and `bo3_sab.csv` hold 400,815 Black Ops 2 and 3 SAB audio paths. Nothing in this
+repository has ever used them, because they are SDBM-hashed and so are not "our games" for
+exclusion -- but their *names* are Treyarch sound paths from the two titles Black Ops 4 descends
+from, and the tail scheme is visibly the same counter: BO2 `.SN65.pc.snd`, BO3 `.SN85.pc.snd`,
+BO4 `.sn100.pc.snd`.
+
+Measured before building this: BO3 shares **9.18%** of its stems with known Black Ops 4 / Cold War
+sound stems, BO2 **1.35%**. For comparison the seams METHODS.md records as dead measured 0.7%,
+0.1% and 0. Offered verbatim the transfer is weak -- 1,721,304 candidates for 3 new names, 1 per
+573,768 -- and every one that landed was a *directory* match
+(`amb\environment\wind\snowy\wind_snow_l.sl100.pc.snd`). So this takes their directories, not
+their stems.
+
+## How it generates
+
+1. **Numbering.** Every known basename ending in digits, walked across the range its own family
+   uses, in the padded and unpadded forms the game mixes, under its own directory.
+2. **Recombination.** Every directory crossed with the basenames seen under the *same top-level
+   head*. Restricting to the head is what keeps this from being a blind cross product: a `wpn`
+   basename under an `amb` directory is not a name the game would have.
+3. **Borrowed directories.** The Black Ops 2 and 3 directories whose head is one of the fifteen,
+   crossed with Black Ops 4 basenames under that head.
+
+Each of the three is crossed with the six measured tails. Nothing is invented: every directory,
+basename and tail was a real Treyarch sound name.
+"""
+import collections
+import glob
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import settings
+import snapshot
+
+BS = chr(92)
+
+# Measured on the names that reproduce a Black Ops 4 sound_asset id: these six cover 8,409 of 8,446.
+TAILS = (
+    "ln100.pc.snd",
+    "ll100.pc.snd",
+    "sn100.pc.snd",
+    "sl100.pc.snd",
+    "pn100.pc.snd",
+    "pl100.pc.snd",
+)
+
+# A basename's trailing number, which is what step 1 walks.
+TRAILING = re.compile(r"^(.*?)(\d+)$")
+
+# The leading language directory Black Ops 2 and 3 SAB paths carry and Black Ops 4 does not.
+LANG_HEAD = re.compile(r"^(?:[a-z]{2}|devraw[\\/][a-z]+)[\\/]", re.I)
+
+
+def sab_stem(name):
+    """A Black Ops 2/3 SAB path reduced to the part Black Ops 4 would recognise."""
+    n = name.replace("/", BS)
+    n = LANG_HEAD.sub("", n)
+    cut = n.find(".")
+    return (n[:cut] if cut > 0 else n).lower()
+
+
+def known_bo4_sab():
+    """Every name that actually reproduces a Black Ops 4 `sound_asset` id, hashed unfolded."""
+    snaps = [snapshot.read(p) for p in snapshot.snapshots()]
+    bo4 = [s for s in snaps if s.game == "BLKOPS04"]
+    if not bo4:
+        raise SystemExit("no BLKOPS04 snapshot -- run snapshot.py first")
+    snap = bo4[0]
+    ids = {a for a, p in snap.records if snap.pool_name(p) == "sound_asset"}
+
+    names = []
+    for path in sorted(glob.glob(os.path.join(settings.tables_csv(), "*.csv"))):
+        base = os.path.splitext(os.path.basename(path))[0]
+        if "sound" in base or "sab" in base:
+            names.extend(snapshot.table_names(base))
+    names.extend(snapshot.confirmed_names("sound_asset"))
+
+    out = {}
+    for n in names:
+        nb = n.replace("/", BS)
+        key = snapshot.fnv1a_nofold(nb) & snapshot.ID_MASK
+        if key in ids:
+            out[key] = nb
+    return list(out.values())
+
+
+def split(name):
+    """`dir`, `basename`, `tail` of a Black Ops 4 SAB name."""
+    cut = name.find(".")
+    stem, tail = (name[:cut], name[cut + 1:]) if cut > 0 else (name, "")
+    parts = stem.split(BS)
+    return BS.join(parts[:-1]), parts[-1], tail
+
+
+def main():
+    report = "--report" in sys.argv
+
+    known = known_bo4_sab()
+    dirs_by_head = collections.defaultdict(set)
+    bases_by_head = collections.defaultdict(set)
+    families = collections.defaultdict(set)      # (dir, prefix) -> numbers seen
+
+    for name in known:
+        d, b, _ = split(name)
+        if not d:
+            continue
+        head = d.split(BS)[0]
+        dirs_by_head[head].add(d)
+        bases_by_head[head].add(b)
+        m = TRAILING.match(b)
+        if m:
+            families[(d, m.group(1))].add(int(m.group(2)))
+
+    heads = set(dirs_by_head)
+
+    # Black Ops 2 and 3 directories, kept only where the head is one Black Ops 4 uses.
+    borrowed = collections.defaultdict(set)
+    for table in ("bo2_sab", "bo3_sab"):
+        for n in snapshot.table_names(table):
+            stem = sab_stem(n)
+            parts = stem.split(BS)
+            if len(parts) < 2:
+                continue
+            d = BS.join(parts[:-1])
+            head = parts[0]
+            if head in heads and d not in dirs_by_head[head]:
+                borrowed[head].add(d)
+
+    if report:
+        step2 = sum(len(dirs_by_head[h]) * len(bases_by_head[h]) for h in heads)
+        step3 = sum(len(borrowed[h]) * len(bases_by_head[h]) for h in heads)
+        print("known BLKOPS04 SAB names: %d" % len(known))
+        print("heads: %d   directories: %d   basenames: %d"
+              % (len(heads), sum(len(v) for v in dirs_by_head.values()),
+                 sum(len(v) for v in bases_by_head.values())))
+        print("borrowed BO2/BO3 directories under those heads: %d"
+              % sum(len(v) for v in borrowed.values()))
+        print("step 2 pairs: %d  -> %d candidates" % (step2, step2 * len(TAILS)))
+        print("step 3 pairs: %d  -> %d candidates" % (step3, step3 * len(TAILS)))
+        for h in sorted(heads, key=lambda x: -len(dirs_by_head[x]) * len(bases_by_head[x])):
+            print("   %-8s dirs %5d  bases %5d  borrowed %5d  pairs %9d"
+                  % (h, len(dirs_by_head[h]), len(bases_by_head[h]), len(borrowed[h]),
+                     len(dirs_by_head[h]) * len(bases_by_head[h])))
+        return
+
+    seen = set()
+    out = sys.stdout
+
+    def emit(stem):
+        if stem in seen:
+            return
+        seen.add(stem)
+        for tail in TAILS:
+            out.write(stem + "." + tail + "\n")
+
+    # 1. numbering, walked over the range each family actually uses
+    for (d, prefix), numbers in families.items():
+        lo, hi = min(numbers), max(numbers)
+        width = max(len(str(n)) for n in numbers)
+        for i in range(max(0, lo - 2), hi + 6):
+            emit("%s%s%s%0*d" % (d, BS, prefix, width, i))
+            if width > 1:
+                emit("%s%s%s%d" % (d, BS, prefix, i))
+
+    # 2. every directory crossed with the basenames of its own head
+    for head in sorted(heads):
+        for d in sorted(dirs_by_head[head]):
+            for b in sorted(bases_by_head[head]):
+                emit(d + BS + b)
+
+    # 3. the borrowed Black Ops 2 and 3 directories, same crossing
+    for head in sorted(borrowed):
+        for d in sorted(borrowed[head]):
+            for b in sorted(bases_by_head[head]):
+                emit(d + BS + b)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/contributed/soundxfer_20260821-070445.py
+++ b/scripts/contributed/soundxfer_20260821-070445.py
@@ -1,0 +1,130 @@
+"""Cold War sound stems, respelled the way Black Ops 4 spells sounds.
+
+A method, not a report. Pipe it into `confirm_list`, and it must be `--no-fold`:
+
+    python scripts/soundxfer.py | ./bin/windows/confirm_list.exe - --no-fold \
+        --label "cross-game sound stem transfer" --script scripts/soundxfer.py
+
+## The problem it solves
+
+`sound_asset` is the largest unnamed ground in either game -- 70,878 of Black Ops 4's 79,263 are
+unnamed -- and it is the one pool where the seed corpus is too thin to grind. Only 8,403 Black
+Ops 4 sound names are known, against 860,676 sound names known for Cold War. Every other method
+here recombines a game's own vocabulary, and Black Ops 4's sound vocabulary is 10.6% of a game.
+
+The two titles share Treyarch's sound scheme exactly -- `wpn\`, `zmb\`, `fly\`, `amb\`,
+`prj\`, `veh\`, `uin\` head both games -- so Cold War's 97,168 distinct stems are the richest
+description of what a Black Ops 4 sound name looks like that exists anywhere.
+
+## Why the tables cannot already do this
+
+Two conventions differ at once, and each alone would be enough to hide the seam:
+
+* **The tail.** Cold War writes `.ln75.pc.all.snd` and `.rn75.pc.<lang>.snd`; Black Ops 4 writes
+  `.ln100.pc.snd` and five siblings. A stem shared by both games carries a different tail in each.
+* **The fold.** Black Ops 4's SAB sound names keep their literal backslashes and the id is the
+  hash of exactly that, where every table stores forward slashes. Measured: of 860,676 table
+  names, 0 match a Black Ops 4 sound id hashed the usual folded way.
+
+So a stem the two games genuinely share still hashes to two unrelated ids, and no table lookup in
+either direction will ever connect them. This strips Cold War's tail, respells the stem with
+backslashes and offers it Black Ops 4's own six tails.
+
+## How it generates
+
+1. Every stem in the sound tables and in everything confirmed so far, cut at its first dot.
+2. Each stem crossed with the six measured Black Ops 4 tails.
+3. Each stem whose basename ends in digits re-numbered across the range those families use,
+   in both the padded and unpadded forms the game mixes, and crossed with the tails again.
+
+Nothing is invented: every stem was a real name in one of the two games and every tail was
+measured on a confirmed Black Ops 4 sound.
+
+## What it is spent by
+
+Measured 2026-08-20, against 70,860 unnamed ids: step 2 reaches 25 ids from 583,008 candidates,
+step 3 a further 18 from 11,147,520. That is the whole of it -- **this seam is worth about 45
+names and no more**, because the stems the two games share are mostly already named and Black
+Ops 4's remaining sounds are content Cold War never shipped. It is recorded as a method because
+the measurement is the useful part: it says the cross-game route into `sound_asset` is closed, so
+the next person grinds Black Ops 4's own vocabulary instead of re-deriving this.
+"""
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import snapshot
+
+BS = chr(92)
+
+# Measured on the 8,403 confirmed Black Ops 4 sound names: these six cover 8,368 of them.
+TAILS = (
+    "ln100.pc.snd",
+    "ll100.pc.snd",
+    "sn100.pc.snd",
+    "sl100.pc.snd",
+    "pn100.pc.snd",
+    "pl100.pc.snd",
+)
+
+# Confirmed numbered sound families run to the low thirties; past that they stop existing.
+NUMBERS = 32
+
+TRAILING_DIGITS = re.compile(r"^(.*?)(\d+)$")
+
+SOUND_TABLES = [
+    "fnv1a_xsounds",
+    "fnv1a_americanspanish_xsounds",
+    "fnv1a_brazilianportugese_xsounds",
+    "fnv1a_chinese_xsounds",
+    "fnv1a_english_xsounds",
+    "fnv1a_french_xsounds",
+    "fnv1a_german_xsounds",
+    "fnv1a_italian_xsounds",
+    "fnv1a_japanese_xsounds",
+    "fnv1a_korean_xsounds",
+    "fnv1a_polish_xsounds",
+    "fnv1a_russian_xsounds",
+    "fnv1a_spanish_xsounds",
+]
+
+
+def stems():
+    """Every sound name either game knows, cut at its first dot and spelled Black Ops 4's way."""
+    seen = set()
+
+    sources = snapshot.table_names(*SOUND_TABLES)
+    sources += snapshot.confirmed_names("sound_asset")
+    sources += snapshot.confirmed_names("sound_alias")
+
+    for name in sources:
+        stem = name.partition(".")[0].strip().lower().replace("/", BS)
+        if stem and stem not in seen:
+            seen.add(stem)
+            yield stem
+
+
+def main():
+    out = sys.stdout
+    roots = set()
+
+    for stem in stems():
+        for tail in TAILS:
+            out.write(stem + "." + tail + "\n")
+
+        match = TRAILING_DIGITS.match(stem)
+        if match:
+            roots.add(match.group(1))
+
+    for root in roots:
+        for index in range(NUMBERS):
+            for form in ("%d" % index, "%02d" % index):
+                base = root + form
+                for tail in TAILS:
+                    out.write(base + "." + tail + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/contributed/suffix_chains_20260821-070445.py
+++ b/scripts/contributed/suffix_chains_20260821-070445.py
@@ -1,0 +1,129 @@
+"""How much reach the 4,800-ending ceiling actually costs, measured on composed endings.
+
+Reconnaissance, not a generator. It prints a number and an argument; it does not emit candidates.
+
+    python scripts/suffix_chains.py
+
+## The question it settles
+
+METHODS.md carried `suffix_chains.py` as a candidate worth building, with this reasoning: endings
+compose (`_01` + `_c`), `data/suffixes.txt` is capped at 4,800 *observed* endings, and
+`derive_lists.py` reports thousands more measured and dropped past that ceiling — so rare
+compositions are structurally absent and no pass can ever express them. The deciding measurement it
+asked for was "how many pairwise compositions of the top 50 endings are already published but
+missing from `data/suffixes.txt`".
+
+**Measured 2026-08-21**, top 60 carried endings, against the 1,460,804 published names in
+`fnv1a_ximages`, `fnv1a_xmaterials`, `fnv1a_xmodels` and `fnv1a_xanims`:
+
+| | |
+|---|---|
+| compositions of the top 60 not carried | 3,384 |
+| of those, actually ending a published name | **1,718** |
+| published names they cover | **49,626** |
+
+`_01_snow` ends 349 published names, `_02_b` 288, `_decal_a` 261, `_02_white` 239. The gap is real
+and it is large.
+
+## Why it was still not built, which is the useful half
+
+**A missing ending is not the same as an unreachable name.** The general search composes
+`beginning + stem + ending`, and the *stem* is an arbitrary piece of a name already known to be
+real — so `mc/mtl_foo_01_snow` is reachable as stem `mc/mtl_foo_01` plus the carried ending
+`_snow`, with nothing composed at all. The composition only buys anything where the intermediate
+stem is *not* independently known, which is a far smaller set than 49,626 and is not measured by
+the number above.
+
+`reach.py` measures the thing that actually matters and reports 83.8-95.9% ending coverage per
+table, which is consistent with most of this gap already being absorbed by stems. Its own warning
+applies here in full: a high share does not predict yield, and **tuning lists until the number is
+high is not the work**.
+
+So this is recorded as *measured and declined* rather than built. If somebody does build it, the
+honest version has to exclude compositions whose left half is already a known piece — otherwise it
+re-finds what a general pass finds anyway, which is the mistake that turned "the best method in
+the project, 1 per 810" into 0 new names on 2026-08-20.
+
+Reads `data/suffixes.txt` and the tables. Writes nothing. Needs no game, network or snapshot.
+"""
+import collections
+import os
+import sys
+
+_root = os.path.dirname(os.path.abspath(__file__))
+while _root != os.path.dirname(_root) and not os.path.isfile(
+    os.path.join(_root, "scripts", "snapshot.py")
+):
+    _root = os.path.dirname(_root)
+sys.path.insert(0, os.path.join(_root, "scripts"))
+
+import snapshot
+
+TABLES = ("fnv1a_ximages", "fnv1a_xmaterials", "fnv1a_xmodels", "fnv1a_xanims")
+
+# How many of the carried endings to compose. The candidate note said 50; 60 is used here so the
+# figure is not sitting exactly on the boundary it was specified at.
+TOP = 60
+
+
+def carried():
+    path = os.path.join(_root, "data", "suffixes.txt")
+    with open(path, encoding="utf-8") as handle:
+        return {line.strip() for line in handle if line.strip()}
+
+
+def tail_counts(names, endings):
+    """How many names each ending finishes, looked up by length rather than scanned."""
+    by_length = collections.defaultdict(set)
+    for ending in endings:
+        by_length[len(ending)].add(ending)
+
+    lengths = sorted(by_length)
+    counts = collections.Counter()
+
+    for name in names:
+        for length in lengths:
+            if length <= len(name) and name[-length:] in by_length[length]:
+                counts[name[-length:]] += 1
+
+    return counts
+
+
+def main():
+    endings = carried()
+    names = []
+    for table in TABLES:
+        names.extend(name.strip().lower() for name in snapshot.table_names(table))
+
+    print("endings carried: %d   published names measured: %d" % (len(endings), len(names)))
+
+    ranked = [ending for ending, _ in tail_counts(names, endings).most_common(TOP)]
+
+    compositions = {
+        left + right
+        for left in ranked
+        for right in ranked
+        if left + right not in endings
+    }
+
+    found = tail_counts(names, compositions)
+    covered = sum(found.values())
+
+    print("\ncompositions of the top %d endings not carried: %d" % (TOP, len(compositions)))
+    print("of those, actually ending a published name:    %d" % len(found))
+    print("published names they cover:                    %d" % covered)
+
+    print("\nthe widest of them:")
+    for composition, count in found.most_common(12):
+        print("   %-26s %d names" % (composition, count))
+
+    print(
+        "\nBefore building a generator on this: the general search's *stem* is an arbitrary piece\n"
+        "of a real name, so `foo_01_snow` is already reachable as stem `foo_01` + ending `_snow`.\n"
+        "Only compositions whose left half is not itself a known piece buy anything. See the\n"
+        "docstring, and reach.py, which measures the ceiling that actually binds."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/submissions/GoastcraftHD_BLKOPSCW_20260821-070445/about_20260821-070445.md
+++ b/submissions/GoastcraftHD_BLKOPSCW_20260821-070445/about_20260821-070445.md
@@ -1,0 +1,35 @@
+# Submission 20260821-070445
+
+- game: **BLKOPSCW**
+- from: GoastcraftHD
+- names: 2
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- material: 1
+- xmodel: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 4 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260821-070054_list
+- method: family column cross product
+- what it does: a candidate list generated outside the search and confirmed here
+- ran for: 2m 55s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- candidates tested: 118617370
+- matched: 943
+- new: 2
+- ids hunted: 147630
+- throughput: 0.7M candidates/s
+- fingerprint: f51c0aa55dfeb4ce
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/GoastcraftHD_BLKOPSCW_20260821-070445/material_20260821-070445.txt
+++ b/submissions/GoastcraftHD_BLKOPSCW_20260821-070445/material_20260821-070445.txt
@@ -1,0 +1,1 @@
+52e214b1950d824d,mc/t8_snow_usa_tracks_blend

--- a/submissions/GoastcraftHD_BLKOPSCW_20260821-070445/xmodel_20260821-070445.txt
+++ b/submissions/GoastcraftHD_BLKOPSCW_20260821-070445/xmodel_20260821-070445.txt
@@ -1,0 +1,1 @@
+73aa3edcd95c53d1,p8_fxp_fluid_clump_blood_dark_sm_hirez


### PR DESCRIPTION
**BLKOPSCW** — 2 asset names, confirmed against that game's own loaded assets.

- material: 1
- xmodel: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @GoastcraftHD

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260821-070054_list
- method: family column cross product
- what it does: a candidate list generated outside the search and confirmed here
- ran for: 2m 55s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- candidates tested: 118617370
- matched: 943
- new: 2
- ids hunted: 147630
- throughput: 0.7M candidates/s
- fingerprint: f51c0aa55dfeb4ce

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/templates_20260819-220821.py`
- `scripts/contributed/aliasswap_20260821-070445.py`
- `scripts/contributed/borrow_old_titles_20260821-070445.py`
- `scripts/contributed/cross_game_20260821-070445.py`
- `scripts/contributed/old_titles_20260821-070445.py`
- `scripts/contributed/sabpaths_20260821-070445.py`
- `scripts/contributed/soundxfer_20260821-070445.py`
- `scripts/contributed/suffix_chains_20260821-070445.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.