### PR TITLE
[BLKOPS04] findings from Dreadbread76, 20260821-112201 (5 names)

### DIFF
--- a/submissions/Dreadbread76_BLKOPS04_20260821-112201/about_20260821-112201.md
+++ b/submissions/Dreadbread76_BLKOPS04_20260821-112201/about_20260821-112201.md
@@ -1,0 +1,33 @@
+# Submission 20260821-112201
+
+- game: **BLKOPS04**
+- from: Dreadbread76
+- names: 5
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 6 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260821-112126_soundfiles
+- method: sound files and aliases (confirm_cw --sounds)
+- what it does: every seed cut to pieces at its marks and recombined as beginning + stem + ending, each candidate hashed and looked up among the game's unnamed ids
+- ran for: 54m 48s
+- game: BLKOPS04
+- pools searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- seed lines: 3289861
+- distinct pieces: 31353970
+- beginnings: 700
+- endings: 4800
+- ids hunted: 87568
+- matches: 62
+- distinct names reached: 23
+- new here: 5
+- fingerprint: 00421e4bb5ca4e88
+
+**Next:** this configuration is now exhausted. Re-measure the lists with `python scripts/derive_lists.py` so the confirmed names widen them, which changes the fingerprint and reopens the method -- or run a method that reaches somewhere else entirely (METHODS.md).

--- a/submissions/Dreadbread76_BLKOPS04_20260821-112201/sound_alias_20260821-112201.txt
+++ b/submissions/Dreadbread76_BLKOPS04_20260821-112201/sound_alias_20260821-112201.txt
@@ -1,0 +1,5 @@
+349ca23ffcbb095,zmb_prima_base_start
+41079af766dbafee,zmb_avogadro_charge_jump
+5a4be9ff92896db5,fly_emote_uni_fem_main
+600ecc5b2212d96f,fly_step_wall_lt_plr_dirt_big
+6221094133bd3b84,fly_emote_uni_male_main


### PR DESCRIPTION
**BLKOPS04** — 5 asset names, confirmed against that game's own loaded assets.

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Dreadbread76

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260821-112126_soundfiles
- method: sound files and aliases (confirm_cw --sounds)
- what it does: every seed cut to pieces at its marks and recombined as beginning + stem + ending, each candidate hashed and looked up among the game's unnamed ids
- ran for: 54m 48s
- game: BLKOPS04
- pools searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
- seed lines: 3289861
- distinct pieces: 31353970
- beginnings: 700
- endings: 4800
- ids hunted: 87568
- matches: 62
- distinct names reached: 23
- new here: 5
- fingerprint: 00421e4bb5ca4e88

**Next:** this configuration is now exhausted. Re-measure the lists with `python scripts/derive_lists.py` so the confirmed names widen them, which changes the fingerprint and reopens the method -- or run a method that reaches somewhere else entirely (METHODS.md).
