### PR TITLE
[BLKOPSCW] findings from Owen-C137, 20260821-152433 (8 names)

### DIFF
--- a/submissions/Owen-C137_BLKOPSCW_20260821-152433/about_20260821-152433.md
+++ b/submissions/Owen-C137_BLKOPSCW_20260821-152433/about_20260821-152433.md
@@ -1,0 +1,38 @@
+# Submission 20260821-152433
+
+- game: **BLKOPSCW**
+- from: Owen-C137
+- names: 8
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- sound_alias: 8
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 0 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260821-144811_soundfiles
+- method: sound files and aliases (confirm_cw --sounds)
+- what it does: every seed cut to pieces at its marks and recombined as beginning + stem + ending, each candidate hashed and looked up among the game's unnamed ids
+- ran for: 36m 06s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- pools searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- seed lines: 4522986
+- distinct pieces: 45167451
+- beginnings: 700
+- endings: 4800
+- ids hunted: 37244
+- matches: 9
+- distinct names reached: 8
+- new here: 8
+- fingerprint: 97057232c5fc3a2a
+
+**Next:** this configuration is now exhausted. Re-measure the lists with `python scripts/derive_lists.py` so the confirmed names widen them, which changes the fingerprint and reopens the method -- or run a method that reaches somewhere else entirely (METHODS.md).

--- a/submissions/Owen-C137_BLKOPSCW_20260821-152433/sound_alias_20260821-152433.txt
+++ b/submissions/Owen-C137_BLKOPSCW_20260821-152433/sound_alias_20260821-152433.txt
@@ -1,0 +1,8 @@
+4a030474e61add8,uin_kls_planemortar
+1052b6155d1244c9,veh_f35_engine_high
+129678d4171a455b,amb_power_thumpy
+1638a96593d3fc2b,uin_cac_perk_tactical_mask
+261ccadb1242dae5,uin_wz_attach_silencer_on
+66dc2a044e26c03d,evt_intro_igc_cia
+74262cffefad9bdc,wpn_arav_turret_overheat_plr
+7743b465748846ec,uin_kls_minigun


### PR DESCRIPTION
**BLKOPSCW** — 8 asset names, confirmed against that game's own loaded assets.

- sound_alias: 8

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Owen-C137

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260821-144811_soundfiles
- method: sound files and aliases (confirm_cw --sounds)
- what it does: every seed cut to pieces at its marks and recombined as beginning + stem + ending, each candidate hashed and looked up among the game's unnamed ids
- ran for: 36m 06s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- pools searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
- seed lines: 4522986
- distinct pieces: 45167451
- beginnings: 700
- endings: 4800
- ids hunted: 37244
- matches: 9
- distinct names reached: 8
- new here: 8
- fingerprint: 97057232c5fc3a2a

**Next:** this configuration is now exhausted. Re-measure the lists with `python scripts/derive_lists.py` so the confirmed names widen them, which changes the fingerprint and reopens the method -- or run a method that reaches somewhere else entirely (METHODS.md).
