### PR TITLE
[BLKOPS04] findings from KingslayerKyle, 20260821-163108 (4 names)

### DIFF
--- a/scripts/contributed/keyword_sweep_20260821-163108.py
+++ b/scripts/contributed/keyword_sweep_20260821-163108.py
@@ -1,0 +1,152 @@
+"""Every known name carrying a keyword, recombined with itself and swept with short affixes.
+
+    python contrib/keyword_sweep.py --keyword zombie --type model | ^
+        bin\\windows\\confirm_list.exe - --label "keyword sweep: zombie" ^
+        --script contrib/keyword_sweep.py --game BLKOPS04
+
+`scripts/affix_sweep.py` sweeps short affixes around a *core*, and it is deliberately blind to
+what the core says -- it takes the middle of a name and wraps it. That is the right shape for the
+whole corpus and the wrong one for a family: an hour spread across every model core in the game
+reaches each of them once, and the affix it can afford gets shorter the more cores there are.
+
+This is the family version, and it does two things that one does not:
+
+  - **the name is recombined with itself.** Every contiguous run of its own tokens that still
+    carries the keyword, every one-token deletion, and every adjacent swap. `p9_zmb_zombie_head_01`
+    offers `zmb_zombie_head`, `zombie_head_01`, `zmb_zombie_01`, `zombie_zmb_head_01` and so on.
+    Real names in a family are each other's rearrangements far more often than they are each
+    other's neighbours in a frequency table.
+  - **then the affixes go on**, exactly as the sweep does it: every one and two character leading
+    and trailing token, so an affix used once in the game is reached even though no measured list
+    can hold it.
+
+The two together are the point. An affix sweep alone needs the core to be right; a recombination
+alone needs the affix to have been measured. A family is small enough to afford both at once.
+
+Nothing here is unseeded except the affixes: every token in every candidate comes from a name the
+game itself holds.
+"""
+import os
+import sys
+
+_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(_root, "scripts"))
+
+import snapshot  # noqa: E402
+
+# What a table is called, and which pool its confirmed names live in.
+TYPES = {
+    "model": ("fnv1a_xmodels", "xmodel"),
+    "material": ("fnv1a_xmaterials", "material"),
+    "image": ("fnv1a_ximages", "image"),
+    "anim": ("fnv1a_xanims", "xanim"),
+}
+
+ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789"
+
+# Roughly what `confirm_list` reads and hashes per second, measured on the zombies run:
+# 452,317,008 candidates in 299 seconds.
+RATE = 1_500_000
+
+
+def affixes():
+    """Every one and two character affix, which is 36 + 1,296 of them."""
+    one = list(ALPHABET)
+    two = [a + b for a in ALPHABET for b in ALPHABET]
+    return one, two
+
+
+def rearrangements(parts, keyword):
+    """The name said in the ways the same family says it elsewhere.
+
+    Contiguous runs, one-token deletions and adjacent swaps -- and only the ones that still carry
+    the keyword, since a variant that has dropped it is no longer this family and is the general
+    search's job.
+    """
+    out = []
+
+    for start in range(len(parts)):
+        for end in range(start + 1, len(parts) + 1):
+            run = parts[start:end]
+            if any(keyword in token for token in run):
+                out.append("_".join(run))
+
+    for index in range(len(parts)):
+        without = parts[:index] + parts[index + 1:]
+        if without and any(keyword in token for token in without):
+            out.append("_".join(without))
+
+    for index in range(len(parts) - 1):
+        swapped = list(parts)
+        swapped[index], swapped[index + 1] = swapped[index + 1], swapped[index]
+        out.append("_".join(swapped))
+
+    return out
+
+
+def seeds(kind, keyword):
+    """Every name of this type, in either game, that carries the keyword."""
+    table, pool = TYPES[kind]
+    seen = set()
+
+    for source in (snapshot.confirmed_names(pool), snapshot.table_names(table)):
+        for name in source:
+            name = name.strip().lower().replace("\\", "/")
+            if keyword not in name:
+                continue
+
+            base = name.rpartition("/")[2]
+            if base and base not in seen:
+                seen.add(base)
+                yield base
+
+
+def main(argv):
+    keyword = argv[argv.index("--keyword") + 1].lower() if "--keyword" in argv else "zombie"
+    kind = argv[argv.index("--type") + 1] if "--type" in argv else "model"
+    hours = float(argv[argv.index("--hours") + 1]) if "--hours" in argv else 1.0
+
+    if kind not in TYPES:
+        raise SystemExit("--type must be one of: %s" % ", ".join(sorted(TYPES)))
+
+    budget = int(hours * 3600 * RATE)
+
+    cores = set()
+    for base in seeds(kind, keyword):
+        cores.add(base)
+        for variant in rearrangements(base.split("_"), keyword):
+            if variant:
+                cores.add(variant)
+
+    cores = sorted(cores)
+    one, two = affixes()
+
+    # What one core costs: itself, a leading affix, a trailing affix, and both at one character.
+    # Two-character affixes go on one side only -- both sides at two characters is 1.7M per core,
+    # which buys length nobody has evidence for at the price of everything else.
+    per_core = 1 + 2 * (len(one) + len(two)) + len(one) * len(one)
+
+    print("%s %ss carrying `%s`, recombined into %d cores"
+          % (kind, kind, keyword, len(cores)), file=sys.stderr)
+    print("%d candidates per core, %d in total" % (per_core, per_core * len(cores)),
+          file=sys.stderr)
+
+    if per_core * len(cores) > budget:
+        keep = max(1, budget // per_core)
+        print("over the %.1f hour budget: sweeping the first %d cores of %d"
+              % (hours, keep, len(cores)), file=sys.stderr)
+        cores = cores[:keep]
+
+    out = sys.stdout
+    for core in cores:
+        out.write(core + "\n")
+        for head in one + two:
+            out.write(head + "_" + core + "\n")
+            out.write(core + "_" + head + "\n")
+        for head in one:
+            for tail in one:
+                out.write(head + "_" + core + "_" + tail + "\n")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/scripts/contributed/zombie_models_20260821-163108.py
+++ b/scripts/contributed/zombie_models_20260821-163108.py
@@ -1,0 +1,118 @@
+"""Zombies-flavoured xmodel names, recombined from every zombies name already known to be real.
+
+    python contrib/zombie_models.py | bin/windows/confirm_list.exe - ^
+        --label "zombie xmodels" --script contrib/zombie_models.py --game BLKOPS04
+
+Black Ops 4's model pool is 61,139 names of which 20,922 are unnamed, and the zombies content is
+a family in its own right: it has its own directories, its own character and prop vocabulary, and
+its own suffixes. This takes the part of the corpus that already says `zombie` -- published names
+from the tables, plus everything this project has confirmed in either game -- cuts it at the marks
+a name is built from, and puts the pieces back together against the model beginnings and endings
+`derive_lists.py` measured.
+
+Seeded, as everything here is: no candidate contains a token that no real name contains. What it
+reaches that a general pass does not is the *cross product* of one family -- every zombies stem
+against every model beginning and ending, rather than whatever share of that the global ceiling
+happens to afford.
+"""
+import os
+import re
+import sys
+
+_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(_root, "scripts"))
+
+import settings  # noqa: E402
+
+WANTED = re.compile(r"zombie|zmb|_zm_|^zm_|/zm_")
+
+# Model beginnings, kept short deliberately. The published model vocabulary heads its names with
+# these; a zombies model is a model first.
+OPENINGS = [
+    "", "p9_", "p8_", "p7_", "p6_", "c_", "t9_", "vm_", "wm_", "attach_", "veh_", "ai_",
+    "p9_zmb_", "p8_zmb_", "c_zmb_", "zmb_", "zm_", "p9_zombie_", "c_zombie_", "zombie_",
+    "clt/", "splm/", "cltp/", "mc/",
+]
+
+# The endings a model family varies. Measured ones come from the committed list; the numbered and
+# lod tails are the ones no table can show, because a mesh entry hides them behind its own hash.
+TAILS = ["", "_lod0", "_lod1", "_lod2", "_lod3", "_body", "_head", "_hat", "_arms", "_legs",
+         "_torso", "_hands", "_fx", "_dead", "_gib", "_world", "_view", "_dmg", "_variant"]
+for number in range(0, 13):
+    TAILS.append("_%02d" % number)
+    TAILS.append("_%d" % number)
+
+
+def measured(name):
+    """The committed endings, which are what the general search itself carries."""
+    path = os.path.join(_root, "data", name)
+    with open(path, encoding="utf-8") as handle:
+        return [line.strip() for line in handle if line.strip()]
+
+
+def corpus():
+    """Every name already known to be real, from the tables and from what has been confirmed."""
+    # Models only. A zombies *sound* path shares the word and none of the shape, and seeding from
+    # it produced 795,105 stems -- 74 billion candidates, which is a week of generating for a pool
+    # of 20,922 unnamed ids.
+    tables = settings.tables_csv()
+    for entry in ("fnv1a_xmodels.csv",):
+        with open(os.path.join(tables, entry), encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                if "," in line:
+                    yield line.strip().split(",", 1)[1].lower().replace(chr(92), "/")
+
+    found = settings.path("findings", "findings")
+    for here, _, files in os.walk(found):
+        for name in files:
+            if not name.startswith("xmodel") or not name.endswith(".txt"):
+                continue
+            with open(os.path.join(here, name), encoding="utf-8", errors="replace") as handle:
+                for line in handle:
+                    if "," in line:
+                        yield line.strip().split(",", 1)[1].lower().replace(chr(92), "/")
+
+
+def stems_of(name):
+    """Every piece of a name that could be a name in its own right, cut at the marks."""
+    base = name.rpartition("/")[2]
+    parts = base.split("_")
+
+    for start in range(len(parts)):
+        for end in range(start + 1, len(parts) + 1):
+            piece = "_".join(parts[start:end])
+            if len(piece) >= 3:
+                yield piece
+
+
+def main():
+    seen_stems = set()
+    for name in corpus():
+        if not WANTED.search(name):
+            continue
+        for stem in stems_of(name):
+            seen_stems.add(stem)
+
+    # Only the pieces that carry the family. A bare `_01` or `head` is every model in the game and
+    # would spend the run on candidates the general search already covers.
+    stems = sorted(stem for stem in seen_stems
+                   if WANTED.search(stem) and stem.count("_") <= 5)
+    print("zombies stems: %d" % len(stems), file=sys.stderr)
+
+    # One trailing segment only, and the commonest of those: an ending is nearly free to the
+    # search but not to this pipe, which has to write every candidate out as text.
+    endings = TAILS + [item for item in measured("suffixes.txt") if item.count("_") == 1][:400]
+    endings = list(dict.fromkeys(endings))
+    print("endings: %d, openings: %d" % (len(endings), len(OPENINGS)), file=sys.stderr)
+    print("candidates: %d" % (len(stems) * len(endings) * len(OPENINGS)), file=sys.stderr)
+
+    out = sys.stdout
+    for stem in stems:
+        for opening in OPENINGS:
+            head = opening + stem
+            for ending in endings:
+                out.write(head + ending + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/submissions/KingslayerKyle_BLKOPS04_20260821-163108/about_20260821-163108.md
+++ b/submissions/KingslayerKyle_BLKOPS04_20260821-163108/about_20260821-163108.md
@@ -1,0 +1,34 @@
+# Submission 20260821-163108
+
+- game: **BLKOPS04**
+- from: KingslayerKyle
+- names: 4
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- image: 4
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 3 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260821-162948_list
+- method: keyword sweep: zombie models
+- what it does: a candidate list generated outside the search and confirmed here
+- ran for: 58s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- candidates tested: 100074665
+- matched: 4
+- new: 4
+- ids hunted: 187447
+- throughput: 1.8M candidates/s
+- fingerprint: 13bd3860a0e5dc4b
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/KingslayerKyle_BLKOPS04_20260821-163108/image_20260821-163108.txt
+++ b/submissions/KingslayerKyle_BLKOPS04_20260821-163108/image_20260821-163108.txt
@@ -1,0 +1,4 @@
+7c15af39e448b520,i_c_t8_zmb_dlc2_zombie_female_hood_g
+7c15b339e448bbec,i_c_t8_zmb_dlc2_zombie_female_hood_c
+7c15b739e448c2b8,i_c_t8_zmb_dlc2_zombie_female_hood_o
+7c15b839e448c46b,i_c_t8_zmb_dlc2_zombie_female_hood_n


### PR DESCRIPTION
**BLKOPS04** — 4 asset names, confirmed against that game's own loaded assets.

- image: 4

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @KingslayerKyle

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260821-162948_list
- method: keyword sweep: zombie models
- what it does: a candidate list generated outside the search and confirmed here
- ran for: 58s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- candidates tested: 100074665
- matched: 4
- new: 4
- ids hunted: 187447
- throughput: 1.8M candidates/s
- fingerprint: 13bd3860a0e5dc4b

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/keyword_sweep_20260821-163108.py`
- `scripts/contributed/zombie_models_20260821-163108.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.