### PR TITLE
[BLKOPSCW] findings from Zakkary19, 20260821-173249 (9 names)

### DIFF
--- a/submissions/Zakkary19_BLKOPSCW_20260821-173249/about_20260821-173249.md
+++ b/submissions/Zakkary19_BLKOPSCW_20260821-173249/about_20260821-173249.md
@@ -1,0 +1,40 @@
+# Submission 20260821-173249
+
+- game: **BLKOPSCW**
+- from: Zakkary19
+- names: 9
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 3
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- material: 7
+- image: 1
+- xanim: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 4 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260821-162232_all
+- method: general search (confirm_cw)
+- what it does: every seed cut to pieces at its marks and recombined as beginning + stem + ending, each candidate hashed and looked up among the game's unnamed ids
+- ran for: 1h 10m 07s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- pools searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- seed lines: 3288289
+- distinct pieces: 31355741
+- beginnings: 700
+- endings: 4800
+- ids hunted: 109649
+- matches: 45
+- distinct names reached: 12
+- new here: 12
+- fingerprint: ebb1fe1878b00d38
+
+**Next:** this configuration is now exhausted. Re-measure the lists with `python scripts/derive_lists.py` so the confirmed names widen them, which changes the fingerprint and reopens the method -- or run a method that reaches somewhere else entirely (METHODS.md).

--- a/submissions/Zakkary19_BLKOPSCW_20260821-173249/image_20260821-173249.txt
+++ b/submissions/Zakkary19_BLKOPSCW_20260821-173249/image_20260821-173249.txt
@@ -1,0 +1,1 @@
+429a5c5a2d35504b,img_postfx_zm_tombstone

--- a/submissions/Zakkary19_BLKOPSCW_20260821-173249/material_20260821-173249.txt
+++ b/submissions/Zakkary19_BLKOPSCW_20260821-173249/material_20260821-173249.txt
@@ -1,0 +1,7 @@
+96fbbb8d5c02c44,clt/t8_snow_usa_chunky_blend
+30b6f44c783e55e0,cltp/t8_snow_usa_chunky
+31b21378f75c2d39,mc/t8_snow_usa_chunky_blend
+51d931b9e43b1361,splm/t8_snow_usa_chunky_blend
+5ef90e4615f66dbc,clt/t8_snow_usa_chunky
+6aeaceff1946ab99,mc/mtl_veh_t9_civ_us_forklift_cockpit_plastic_accent
+7882b43a94aad3d3,mc/mtl_p8_usa_saddle_decal_stitches_under

--- a/submissions/Zakkary19_BLKOPSCW_20260821-173249/xanim_20260821-173249.txt
+++ b/submissions/Zakkary19_BLKOPSCW_20260821-173249/xanim_20260821-173249.txt
@@ -1,0 +1,1 @@
+2f4ed7a6a38495db,v_cin_mp_moscow_cia_intro_shot010_player_bump


### PR DESCRIPTION
**BLKOPSCW** — 9 asset names, confirmed against that game's own loaded assets.

- material: 7
- image: 1
- xanim: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 3
- submitted by: @Zakkary19

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260821-162232_all
- method: general search (confirm_cw)
- what it does: every seed cut to pieces at its marks and recombined as beginning + stem + ending, each candidate hashed and looked up among the game's unnamed ids
- ran for: 1h 10m 07s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- pools searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
- seed lines: 3288289
- distinct pieces: 31355741
- beginnings: 700
- endings: 4800
- ids hunted: 109649
- matches: 45
- distinct names reached: 12
- new here: 12
- fingerprint: ebb1fe1878b00d38

**Next:** this configuration is now exhausted. Re-measure the lists with `python scripts/derive_lists.py` so the confirmed names widen them, which changes the fingerprint and reopens the method -- or run a method that reaches somewhere else entirely (METHODS.md).


## Tooling this run leaves behind

- `scripts/contributed/numbered_grids_20260821-054219.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.