### PR TITLE
[BLKOPS04] findings from Zakkary19, 20260821-200511 (1 names)

### DIFF
--- a/submissions/Zakkary19_BLKOPS04_20260821-200511/about_20260821-200511.md
+++ b/submissions/Zakkary19_BLKOPS04_20260821-200511/about_20260821-200511.md
@@ -1,0 +1,38 @@
+# Submission 20260821-200511
+
+- game: **BLKOPS04**
+- from: Zakkary19
+- names: 1
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- sound_alias: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 6 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260821-191336_soundfiles
+- method: sound files and aliases (confirm_cw --sounds)
+- what it does: every seed cut to pieces at its marks and recombined as beginning + stem + ending, each candidate hashed and looked up among the game's unnamed ids
+- ran for: 51m 25s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- pools searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- seed lines: 3288417
+- distinct pieces: 31355839
+- beginnings: 700
+- endings: 4800
+- ids hunted: 87350
+- matches: 523
+- distinct names reached: 76
+- new here: 1
+- fingerprint: 2145382e394850f0
+
+**Next:** this configuration is now exhausted. Re-measure the lists with `python scripts/derive_lists.py` so the confirmed names widen them, which changes the fingerprint and reopens the method -- or run a method that reaches somewhere else entirely (METHODS.md).

--- a/submissions/Zakkary19_BLKOPS04_20260821-200511/sound_alias_20260821-200511.txt
+++ b/submissions/Zakkary19_BLKOPS04_20260821-200511/sound_alias_20260821-200511.txt
@@ -1,0 +1,1 @@
+7df5936bf211e1e2,amb_fan_spin


### PR DESCRIPTION
**BLKOPS04** — 1 asset names, confirmed against that game's own loaded assets.

- sound_alias: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Zakkary19

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260821-191336_soundfiles
- method: sound files and aliases (confirm_cw --sounds)
- what it does: every seed cut to pieces at its marks and recombined as beginning + stem + ending, each candidate hashed and looked up among the game's unnamed ids
- ran for: 51m 25s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- pools searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
- seed lines: 3288417
- distinct pieces: 31355839
- beginnings: 700
- endings: 4800
- ids hunted: 87350
- matches: 523
- distinct names reached: 76
- new here: 1
- fingerprint: 2145382e394850f0

**Next:** this configuration is now exhausted. Re-measure the lists with `python scripts/derive_lists.py` so the confirmed names widen them, which changes the fingerprint and reopens the method -- or run a method that reaches somewhere else entirely (METHODS.md).


## Tooling this run leaves behind

- `scripts/contributed/numbered_grids_20260821-054219.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.