### PR TITLE
[BLKOPSCW] findings from Zakkary19, 20260822-014525 (1 names)

### DIFF
--- a/submissions/Zakkary19_BLKOPSCW_20260822-014525/about_20260822-014525.md
+++ b/submissions/Zakkary19_BLKOPSCW_20260822-014525/about_20260822-014525.md
@@ -1,0 +1,34 @@
+# Submission 20260822-014525
+
+- game: **BLKOPSCW**
+- from: Zakkary19
+- names: 1
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- sound_alias: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 12 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260822-014509_list
+- method: sound alias slot substitution
+- what it does: a candidate list generated outside the search and confirmed here
+- ran for: 4s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- candidates tested: 2062280
+- matched: 11
+- new: 1
+- ids hunted: 146873
+- throughput: 0.8M candidates/s
+- fingerprint: 1735cfdb4aacdf9c
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/Zakkary19_BLKOPSCW_20260822-014525/sound_alias_20260822-014525.txt
+++ b/submissions/Zakkary19_BLKOPSCW_20260822-014525/sound_alias_20260822-014525.txt
@@ -1,0 +1,1 @@
+53829a1c925d9650,wpn_bhbomb_explode_swt


### PR DESCRIPTION
**BLKOPSCW** — 1 asset names, confirmed against that game's own loaded assets.

- sound_alias: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Zakkary19

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260822-014509_list
- method: sound alias slot substitution
- what it does: a candidate list generated outside the search and confirmed here
- ran for: 4s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- candidates tested: 2062280
- matched: 11
- new: 1
- ids hunted: 146873
- throughput: 0.8M candidates/s
- fingerprint: 1735cfdb4aacdf9c

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/aliasswap_20260821-003619.py`
- `scripts/contributed/numbered_grids_20260821-054219.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.