### PR TITLE
[BLKOPSCW] findings from KingslayerKyle, 20260822-020216 (5 names)

### DIFF
--- a/submissions/KingslayerKyle_BLKOPSCW_20260822-020216/about_20260822-020216.md
+++ b/submissions/KingslayerKyle_BLKOPSCW_20260822-020216/about_20260822-020216.md
@@ -1,0 +1,36 @@
+# Submission 20260822-020216
+
+- game: **BLKOPSCW**
+- from: KingslayerKyle
+- names: 5
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- sound_alias: 4
+- xanim: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 13 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260822-015637_plan
+- method: uncarried beginnings, optics and prefixed families
+- what it does: the 208 leading segments reach.py measures as unexpressible by the committed beginning list, against cores taken from the published names that use them and from everything this machine has confirmed
+- ran for: 2m 29s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- beginnings: 208
+- endings: 4629
+- stems: 140947
+- ids hunted: 146832
+- candidates tested: 135737598880
+- new: 5
+- fingerprint: 30c850c23b3b3010
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/KingslayerKyle_BLKOPSCW_20260822-020216/sound_alias_20260822-020216.txt
+++ b/submissions/KingslayerKyle_BLKOPSCW_20260822-020216/sound_alias_20260822-020216.txt
@@ -1,0 +1,4 @@
+116a7294b71cf1cb,zmb_vocals_orda_swarm
+4e9f052116a0cb95,zmb_tungsten_teleporter_activate_switch
+6815f73d5b19aa6c,zmb_ai_raz_damage_armor_accent
+7f0be224a48375bd,zmb_perksacola_activate_fx

--- a/submissions/KingslayerKyle_BLKOPSCW_20260822-020216/xanim_20260822-020216.txt
+++ b/submissions/KingslayerKyle_BLKOPSCW_20260822-020216/xanim_20260822-020216.txt
@@ -1,0 +1,1 @@
+50bf30e5c9708e82,o_heavy_attack_chopper_gunner_enter


### PR DESCRIPTION
**BLKOPSCW** — 5 asset names, confirmed against that game's own loaded assets.

- sound_alias: 4
- xanim: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @KingslayerKyle

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260822-015637_plan
- method: uncarried beginnings, optics and prefixed families
- what it does: the 208 leading segments reach.py measures as unexpressible by the committed beginning list, against cores taken from the published names that use them and from everything this machine has confirmed
- ran for: 2m 29s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- beginnings: 208
- endings: 4629
- stems: 140947
- ids hunted: 146832
- candidates tested: 135737598880
- new: 5
- fingerprint: 30c850c23b3b3010

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/keyword_sweep_20260822-020208.py`
- `scripts/contributed/uncarried_beginnings_20260822-020208.txt`
- `scripts/contributed/uncarried_stems_20260822-020208.txt`
- `scripts/contributed/zombie_models_20260822-020208.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.