### PR TITLE
[BLKOPSCW] findings from GoastcraftHD, 20260822-024055 (2 names)

### DIFF
--- a/scripts/contributed/harvest_bo3_20260822-024055.py
+++ b/scripts/contributed/harvest_bo3_20260822-024055.py
@@ -1,0 +1,262 @@
+"""Black Ops 3's own asset names, read out of the retail build Steam ships.
+
+    python contrib/harvest_bo3.py                 find the build, harvest into borrowed/
+    python contrib/harvest_bo3.py --limit 4       first four containers, to try it
+    python contrib/harvest_bo3.py --zone PATH     point it at a zone folder yourself
+
+**What problem it solves.** METHODS.md says, in three separate places, that the biggest pools are
+only reachable "from outside the known names -- the SAB files, a build, or the game's own
+strings", and every attempt to get outside has run into a wall: the newer titles' tables are
+measured **dead** (0 of 1,175,524), and Black Ops 4 and Cold War are installed as **CASC** --
+BLTE-framed 1 GB archives, Cold War's fast files AES-256-CTR on top -- so a raw scan of one
+returns byte-coincidence noise and nothing else.
+
+Black Ops 3 is the exception, and it is the one that matters most: it is Black Ops 4's direct
+predecessor, Steam ships it as **loose, unencrypted fast files**, and cod-name-db has **no Black
+Ops 3 model, material, image or anim table at all** -- only `bo3_sab`, which is audio. So this is
+a large, closely related vocabulary the project has never seen, and older-title vocabulary is the
+densest transfer measured here (`config.toml`: 1 new per 19,591 candidates).
+
+**Why nobody had read it.** The containers use the same block chain Cold War does -- a 16-byte
+record whose fourth word is its own offset, payload following -- with two differences that each
+look like "this file is not readable" rather than "you are one constant out":
+
+  - the chain starts at **0x248**, and `harvest_retail.py` searches from `0x400`, so it walks past;
+  - the payload is zlib with a **4 KB window**, so the header byte is **0x48, not 0x78**. Every
+    scanner that hunts for 0x78 -- including the first three written for this -- reports the file
+    as having no zlib in it at all, which is exactly what a compressed-and-encrypted container
+    looks like. The test that actually holds is `(cmf & 0x0F) == 8 and (cmf << 8 | flg) % 31 == 0`.
+
+Tested with Cold War's own `oo2core_8_win64.dll` first, which returns 0: it is not Oodle, and that
+negative is what sent the search back to deflate.
+
+**Reads** every `.ff` and `.fd` under the build's `zone/` folder, one block at a time, so the peak
+cost is one block rather than the size of the build. Nothing decompressed is written down.
+**Writes** the names it finds to `borrowed/bo3_build.txt`, which is what `[paths] borrowed` in
+`config.toml` already points at -- so the next general pass picks the whole vocabulary up as
+pieces with no further wiring, and `scripts/old_titles.py` can respell it.
+
+**Measured, 2026-08-22:** see the run notes in the submission this shipped with.
+"""
+import argparse
+import glob
+import os
+import sys
+import zlib
+
+_root = os.path.dirname(os.path.abspath(__file__))
+while _root != os.path.dirname(_root) and not os.path.isfile(
+    os.path.join(_root, "scripts", "snapshot.py")
+):
+    _root = os.path.dirname(_root)
+sys.path.insert(0, os.path.join(_root, "scripts"))
+
+# The name filters live in `harvest_retail.py` and are deliberately not copied: they encode what a
+# Treyarch asset name looks like against compressed data that happens to decode as printable, and
+# two copies of that would drift apart.
+import harvest_retail
+
+# Where Steam puts it, in the order worth trying. `--zone` overrides all of this.
+LIKELY = [
+    r"C:\Program Files (x86)\Steam\steamapps\common\Call of Duty Black Ops III\zone",
+    r"D:\SteamLibrary\steamapps\common\Call of Duty Black Ops III\zone",
+    r"E:\SteamLibrary\steamapps\common\Call of Duty Black Ops III\zone",
+    r"F:\SteamLibrary\steamapps\common\Call of Duty Black Ops III\zone",
+]
+
+BLOCK = 16
+BOUNDARY = 0x800000
+
+# Black Ops 3 puts the chain at 0x248. Cold War's is past 0x400. Search wide enough for both
+# rather than carrying a per-title constant the next build breaks.
+SEARCH_FROM = 0x100
+SEARCH_TO = 0x900
+
+
+def zlib_header_at(blob, at):
+    """Whether a zlib stream starts here, without assuming the usual 32 KB window.
+
+    The window size lives in the high nibble of CMF, so a 4 KB stream begins 0x48 and a 32 KB one
+    begins 0x78. Hunting for 0x78 alone is what hid this entire build.
+    """
+    if at + 1 >= len(blob):
+        return False
+    cmf = blob[at]
+    return (cmf & 0x0F) == 8 and ((cmf << 8 | blob[at + 1]) % 31) == 0
+
+
+def block_table(head):
+    """Where the chain begins, proved by a block that names its own offset."""
+    for offset in range(SEARCH_FROM, min(SEARCH_TO, len(head) - BLOCK)):
+        if int.from_bytes(head[offset + 12:offset + 16], "little") != offset:
+            continue
+        compressed = int.from_bytes(head[offset:offset + 4], "little")
+        decompressed = int.from_bytes(head[offset + 4:offset + 8], "little")
+        if 0 < compressed <= decompressed <= 0x4000000:
+            return offset
+    return None
+
+
+def walk_chain(path):
+    """One container, block by block. Returns how many blocks actually decompressed."""
+    size = os.path.getsize(path)
+    blocks = 0
+
+    with open(path, "rb") as handle:
+        head = handle.read(SEARCH_TO + BLOCK)
+        offset = block_table(head)
+        if offset is None:
+            return 0
+
+        handle.seek(offset)
+
+        while offset < size:
+            header = handle.read(BLOCK)
+            if len(header) < BLOCK:
+                break
+
+            compressed = int.from_bytes(header[0:4], "little")
+            decompressed = int.from_bytes(header[4:8], "little")
+            aligned = int.from_bytes(header[8:12], "little")
+            stated = int.from_bytes(header[12:16], "little")
+
+            if stated != offset:
+                break
+
+            # A block with nothing in it means skip to the next boundary.
+            if decompressed == 0:
+                offset = (offset // BOUNDARY + 1) * BOUNDARY
+                handle.seek(offset)
+                continue
+
+            if compressed == 0 or decompressed > 0x4000000 or aligned > 0x4000000:
+                break
+
+            payload = handle.read(aligned)
+            if len(payload) < compressed:
+                break
+
+            try:
+                output = zlib.decompressobj().decompress(payload[:compressed], decompressed)
+            except zlib.error:
+                # A codec this does not speak, or a damaged block. Dropped rather than guessed at,
+                # and the file carries on -- the same rule `harvest_retail` follows.
+                output = b""
+
+            if output:
+                harvest_retail.take(output)
+                blocks += 1
+
+            offset += BLOCK + aligned
+            handle.seek(offset)
+
+    return blocks
+
+
+def walk_stream(path, window=1 << 16):
+    """A container that is one zlib stream rather than a chain -- which is what `.fd` files are.
+
+    Inflated in pieces, so a 27 MB expansion never costs more than a piece at a time.
+    """
+    with open(path, "rb") as handle:
+        head = handle.read(window)
+
+        start = None
+        for at in range(len(head) - 1):
+            if not zlib_header_at(head, at):
+                continue
+            try:
+                probe = zlib.decompressobj().decompress(head[at:], 1 << 20)
+            except zlib.error:
+                continue
+            if len(probe) > 4096:
+                start = at
+                break
+
+        if start is None:
+            return 0
+
+        handle.seek(start)
+        machine = zlib.decompressobj()
+        carry = b""
+        produced = 0
+
+        while True:
+            chunk = handle.read(1 << 22)
+            if not chunk:
+                break
+            try:
+                out = machine.decompress(chunk)
+            except zlib.error:
+                break
+            if out:
+                produced += len(out)
+                # A name can straddle two pieces, so the tail of one is prefixed to the next.
+                harvest_retail.take(carry + out)
+                carry = out[-256:]
+            if machine.eof:
+                break
+
+    return 1 if produced else 0
+
+
+def find_zone(given):
+    if given:
+        return given
+    for path in LIKELY:
+        if os.path.isdir(path):
+            return path
+    return None
+
+
+def main(argv):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--zone", help="the build's zone folder")
+    parser.add_argument("--limit", type=int, help="only this many containers, to try it")
+    parser.add_argument("--out", default=os.path.join(_root, "borrowed", "bo3_build.txt"))
+    args = parser.parse_args(argv)
+
+    zone = find_zone(args.zone)
+    if not zone or not os.path.isdir(zone):
+        raise SystemExit(
+            "no Black Ops 3 zone folder found. Pass --zone <path>; it is the folder holding\n"
+            "the .ff and .fd files, under the Steam install."
+        )
+
+    containers = sorted(glob.glob(os.path.join(zone, "*.ff")))
+    containers += sorted(glob.glob(os.path.join(zone, "*.fd")))
+    if args.limit:
+        containers = containers[:args.limit]
+
+    print("%d container(s) in %s" % (len(containers), zone), file=sys.stderr)
+
+    read = 0
+    for index, path in enumerate(containers, 1):
+        before = len(harvest_retail.names)
+        got = walk_chain(path) or walk_stream(path)
+        if got:
+            read += 1
+        print(
+            "  [%3d/%3d] %-46s %s %+7d  (%d total)"
+            % (
+                index, len(containers), os.path.basename(path)[:46],
+                "ok" if got else "--", len(harvest_retail.names) - before,
+                len(harvest_retail.names),
+            ),
+            file=sys.stderr,
+        )
+
+    os.makedirs(os.path.dirname(args.out), exist_ok=True)
+    with open(args.out, "w", encoding="utf-8", newline="\n") as handle:
+        for name in sorted(harvest_retail.names):
+            handle.write(name + "\n")
+
+    print(
+        "read %d of %d containers; %d distinct names -> %s"
+        % (read, len(containers), len(harvest_retail.names), args.out),
+        file=sys.stderr,
+    )
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/scripts/contributed/speaker_grids_20260822-024055.py
+++ b/scripts/contributed/speaker_grids_20260822-024055.py
@@ -1,0 +1,178 @@
+"""The same voice line, spoken by every speaker the game has -- the sound grid nothing reaches.
+
+    python contrib/speaker_grids.py | bin/windows/confirm_list.exe - \
+        --label "speaker grids" --script contrib/speaker_grids.py
+
+**What problem it solves.** `scripts/reach.py` measures the sound lists against the published
+sound tables and puts `xsounds` at **10.6% `named`**: nine tenths of real Cold War sound-file
+names carry a beginning the 700-entry sound prefix list cannot express, so no general pass can
+ever build them however long it runs. The names it cannot reach are not scattered -- they are
+deep, regular voice paths, and the reach report names them itself (`vox/scripted/wolf/vox_`,
+449 names; `vox/scripted/bdzr/vox_`, 448; six more of the same shape).
+
+**Why it is not the dead end in METHODS.md.** "Recombining sound file paths, in either game, at
+any corpus density" is recorded dead -- directory x basename, 0 new of 400,000. That measurement
+transplanted a basename *verbatim* under another directory. For this family that is guaranteed
+to fail, because the leaf directory name is **also a token inside the basename**:
+
+    vox/scripted/mpl/abnd/vox_abnd_bb_ctf_start_00.rn75.pc.en.snd
+                     ^^^^      ^^^^
+
+Moving that basename under `anbo/` yields `vox/scripted/mpl/anbo/vox_abnd_...`, which is not how
+the game spells anything. The axis has to be substituted in *both* places at once. That is a
+transformation, not a transplant, and it is why the recorded negative does not cover this ground.
+
+**The structure, measured 2026-08-22** over `fnv1a_xsounds` + `fnv1a_english_xsounds` + everything
+confirmed: 69,510 `vox/scripted/` names, **62,965 of which (90.6%) match `<parent>/<key>/vox_<key>_<line>`
+exactly**. Grouping them into (parent -> speakers x lines) grids:
+
+    parent dir                     speakers   lines     cells     holes
+    vox/scripted/operators               37     753     27861      8417
+    vox/scripted/ping                    37     509     18833      4628
+    vox/scripted/zm_operators            37     389     14393      3372
+    vox/scripted                         37     258      9546       675
+    vox/scripted/mpl                     64    1738    111232    102092
+
+`operators`, `ping` and `zm_operators` are grids that are **70% filled already** -- the game
+really does record every line for every operator -- so their holes are the highest-confidence
+candidates in the pool. Six `mpl` speakers carry an inventory of *exactly* 1,098 lines apiece,
+which is what a filled row looks like.
+
+**Reads** every published sound table and every confirmed `sound_asset` name. **Writes** the
+holes: for each grid, each speaker crossed with each line the grid knows, spelled with the
+speaker token substituted in both the directory and the basename, wearing only the tails that
+line has actually been observed with. Names already known are dropped. **Writes backslashes**,
+which is the spelling Black Ops 4 hashes and which Cold War folds, so one output serves both.
+
+**Reusable.** It refills whenever a pass confirms a sound name that adds a speaker or a line to
+any grid, so it is worth re-running after any pass that gains sounds.
+"""
+import os
+import sys
+import collections
+
+# Find `scripts/` wherever this file has been filed -- `contrib/`, `scripts/`, or
+# `scripts/contributed/` after `submit` files it. Walk up rather than counting parents.
+_root = os.path.dirname(os.path.abspath(__file__))
+while _root != os.path.dirname(_root) and not os.path.isfile(
+    os.path.join(_root, "scripts", "snapshot.py")
+):
+    _root = os.path.dirname(_root)
+sys.path.insert(0, os.path.join(_root, "scripts"))
+
+import snapshot
+
+# Every sound table in cod-name-db that holds file paths for these two eras. The language tables
+# are included deliberately: a line recorded for one speaker in one language is direct evidence
+# of the same line for another speaker, and they are where most of the vox corpus lives.
+TABLES = [
+    "fnv1a_xsounds",
+    "fnv1a_english_xsounds",
+    "fnv1a_french_xsounds",
+    "fnv1a_german_xsounds",
+    "fnv1a_italian_xsounds",
+    "fnv1a_spanish_xsounds",
+    "fnv1a_americanspanish_xsounds",
+    "fnv1a_brazilianportugese_xsounds",
+    "fnv1a_russian_xsounds",
+    "fnv1a_polish_xsounds",
+    "fnv1a_japanese_xsounds",
+    "fnv1a_korean_xsounds",
+    "fnv1a_chinese_xsounds",
+]
+
+
+def known_sound_names():
+    """Every sound file name anybody here can see, folded to forward slashes and lower cased."""
+    names = set()
+
+    for name in snapshot.table_names(*TABLES):
+        names.add(name.strip().lower().replace("\\", "/"))
+    for name in snapshot.confirmed_names("sound_asset"):
+        names.add(name.strip().lower().replace("\\", "/"))
+
+    names.discard("")
+    return names
+
+
+def split(name):
+    """`a/b/key/vox_key_line.tail` -> (`a/b`, `key`, `line`, `tail`), or None if it is not one.
+
+    The requirement that the leaf directory appear as a token in the basename is the whole
+    method: it is what makes the axis substitutable, and it is what the verbatim-transplant
+    measurement recorded dead could not have used.
+    """
+    directory, _, last = name.rpartition("/")
+    if not directory or "/" not in directory:
+        return None
+
+    core, dot, tail = last.partition(".")
+    if not dot:
+        return None
+
+    parent, _, key = directory.rpartition("/")
+    if not key or not parent:
+        return None
+
+    # The line is what is left once the speaker token is taken out of the basename. Anchoring on
+    # `_<key>_` rather than a bare substring keeps `ami6` from matching inside another token.
+    marker = "_" + key + "_"
+    at = core.find(marker)
+    if at < 0:
+        return None
+
+    line = core[:at] + "_\x00_" + core[at + len(marker):]
+    return parent, key, line, tail
+
+
+def main():
+    known = known_sound_names()
+    print("%d known sound names" % len(known), file=sys.stderr)
+
+    # parent -> speakers seen, and parent -> line -> tails that line wears anywhere.
+    speakers = collections.defaultdict(set)
+    lines = collections.defaultdict(lambda: collections.defaultdict(set))
+    matched = 0
+
+    for name in known:
+        piece = split(name)
+        if piece is None:
+            continue
+        parent, key, line, tail = piece
+        matched += 1
+        speakers[parent].add(key)
+        lines[parent][line].add(tail)
+
+    print(
+        "%d names sit in a speaker grid, across %d parent directories"
+        % (matched, len(speakers)),
+        file=sys.stderr,
+    )
+
+    produced = 0
+    seen = set()
+
+    for parent in sorted(speakers):
+        who = speakers[parent]
+
+        # A grid needs at least two speakers to have an axis at all; one speaker tells us
+        # nothing about anybody else and would just re-emit what we already have.
+        if len(who) < 2:
+            continue
+
+        for line, tails in lines[parent].items():
+            for key in who:
+                core = line.replace("\x00", key)
+                for tail in tails:
+                    name = "%s/%s/%s.%s" % (parent, key, core, tail)
+                    if name in known or name in seen:
+                        continue
+                    seen.add(name)
+                    produced += 1
+                    print(name.replace("/", "\\"))
+
+    print("%d candidates" % produced, file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/submissions/GoastcraftHD_BLKOPSCW_20260822-024055/about_20260822-024055.md
+++ b/submissions/GoastcraftHD_BLKOPSCW_20260822-024055/about_20260822-024055.md
@@ -1,0 +1,21 @@
+# Submission 20260822-024055
+
+- game: **BLKOPSCW**
+- from: GoastcraftHD
+- names: 2
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: not recorded (run predates this field)
+- confirmed on: not recorded (run predates this field)
+- material: 2
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 2 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260822-024042_recovered
+- method: not recorded (an older or interrupted run)

--- a/submissions/GoastcraftHD_BLKOPSCW_20260822-024055/material_20260822-024055.txt
+++ b/submissions/GoastcraftHD_BLKOPSCW_20260822-024055/material_20260822-024055.txt
@@ -1,0 +1,2 @@
+2da85fe81a9fbaf,mc/mtl_p9_rm_pai_can_light_screw_01
+25281fd6705b6551,mc/mtl_p9_rm_pai_scoreboard_emissive_red


### PR DESCRIPTION
**BLKOPSCW** — 2 asset names, confirmed against that game's own loaded assets.

- material: 2

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @GoastcraftHD

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260822-024042_recovered
- method: not recorded (an older or interrupted run)


## Tooling this run leaves behind

- `scripts/contributed/harvest_bo3_20260822-024055.py`
- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/speaker_grids_20260822-024055.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.