### PR TITLE
[BLKOPSCW] findings from Zakkary19, 20260822-052348 (3 names)

### DIFF
--- a/submissions/Zakkary19_BLKOPSCW_20260822-052348/about_20260822-052348.md
+++ b/submissions/Zakkary19_BLKOPSCW_20260822-052348/about_20260822-052348.md
@@ -1,0 +1,31 @@
+# Submission 20260822-052348
+
+- game: **BLKOPSCW**
+- from: Zakkary19
+- names: 3
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- sound_alias: 2
+- material: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 7 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260822-052340_variants
+- method: family walking, numbers in place (variants)
+- what it does: each number or letter field of a name already known to be real counted through in place, keeping the width of what was there
+- ran for: 4m 47s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- ids hunted: 146495
+- candidates tested: 10340483443
+- new: 3
+- fingerprint: fc54c052f7d36234

--- a/submissions/Zakkary19_BLKOPSCW_20260822-052348/material_20260822-052348.txt
+++ b/submissions/Zakkary19_BLKOPSCW_20260822-052348/material_20260822-052348.txt
@@ -1,0 +1,1 @@
+4d7045bc2638d69e,t7_decal_grunge_water_puddle_128_decal_dsp

--- a/submissions/Zakkary19_BLKOPSCW_20260822-052348/sound_alias_20260822-052348.txt
+++ b/submissions/Zakkary19_BLKOPSCW_20260822-052348/sound_alias_20260822-052348.txt
@@ -1,0 +1,2 @@
+660020fd3436f31d,mus_bossfight_00_loop_0
+6b40c468a51a5f68,mus_bonusroom_00_loop_0


### PR DESCRIPTION
**BLKOPSCW** — 3 asset names, confirmed against that game's own loaded assets.

- sound_alias: 2
- material: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Zakkary19

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260822-052340_variants
- method: family walking, numbers in place (variants)
- what it does: each number or letter field of a name already known to be real counted through in place, keeping the width of what was there
- ran for: 4m 47s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- ids hunted: 146495
- candidates tested: 10340483443
- new: 3
- fingerprint: fc54c052f7d36234


## Tooling this run leaves behind

- `scripts/contributed/numbered_grids_20260821-054219.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.