### PR TITLE
[BLKOPSCW] findings from KingslayerKyle, 20260822-060618 (1 names)

### DIFF
--- a/submissions/KingslayerKyle_BLKOPSCW_20260822-060618/about_20260822-060618.md
+++ b/submissions/KingslayerKyle_BLKOPSCW_20260822-060618/about_20260822-060618.md
@@ -1,0 +1,38 @@
+# Submission 20260822-060618
+
+- game: **BLKOPSCW**
+- from: KingslayerKyle
+- names: 1
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- material: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 1 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260822-060204_plan
+- method: head of one name, tail of another
+- what it does: every name cut at each underscore into a head and a tail, then the 400,000 commonest heads crossed with the 120,000 commonest tails -- so a head wears tails that belong to other names entirely
+- ran for: 1m 44s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- beginnings: 0
+- endings: 120000
+- stems: 400000
+- ids hunted: 146832
+- candidates tested: 48000400000
+- new: 1
+- sketch beginnings: 
+- sketch stems: 000009895be2fb2600001f20f399970c0000250ce9be540f00002afb9803e5ca00004c5eb57397d6000057bfc43e03de00006de6c0b7b4d00000807ae286b10700008a4e0affb3210000b4875a0a875b0000f7e903750f9e0000fb763142905a00013c32bebe667d00014510817344eb00014cad6bcdce81000151b034ae0fe600016e9de3e48856000179a1a681813300018ea86213071d0001c4756580ca9b0001d76521cd06f50001e55a6792ecb90002007c4746e15a00020f1c177af27f000233e2616b96800002704f312ea9650002797b0cb0c0e00002947d48f2f9b50002c8a995c85e2a0002e8431c6317ed0002e9fa980b2ec800032bea761bca85
+- sketch endings: 00009f0c4c8348050000b498aeee251c00013f24e9c023120001b4dd72acd1050001bf49f7ec48d30001c12df56c9766000229682628f65c00025a3472daa8da0002d6b30c140eb90002e90a8e1715b400033efde976b4850004be5a5d6abaa70007df8e8462b9b80007ebdee4342b29000a26aa4929c79c000a9af4240446ca000aa7bc54de0394000bb13401304074000e676be6fed101000e7141ce6f612d000e99746e60cb0c000f3fed4afaa24f000f4b39796c6d2a000f8199e263a7ab00103ca407b45ca70010905053b9369a0010c782cf446e610010ed214e961c3900115a72530fe2950012f03820724db60013177929c37c760014215424ecaa9f
+- fingerprint: 955789e7c11fe86b
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/KingslayerKyle_BLKOPSCW_20260822-060618/material_20260822-060618.txt
+++ b/submissions/KingslayerKyle_BLKOPSCW_20260822-060618/material_20260822-060618.txt
@@ -1,0 +1,1 @@
+558f9ded9002075f,mc/mtl_p9_rm_zoo_fence_stable__hold


### PR DESCRIPTION
**BLKOPSCW** — 1 asset names, confirmed against that game's own loaded assets.

- material: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @KingslayerKyle

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260822-060204_plan
- method: head of one name, tail of another
- what it does: every name cut at each underscore into a head and a tail, then the 400,000 commonest heads crossed with the 120,000 commonest tails -- so a head wears tails that belong to other names entirely
- ran for: 1m 44s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- beginnings: 0
- endings: 120000
- stems: 400000
- ids hunted: 146832
- candidates tested: 48000400000
- new: 1
- sketch beginnings: 
- sketch stems: 000009895be2fb2600001f20f399970c0000250ce9be540f00002afb9803e5ca00004c5eb57397d6000057bfc43e03de00006de6c0b7b4d00000807ae286b10700008a4e0affb3210000b4875a0a875b0000f7e903750f9e0000fb763142905a00013c32bebe667d00014510817344eb00014cad6bcdce81000151b034ae0fe600016e9de3e48856000179a1a681813300018ea86213071d0001c4756580ca9b0001d76521cd06f50001e55a6792ecb90002007c4746e15a00020f1c177af27f000233e2616b96800002704f312ea9650002797b0cb0c0e00002947d48f2f9b50002c8a995c85e2a0002e8431c6317ed0002e9fa980b2ec800032bea761bca85
- sketch endings: 00009f0c4c8348050000b498aeee251c00013f24e9c023120001b4dd72acd1050001bf49f7ec48d30001c12df56c9766000229682628f65c00025a3472daa8da0002d6b30c140eb90002e90a8e1715b400033efde976b4850004be5a5d6abaa70007df8e8462b9b80007ebdee4342b29000a26aa4929c79c000a9af4240446ca000aa7bc54de0394000bb13401304074000e676be6fed101000e7141ce6f612d000e99746e60cb0c000f3fed4afaa24f000f4b39796c6d2a000f8199e263a7ab00103ca407b45ca70010905053b9369a0010c782cf446e610010ed214e961c3900115a72530fe2950012f03820724db60013177929c37c760014215424ecaa9f
- fingerprint: 955789e7c11fe86b

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/keyword_sweep_20260822-020208.py`
- `scripts/contributed/zombie_models_20260821-163108.py`
- `scripts/contributed/splice_20260822-060612.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.