### PR TITLE
[BLKOPSCW] findings from GoastcraftHD, 20260822-061937 (2 names)

### DIFF
--- a/submissions/GoastcraftHD_BLKOPSCW_20260822-061937/about_20260822-061937.md
+++ b/submissions/GoastcraftHD_BLKOPSCW_20260822-061937/about_20260822-061937.md
@@ -1,0 +1,43 @@
+# Submission 20260822-061937
+
+- game: **BLKOPSCW**
+- from: GoastcraftHD
+- names: 2
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 187
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- image: 1
+- material: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 1 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260822-050651_all
+- method: general search (confirm_cw)
+- what it does: every seed cut to pieces at its marks and recombined as beginning + stem + ending, each candidate hashed and looked up among the game's unnamed ids
+- ran for: 1h 11m 31s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- pools searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- seed lines: 6993291
+- distinct pieces: 62578726
+- beginnings: 700
+- endings: 4629
+- ids hunted: 109317
+- candidates tested: 203107390467380
+- matches: 664
+- distinct names reached: 245
+- new here: 189
+- sketch beginnings: 00d1619a1a6d2ffb011bc5777ea53602027d47769d2e7293029fce5be32a4e1503de25cbb3445ea703f88180dfe7ae6304368b6ae25b3a07045b997cbd8f138c04c8546099fd590b051c07fcae86ccdb052211a042611ba2055e1d80014ed2c4068d51da47a73058079e72201f11006807f1e3bbd3e73d71087ab3aa869f5c6b09d289302e2fce7e0aa7f530375b59100b81e93fd73a8d620bc67552b25d85fe0c04285ddee9926b0cbb3606f249820f0ce910035092d6000cf1339af0e750fc0dcbc746897133e10e51850ee6046c710e9bcfb5332201420ea6514405dd88650eb67b2f5bc94e1f0ee2eb6286d5695c0f619bbf0579699e100db404d9bc3c03
+- sketch stems: 0000003d0b47de550000008ca2a96852000000ba0c9f0dfe000000d45e0ab3780000013723f320a300000151d2bfe40a0000016a4ab426f7000001bc85c24ba9000001c029a8efd70000023b9e44d0160000024fa9031a32000002a3bce4ea7d000002b31065f0200000034514625b510000038d3139e634000004172557c4db000004259ad9a2890000046a68f5e88800000491769b2dcb000004cf8f880bd40000050c6bb98eca000005519b2d7d23000005e302aee5830000065093d2ddcb0000069733a15329000006dc1448c5e3000007200362a65700000794e135e0c0000007da7ab813430000081b8c6b3cb4000008527395fce00000086321cda087
+- sketch endings: 00013f24e9c02312000e99746e60cb0c0021ad1c1ec69307006ef56eb12e99de0079e3b242d77715009072d9a0fdb056009a7b66951c5917009c15ec9396ebe7009f2d1508ebb20700c54a81d77e708d00c85aaad3ac2ef900e6571a83b53ecb00f216ca5435be4a00f6ff637612aa210104a330f10582350109de0acab502c20113f5c1bdd185dd01209e6672fa09ae0122426a4c250c7901257c80cacd49bb0140a72543eec36d014e5a7b64d98c35017b5fae025c739d017b69b311ad8d88017e3e9d07ed17e00186a019561fbcde0190916401b2b4ca019605d7d622c68601b2b53ee592a84b01b309ae5eed3d5801b396974159901701cbfe144208d0a3
+- fingerprint: d25e95a08dd3484b
+
+**Next:** this configuration is now exhausted, and what reopens it is different ground rather than a different name. Re-measuring the lists is not the remedy this line used to recommend: measured over three consecutive folds it returned 55 names, then 294, then 51, the last on a corpus two and a half times larger. It changes the fingerprint without changing what the search can reach, and following it is most of how the yield here collapsed. Run a method that reaches somewhere else -- METHODS.md says what each one gets at that nothing else does -- or invent one: `confirm_list` takes candidate names on standard input, so a method is a script that prints names.

--- a/submissions/GoastcraftHD_BLKOPSCW_20260822-061937/image_20260822-061937.txt
+++ b/submissions/GoastcraftHD_BLKOPSCW_20260822-061937/image_20260822-061937.txt
@@ -1,0 +1,1 @@
+6d3642370cf8b75a,i_fire_flames_med_02

--- a/submissions/GoastcraftHD_BLKOPSCW_20260822-061937/material_20260822-061937.txt
+++ b/submissions/GoastcraftHD_BLKOPSCW_20260822-061937/material_20260822-061937.txt
@@ -1,0 +1,1 @@
+3a974e0817e7ea14,mc/mtl_wpn_t9_zm_ballistic_knife_babayaga


### PR DESCRIPTION
**BLKOPSCW** — 2 asset names, confirmed against that game's own loaded assets.

- image: 1
- material: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 187
- submitted by: @GoastcraftHD

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260822-050651_all
- method: general search (confirm_cw)
- what it does: every seed cut to pieces at its marks and recombined as beginning + stem + ending, each candidate hashed and looked up among the game's unnamed ids
- ran for: 1h 11m 31s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- pools searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
- seed lines: 6993291
- distinct pieces: 62578726
- beginnings: 700
- endings: 4629
- ids hunted: 109317
- candidates tested: 203107390467380
- matches: 664
- distinct names reached: 245
- new here: 189
- sketch beginnings: 00d1619a1a6d2ffb011bc5777ea53602027d47769d2e7293029fce5be32a4e1503de25cbb3445ea703f88180dfe7ae6304368b6ae25b3a07045b997cbd8f138c04c8546099fd590b051c07fcae86ccdb052211a042611ba2055e1d80014ed2c4068d51da47a73058079e72201f11006807f1e3bbd3e73d71087ab3aa869f5c6b09d289302e2fce7e0aa7f530375b59100b81e93fd73a8d620bc67552b25d85fe0c04285ddee9926b0cbb3606f249820f0ce910035092d6000cf1339af0e750fc0dcbc746897133e10e51850ee6046c710e9bcfb5332201420ea6514405dd88650eb67b2f5bc94e1f0ee2eb6286d5695c0f619bbf0579699e100db404d9bc3c03
- sketch stems: 0000003d0b47de550000008ca2a96852000000ba0c9f0dfe000000d45e0ab3780000013723f320a300000151d2bfe40a0000016a4ab426f7000001bc85c24ba9000001c029a8efd70000023b9e44d0160000024fa9031a32000002a3bce4ea7d000002b31065f0200000034514625b510000038d3139e634000004172557c4db000004259ad9a2890000046a68f5e88800000491769b2dcb000004cf8f880bd40000050c6bb98eca000005519b2d7d23000005e302aee5830000065093d2ddcb0000069733a15329000006dc1448c5e3000007200362a65700000794e135e0c0000007da7ab813430000081b8c6b3cb4000008527395fce00000086321cda087
- sketch endings: 00013f24e9c02312000e99746e60cb0c0021ad1c1ec69307006ef56eb12e99de0079e3b242d77715009072d9a0fdb056009a7b66951c5917009c15ec9396ebe7009f2d1508ebb20700c54a81d77e708d00c85aaad3ac2ef900e6571a83b53ecb00f216ca5435be4a00f6ff637612aa210104a330f10582350109de0acab502c20113f5c1bdd185dd01209e6672fa09ae0122426a4c250c7901257c80cacd49bb0140a72543eec36d014e5a7b64d98c35017b5fae025c739d017b69b311ad8d88017e3e9d07ed17e00186a019561fbcde0190916401b2b4ca019605d7d622c68601b2b53ee592a84b01b309ae5eed3d5801b396974159901701cbfe144208d0a3
- fingerprint: d25e95a08dd3484b

**Next:** this configuration is now exhausted, and what reopens it is different ground rather than a different name. Re-measuring the lists is not the remedy this line used to recommend: measured over three consecutive folds it returned 55 names, then 294, then 51, the last on a corpus two and a half times larger. It changes the fingerprint without changing what the search can reach, and following it is most of how the yield here collapsed. Run a method that reaches somewhere else -- METHODS.md says what each one gets at that nothing else does -- or invent one: `confirm_list` takes candidate names on standard input, so a method is a script that prints names.


## Tooling this run leaves behind

- `scripts/contributed/bo3_cores_20260822-025123.py`
- `scripts/contributed/bo3_respell_20260822-024314.py`
- `scripts/contributed/harvest_bo3_20260822-030351.py`
- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/speaker_grids_20260822-021342.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.