### PR TITLE
[BLKOPS04] findings from KingslayerKyle, 20260822-123438 (1 names)

### DIFF
--- a/submissions/KingslayerKyle_BLKOPS04_20260822-123438/about_20260822-123438.md
+++ b/submissions/KingslayerKyle_BLKOPS04_20260822-123438/about_20260822-123438.md
@@ -1,0 +1,21 @@
+# Submission 20260822-123438
+
+- game: **BLKOPS04**
+- from: KingslayerKyle
+- names: 1
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 30
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: not recorded (run predates this field)
+- confirmed on: not recorded (run predates this field)
+- material: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 3 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260822-123425_recovered
+- method: not recorded (an older or interrupted run)

--- a/submissions/KingslayerKyle_BLKOPS04_20260822-123438/material_20260822-123438.txt
+++ b/submissions/KingslayerKyle_BLKOPS04_20260822-123438/material_20260822-123438.txt
@@ -1,0 +1,1 @@
+4607e24560b3bdeb,ei/gfx8_elec_arc_rand_center_em_gp_i20


### PR DESCRIPTION
**BLKOPS04** — 1 asset names, confirmed against that game's own loaded assets.

- material: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 30
- submitted by: @KingslayerKyle

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260822-123425_recovered
- method: not recorded (an older or interrupted run)


## Tooling this run leaves behind

- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/keyword_sweep_20260822-020208.py`
- `scripts/contributed/zombie_models_20260821-163108.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.