### PR TITLE
[BLKOPS04] findings from KingslayerKyle, 20260822-125540 (6 names)

### DIFF
--- a/submissions/KingslayerKyle_BLKOPS04_20260822-125540/about_20260822-125540.md
+++ b/submissions/KingslayerKyle_BLKOPS04_20260822-125540/about_20260822-125540.md
@@ -1,0 +1,22 @@
+# Submission 20260822-125540
+
+- game: **BLKOPS04**
+- from: KingslayerKyle
+- names: 6
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 4
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: not recorded (run predates this field)
+- confirmed on: not recorded (run predates this field)
+- material: 3
+- xmodel: 3
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 0 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260822-125533_recovered
+- method: not recorded (an older or interrupted run)

--- a/submissions/KingslayerKyle_BLKOPS04_20260822-125540/material_20260822-125540.txt
+++ b/submissions/KingslayerKyle_BLKOPS04_20260822-125540/material_20260822-125540.txt
@@ -1,0 +1,3 @@
+1f18df46d9c1583d,mc/mtl_veh_t8_civ_truck_pickup_interior_engine_plastic_clean
+1fdef402280dc517,mc/mtl_t8_mil_vtol_dropship_skids_mtl_mp_camo
+7f561c0af350e1a6,mc/mtl_veh_t8_civ_truck_pickup_interior_seat_plastic_clean

--- a/submissions/KingslayerKyle_BLKOPS04_20260822-125540/xmodel_20260822-125540.txt
+++ b/submissions/KingslayerKyle_BLKOPS04_20260822-125540/xmodel_20260822-125540.txt
@@ -1,0 +1,3 @@
+1cd7fc7b059383c9,p8_fxp_debris_rock_02_no_lod
+3e51a8b11848607a,p8_fxp_debris_rock_01_no_lod
+5bba881a5f551e90,p8_fxp_debris_rock_03_no_lod


### PR DESCRIPTION
**BLKOPS04** — 6 asset names, confirmed against that game's own loaded assets.

- material: 3
- xmodel: 3

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 4
- submitted by: @KingslayerKyle

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260822-125533_recovered
- method: not recorded (an older or interrupted run)


## Tooling this run leaves behind

- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/keyword_sweep_20260822-020208.py`
- `scripts/contributed/zombie_models_20260821-163108.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.