### PR TITLE
[BLKOPS04] findings from KingslayerKyle, 20260822-132415 (1 names)

### DIFF
--- a/submissions/KingslayerKyle_BLKOPS04_20260822-132415/about_20260822-132415.md
+++ b/submissions/KingslayerKyle_BLKOPS04_20260822-132415/about_20260822-132415.md
@@ -1,0 +1,38 @@
+# Submission 20260822-132415
+
+- game: **BLKOPS04**
+- from: KingslayerKyle
+- names: 1
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 439
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- xmodel: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 2 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260822-115525_plan
+- method: tails of length 5
+- what it does: every known name cut short by 5 character(s), against every 5-character ending over the 24 characters names are measured to end in
+- ran for: 1h 28m 48s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- beginnings: 0
+- endings: 7962624
+- stems: 588691
+- ids hunted: 187334
+- candidates tested: 4687525673875
+- new: 440
+- sketch beginnings: 
+- sketch stems: 00000da892f7d7c100008a4e0affb321000097d17d4ea26c0000b9a20339b21f0000c49feab669610000f6020c7b2c42000145d3bb88cad100015b2c9392a4e900015e56f601e257000162a212aa6a59000179a1a6818133000181de7999d5fc000189963febc5170001a12ca623f7480001bc2bbce2a8580001c4756580ca9b0001e55a6792ecb90001ef6bdb3ac0c4000220cb02dafba5000255113786343100029cdfd81f8f0c0002b62b3ef7b65f0002c0fab6bbf2290002d16b35a3d8930002e5509e440dbe0002e8431c6317ed00031adfc7482e60000324af7e2e3e8e000357569aef074c0003a24f5f38d5190003e940d2e51deb0003f0e60decca83
+- sketch endings: 0000027dca1f913b000003ba51dfd41c00000566c1cfaead00000633ef522e9d0000074b212555d2000008450d4ef0450000098570cd576800000adf859af91a00000c381555cda400000c3c580d9dbc00000d5ec730d80f00000f9af100a0f0000013e6be315bf90000196ec851c28400001a52b1f48e5400001abda70f04b200001b53172b9dc400001b9090b4ffb600001bad8e5d221b00001c73314507fa00001df42352473a00001e839bca819d00001ec9136fb02d000020cb7cea7c020000247bd4af0ab100002646cc1a404b00002696cbb08374000028a3c5ec636d00002b51e3a5925400002c049b8b35e1000030e390bd4cd700003200175322bd
+- fingerprint: e054314f09fdea8c
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/KingslayerKyle_BLKOPS04_20260822-132415/xmodel_20260822-132415.txt
+++ b/submissions/KingslayerKyle_BLKOPS04_20260822-132415/xmodel_20260822-132415.txt
@@ -1,0 +1,1 @@
+4ea0847df7b82f57,p8_chi_heat_sink_single_02


### PR DESCRIPTION
**BLKOPS04** — 1 asset names, confirmed against that game's own loaded assets.

- xmodel: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 439
- submitted by: @KingslayerKyle

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260822-115525_plan
- method: tails of length 5
- what it does: every known name cut short by 5 character(s), against every 5-character ending over the 24 characters names are measured to end in
- ran for: 1h 28m 48s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- beginnings: 0
- endings: 7962624
- stems: 588691
- ids hunted: 187334
- candidates tested: 4687525673875
- new: 440
- sketch beginnings: 
- sketch stems: 00000da892f7d7c100008a4e0affb321000097d17d4ea26c0000b9a20339b21f0000c49feab669610000f6020c7b2c42000145d3bb88cad100015b2c9392a4e900015e56f601e257000162a212aa6a59000179a1a6818133000181de7999d5fc000189963febc5170001a12ca623f7480001bc2bbce2a8580001c4756580ca9b0001e55a6792ecb90001ef6bdb3ac0c4000220cb02dafba5000255113786343100029cdfd81f8f0c0002b62b3ef7b65f0002c0fab6bbf2290002d16b35a3d8930002e5509e440dbe0002e8431c6317ed00031adfc7482e60000324af7e2e3e8e000357569aef074c0003a24f5f38d5190003e940d2e51deb0003f0e60decca83
- sketch endings: 0000027dca1f913b000003ba51dfd41c00000566c1cfaead00000633ef522e9d0000074b212555d2000008450d4ef0450000098570cd576800000adf859af91a00000c381555cda400000c3c580d9dbc00000d5ec730d80f00000f9af100a0f0000013e6be315bf90000196ec851c28400001a52b1f48e5400001abda70f04b200001b53172b9dc400001b9090b4ffb600001bad8e5d221b00001c73314507fa00001df42352473a00001e839bca819d00001ec9136fb02d000020cb7cea7c020000247bd4af0ab100002646cc1a404b00002696cbb08374000028a3c5ec636d00002b51e3a5925400002c049b8b35e1000030e390bd4cd700003200175322bd
- fingerprint: e054314f09fdea8c

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/keyword_sweep_20260822-020208.py`
- `scripts/contributed/zombie_models_20260821-163108.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.