### PR TITLE
[BLKOPSCW] findings from Zakkary19, 20260822-163756 (2 names)

### DIFF
--- a/submissions/Zakkary19_BLKOPSCW_20260822-163756/about_20260822-163756.md
+++ b/submissions/Zakkary19_BLKOPSCW_20260822-163756/about_20260822-163756.md
@@ -1,0 +1,30 @@
+# Submission 20260822-163756
+
+- game: **BLKOPSCW**
+- from: Zakkary19
+- names: 2
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- material: 2
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 7 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260822-163749_variants
+- method: family walking, numbers in place (variants)
+- what it does: each number or letter field of a name already known to be real counted through in place, keeping the width of what was there
+- ran for: 4m 46s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- ids hunted: 144925
+- candidates tested: 10340508089
+- new: 2
+- fingerprint: 160b39e66315918c

--- a/submissions/Zakkary19_BLKOPSCW_20260822-163756/material_20260822-163756.txt
+++ b/submissions/Zakkary19_BLKOPSCW_20260822-163756/material_20260822-163756.txt
@@ -1,0 +1,2 @@
+12424f4714a05db,mc/t7_decal_grunge_water_puddle_256_blend
+3bdc9bd05ff36101,wc/t7_decal_grunge_water_puddle_256_blend


### PR DESCRIPTION
**BLKOPSCW** — 2 asset names, confirmed against that game's own loaded assets.

- material: 2

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Zakkary19

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260822-163749_variants
- method: family walking, numbers in place (variants)
- what it does: each number or letter field of a name already known to be real counted through in place, keeping the width of what was there
- ran for: 4m 46s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- ids hunted: 144925
- candidates tested: 10340508089
- new: 2
- fingerprint: 160b39e66315918c


## Tooling this run leaves behind

- `scripts/contributed/numbered_grids_20260821-054219.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.