### PR TITLE
[BLKOPS04] findings from Zakkary19, 20260822-212456 (1 names)

### DIFF
--- a/submissions/Zakkary19_BLKOPS04_20260822-212456/about_20260822-212456.md
+++ b/submissions/Zakkary19_BLKOPS04_20260822-212456/about_20260822-212456.md
@@ -1,0 +1,32 @@
+# Submission 20260822-212456
+
+- game: **BLKOPS04**
+- from: Zakkary19
+- names: 1
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- material: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 1 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260822-212448_variants
+- method: family walking, numbers in place (variants)
+- what it does: each number or letter field of a name already known to be real counted through in place, keeping the width of what was there
+- ran for: 4m 58s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- ids hunted: 184619
+- candidates tested: 10387893818
+- new: 1
+- sketch stems: 0000003d0b47de55000004172557c4db000009ac7953308b000010fbc36d8f27000012af82f269c40000193e87ceefbc00001aa719502d7c00001e1cccd31eec00001f7cf71e4848000023c08dc4a124000027948203cd2f00002c7c8411c63b00002e8caedc668d000032b4dbfef915000033689cd693f5000033f4eab88546000034bcb64c23ae00003d7c0bcf6daa00003e3feaf74564000046d733dba53c000052eddb08e5db0000611a79b9159500006af15f2fba32000072ae09156ad400007461f8a07236000078bb58212d4d00007965d060178a000082778bc1f3c70000836bd73172550000837c07d21d7b00008bab2a98a97c00008e8f3851f106
+- sketch endings: 
+- fingerprint: a9be68f4680a9d19

--- a/submissions/Zakkary19_BLKOPS04_20260822-212456/material_20260822-212456.txt
+++ b/submissions/Zakkary19_BLKOPS04_20260822-212456/material_20260822-212456.txt
@@ -1,0 +1,1 @@
+4d9f2eba9e0835d9,vd/t7_decal_grunge_water_puddle_256_blend


### PR DESCRIPTION
**BLKOPS04** — 1 asset names, confirmed against that game's own loaded assets.

- material: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Zakkary19

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260822-212448_variants
- method: family walking, numbers in place (variants)
- what it does: each number or letter field of a name already known to be real counted through in place, keeping the width of what was there
- ran for: 4m 58s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- ids hunted: 184619
- candidates tested: 10387893818
- new: 1
- sketch stems: 0000003d0b47de55000004172557c4db000009ac7953308b000010fbc36d8f27000012af82f269c40000193e87ceefbc00001aa719502d7c00001e1cccd31eec00001f7cf71e4848000023c08dc4a124000027948203cd2f00002c7c8411c63b00002e8caedc668d000032b4dbfef915000033689cd693f5000033f4eab88546000034bcb64c23ae00003d7c0bcf6daa00003e3feaf74564000046d733dba53c000052eddb08e5db0000611a79b9159500006af15f2fba32000072ae09156ad400007461f8a07236000078bb58212d4d00007965d060178a000082778bc1f3c70000836bd73172550000837c07d21d7b00008bab2a98a97c00008e8f3851f106
- sketch endings: 
- fingerprint: a9be68f4680a9d19


## Tooling this run leaves behind

- `scripts/contributed/numbered_grids_20260821-054219.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.