### PR TITLE
[BLKOPSCW] findings from BrandonT01, 20260823-030221 (3 names)

### DIFF
--- a/submissions/BrandonT01_BLKOPSCW_20260823-030221/about_20260823-030221.md
+++ b/submissions/BrandonT01_BLKOPSCW_20260823-030221/about_20260823-030221.md
@@ -1,0 +1,38 @@
+# Submission 20260823-030221
+
+- game: **BLKOPSCW**
+- from: BrandonT01
+- names: 3
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- image: 3
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 12 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260823-025719_plan
+- method: uncarried beginnings
+- what it does: the 321 leading segments no cut of which `data/prefixes.txt` carries, against cores from the published names that use them and from everything this machine has confirmed
+- ran for: 4m 41s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- beginnings: 321
+- endings: 4629
+- stems: 149219
+- ids hunted: 141482
+- candidates tested: 221773754370
+- new: 3
+- sketch beginnings: 0084b979595f86df00ac8133506d429c019b13085548754801f06f475d5e01cd022e34e844929260023406f88536a8de0661fb30aa41db0806b447482b9b5c4c077e5a5892a3a555093d63aa30ac6a890a7df80f944ea2dc0a8a3ee3821a9c200c6e148aebdba61010305f4ce6a3acb710ae443e5c2e4f6910ba4644e2f2362210e46cfccf95307513a71ef39f0565921458682ce02b007b1468bd47616673c616f376f22c888dd617afaf989a8f88dd1a57d5c3f28f26fc1b422267e8c11d6a1e6081a8b7d556401ea834b7fb05f7bb1f40f1f82eb340342015f21d86f2366b20bb4254738dbfd521226e9452a89e1b213e56e5c91f648921d7a5f19fded146
+- sketch stems: 000063a33732586900006dcf42216389000237540b6e3f930002911d10cffd91000310ff73e68ee600035a6d588aa75600035ede9efa5e900003f6860e09096b00041a795924b8050004580ec440bc3700045dbd500476f70004ba2cf231767300053721e203b70500069d83370d16da0007062ac4634403000787492ee03c490007b8194b955b970008672ecbe2454e000881f91cb06af30008fbb8f33ee9d600093b33cbd771cf000989a03fbea75e0009fa61ad751196000a02de21dd0e7f000a3e0cc6464e33000a5d1374f8322b000a8487d86b5c78000ac5c63aaefac7000b02324c57d11e000b5bb05ee1d476000c048aea71e323000ca38e76cd7b33
+- sketch endings: 00013f24e9c02312000e99746e60cb0c0021ad1c1ec69307006ef56eb12e99de0079e3b242d77715009072d9a0fdb056009a7b66951c5917009c15ec9396ebe7009f2d1508ebb20700c54a81d77e708d00c85aaad3ac2ef900e6571a83b53ecb00f216ca5435be4a00f6ff637612aa210104a330f10582350109de0acab502c20113f5c1bdd185dd01209e6672fa09ae0122426a4c250c7901257c80cacd49bb0140a72543eec36d014e5a7b64d98c35017b5fae025c739d017b69b311ad8d88017e3e9d07ed17e00186a019561fbcde0190916401b2b4ca019605d7d622c68601b2b53ee592a84b01b309ae5eed3d5801b396974159901701cbfe144208d0a3
+- fingerprint: 796719f6d7375928
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/BrandonT01_BLKOPSCW_20260823-030221/image_20260823-030221.txt
+++ b/submissions/BrandonT01_BLKOPSCW_20260823-030221/image_20260823-030221.txt
@@ -1,0 +1,3 @@
+3497a555e89df15a,microsoft_stick_turn
+387b437af1f617f2,$black_diffuse_hdr
+742b29a826d8899a,microsoft_stick_move_look


### PR DESCRIPTION
**BLKOPSCW** — 3 asset names, confirmed against that game's own loaded assets.

- image: 3

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @BrandonT01

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260823-025719_plan
- method: uncarried beginnings
- what it does: the 321 leading segments no cut of which `data/prefixes.txt` carries, against cores from the published names that use them and from everything this machine has confirmed
- ran for: 4m 41s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- beginnings: 321
- endings: 4629
- stems: 149219
- ids hunted: 141482
- candidates tested: 221773754370
- new: 3
- sketch beginnings: 0084b979595f86df00ac8133506d429c019b13085548754801f06f475d5e01cd022e34e844929260023406f88536a8de0661fb30aa41db0806b447482b9b5c4c077e5a5892a3a555093d63aa30ac6a890a7df80f944ea2dc0a8a3ee3821a9c200c6e148aebdba61010305f4ce6a3acb710ae443e5c2e4f6910ba4644e2f2362210e46cfccf95307513a71ef39f0565921458682ce02b007b1468bd47616673c616f376f22c888dd617afaf989a8f88dd1a57d5c3f28f26fc1b422267e8c11d6a1e6081a8b7d556401ea834b7fb05f7bb1f40f1f82eb340342015f21d86f2366b20bb4254738dbfd521226e9452a89e1b213e56e5c91f648921d7a5f19fded146
- sketch stems: 000063a33732586900006dcf42216389000237540b6e3f930002911d10cffd91000310ff73e68ee600035a6d588aa75600035ede9efa5e900003f6860e09096b00041a795924b8050004580ec440bc3700045dbd500476f70004ba2cf231767300053721e203b70500069d83370d16da0007062ac4634403000787492ee03c490007b8194b955b970008672ecbe2454e000881f91cb06af30008fbb8f33ee9d600093b33cbd771cf000989a03fbea75e0009fa61ad751196000a02de21dd0e7f000a3e0cc6464e33000a5d1374f8322b000a8487d86b5c78000ac5c63aaefac7000b02324c57d11e000b5bb05ee1d476000c048aea71e323000ca38e76cd7b33
- sketch endings: 00013f24e9c02312000e99746e60cb0c0021ad1c1ec69307006ef56eb12e99de0079e3b242d77715009072d9a0fdb056009a7b66951c5917009c15ec9396ebe7009f2d1508ebb20700c54a81d77e708d00c85aaad3ac2ef900e6571a83b53ecb00f216ca5435be4a00f6ff637612aa210104a330f10582350109de0acab502c20113f5c1bdd185dd01209e6672fa09ae0122426a4c250c7901257c80cacd49bb0140a72543eec36d014e5a7b64d98c35017b5fae025c739d017b69b311ad8d88017e3e9d07ed17e00186a019561fbcde0190916401b2b4ca019605d7d622c68601b2b53ee592a84b01b309ae5eed3d5801b396974159901701cbfe144208d0a3
- fingerprint: 796719f6d7375928

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.
