### PR TITLE
[BLKOPSCW] findings from BrandonT01, 20260823-031957 (5 names)

### DIFF
--- a/submissions/BrandonT01_BLKOPSCW_20260823-031957/about_20260823-031957.md
+++ b/submissions/BrandonT01_BLKOPSCW_20260823-031957/about_20260823-031957.md
@@ -1,0 +1,39 @@
+# Submission 20260823-031957
+
+- game: **BLKOPSCW**
+- from: BrandonT01
+- names: 5
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- image: 3
+- material: 2
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 19 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260823-031659_plan
+- method: uncarried endings ranks 60001-120000 over published cores
+- what it does: a disjoint rank band of real endings the committed suffix list cannot express
+- ran for: 2m 17s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- beginnings: 0
+- endings: 60000
+- stems: 798733
+- ids hunted: 141342
+- candidates tested: 47924778733
+- new: 5
+- sketch beginnings: 
+- sketch stems: 000006e18d650fb900000ab4ba1aeee400000feaf9e727be000012c311da10ff00003b9f496e1f3100004e56e3fbb0ec000054e2e1aff6700000595d5e43b51e000062e7cbfd19140000673d5ec1845600006c06f14346560000953fd0beca160000b9a20339b21f0000bb7c449703510000bdf5ddb3c7270000c951a42bde610000dff33e0893840000ef4a2113a6a70000f0d2d965b07e00010febc6787b7c00012a876c73b4c1000143bad25e351f0001515250ad506c000153bf44a30feb0001882917eb440a0001a7ca8c87ec650001e38328758b280001f508b316f7550001fdf14af0e8cf0002006e1d7163400002218fe7128f6d000256f065b5d356
+- sketch endings: 0000529b80a633f200009f9cc2c74c800000c758cb1bbbed000537a26427bb76000549dfe34f77e000058cb7b8c069a400070f3e249ec3bc0008935e985c4a78000b2cdb3ba9c339000b7d5ee4e019ac000e2c2ee4def5af00137f0079c504890015c8111a06a6f40016742005dc6b4b00196c8bf87a33cd00198bb2627eb256001aa28d4d1ee557001cf032890900c0001d8a58214e2628001dee351923afda001df2d56162935f001e82c892af709f001fad8c9380c2ab0020287f6445344d00227759a2201fe600234c44a37d0ee50024ce5ab3a70cf000253156e593fa5c0026dd5da6f8b41c0027fcfcb7b139f000281239de6d6ada0028af57b3ed6ba8
+- fingerprint: 6fd6ae1b88354df6
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/BrandonT01_BLKOPSCW_20260823-031957/image_20260823-031957.txt
+++ b/submissions/BrandonT01_BLKOPSCW_20260823-031957/image_20260823-031957.txt
@@ -1,0 +1,3 @@
+2cf8059974ca33cd,reticle_pineapplegun_notches
+40f92cf4352d1bbd,uie_ui_hud_reticle_ieu_centerdot
+6616e5e39e9694ae,uie_ui_hud_core_compass_widget_hash

--- a/submissions/BrandonT01_BLKOPSCW_20260823-031957/material_20260823-031957.txt
+++ b/submissions/BrandonT01_BLKOPSCW_20260823-031957/material_20260823-031957.txt
@@ -1,0 +1,2 @@
+1f748aaac19e35c9,mc/mtl_p9_foliage_tree_spruce_norway_needle_02_trample
+29af204cad584546,mc/mtl_p9_foliage_tree_spruce_norway_needle_03_trample


### PR DESCRIPTION
**BLKOPSCW** — 5 asset names, confirmed against that game's own loaded assets.

- image: 3
- material: 2

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @BrandonT01

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260823-031659_plan
- method: uncarried endings ranks 60001-120000 over published cores
- what it does: a disjoint rank band of real endings the committed suffix list cannot express
- ran for: 2m 17s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- beginnings: 0
- endings: 60000
- stems: 798733
- ids hunted: 141342
- candidates tested: 47924778733
- new: 5
- sketch beginnings: 
- sketch stems: 000006e18d650fb900000ab4ba1aeee400000feaf9e727be000012c311da10ff00003b9f496e1f3100004e56e3fbb0ec000054e2e1aff6700000595d5e43b51e000062e7cbfd19140000673d5ec1845600006c06f14346560000953fd0beca160000b9a20339b21f0000bb7c449703510000bdf5ddb3c7270000c951a42bde610000dff33e0893840000ef4a2113a6a70000f0d2d965b07e00010febc6787b7c00012a876c73b4c1000143bad25e351f0001515250ad506c000153bf44a30feb0001882917eb440a0001a7ca8c87ec650001e38328758b280001f508b316f7550001fdf14af0e8cf0002006e1d7163400002218fe7128f6d000256f065b5d356
- sketch endings: 0000529b80a633f200009f9cc2c74c800000c758cb1bbbed000537a26427bb76000549dfe34f77e000058cb7b8c069a400070f3e249ec3bc0008935e985c4a78000b2cdb3ba9c339000b7d5ee4e019ac000e2c2ee4def5af00137f0079c504890015c8111a06a6f40016742005dc6b4b00196c8bf87a33cd00198bb2627eb256001aa28d4d1ee557001cf032890900c0001d8a58214e2628001dee351923afda001df2d56162935f001e82c892af709f001fad8c9380c2ab0020287f6445344d00227759a2201fe600234c44a37d0ee50024ce5ab3a70cf000253156e593fa5c0026dd5da6f8b41c0027fcfcb7b139f000281239de6d6ada0028af57b3ed6ba8
- fingerprint: 6fd6ae1b88354df6

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/uncarried_endings_ranges_20260823-031639.py`
- `scripts/contributed/uncarried_ends_20260823-031639.txt`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.