### PR TITLE
[BLKOPSCW] findings from Zakkary19, 20260823-034710 (1 names)

### DIFF
--- a/submissions/Zakkary19_BLKOPSCW_20260823-034710/about_20260823-034710.md
+++ b/submissions/Zakkary19_BLKOPSCW_20260823-034710/about_20260823-034710.md
@@ -1,0 +1,42 @@
+# Submission 20260823-034710
+
+- game: **BLKOPSCW**
+- from: Zakkary19
+- names: 1
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 2914
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- material: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 33 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260823-023424_all
+- method: general search (confirm_cw)
+- what it does: every seed cut to pieces at its marks and recombined as beginning + stem + ending, each candidate hashed and looked up among the game's unnamed ids
+- ran for: 1h 11m 33s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- pools searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- seed lines: 3295984
+- distinct pieces: 31439102
+- beginnings: 700
+- endings: 4638
+- ids hunted: 107595
+- candidates tested: 102238041918778
+- matches: 15345
+- distinct names reached: 2945
+- new here: 2915
+- sketch beginnings: 00d1619a1a6d2ffb011bc5777ea53602027d47769d2e7293029fce5be32a4e1503de25cbb3445ea703f88180dfe7ae6304368b6ae25b3a0704551b318775f711045b997cbd8f138c04c8546099fd590b051c07fcae86ccdb052211a042611ba2055e1d80014ed2c4079e72201f11006807f1e3bbd3e73d71087ab3aa869f5c6b09d289302e2fce7e0aa7f530375b59100b81e93fd73a8d620bc67552b25d85fe0c04285ddee9926b0cbb3606f249820f0ce910035092d6000cf1339af0e750fc0dcbc746897133e10e51850ee6046c710e9bcfb5332201420ea6514405dd88650eb67b2f5bc94e1f0ee2eb6286d5695c0f619bbf0579699e100db404d9bc3c03
+- sketch stems: 0000003d0b47de55000000d45e0ab3780000013723f320a30000016a4ab426f7000001bc85c24ba9000001c029a8efd70000024fa9031a32000002a3bce4ea7d0000034514625b510000038d3139e634000004259ad9a28900000491769b2dcb000004cf8f880bd40000069733a15329000007da7ab81343000008527395fce00000095ca492a028000009ac7953308b00000ab4ba1aeee400000ac9194dd2c300000b61d1f9c0d000000bf2fcc0175f00000c117bc1e74e00000c3f4f949a9e00000c5e26ddd31500000c76c90665c700000cb0e2df3f6900000d2f6c89fd3100000d4a310a34d800000d70dcf0d5eb00000dd14f3c6f1a00000e057fa6ef7c
+- sketch endings: 00013f24e9c02312000e99746e60cb0c0021ad1c1ec69307006ef56eb12e99de0079e3b242d77715008388613f891ff3009072d9a0fdb056009a7b66951c5917009c15ec9396ebe7009f2d1508ebb20700c54a81d77e708d00c85aaad3ac2ef900e6571a83b53ecb00f216ca5435be4a00f6ff637612aa210104a330f10582350109de0acab502c20113f5c1bdd185dd01209e6672fa09ae0122426a4c250c7901257c80cacd49bb0140a72543eec36d014e5a7b64d98c35017b5fae025c739d017b69b311ad8d88017e3e9d07ed17e00186a019561fbcde0190916401b2b4ca019605d7d622c68601b2b53ee592a84b01b309ae5eed3d5801b3969741599017
+- fingerprint: 1916db2667c98704
+
+**Next:** this configuration is now exhausted, and what reopens it is different ground rather than a different name. Re-measuring the lists is not the remedy this line used to recommend: measured over three consecutive folds it returned 55 names, then 294, then 51, the last on a corpus two and a half times larger. It changes the fingerprint without changing what the search can reach, and following it is most of how the yield here collapsed. Run a method that reaches somewhere else -- METHODS.md says what each one gets at that nothing else does -- or invent one: `confirm_list` takes candidate names on standard input, so a method is a script that prints names.

--- a/submissions/Zakkary19_BLKOPSCW_20260823-034710/material_20260823-034710.txt
+++ b/submissions/Zakkary19_BLKOPSCW_20260823-034710/material_20260823-034710.txt
@@ -1,0 +1,1 @@
+3927478a39548326,mc/mtl_p9_ech_solar_array_01_decal_dirt_02_wet


### PR DESCRIPTION
**BLKOPSCW** — 1 asset names, confirmed against that game's own loaded assets.

- material: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 2914
- submitted by: @Zakkary19

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260823-023424_all
- method: general search (confirm_cw)
- what it does: every seed cut to pieces at its marks and recombined as beginning + stem + ending, each candidate hashed and looked up among the game's unnamed ids
- ran for: 1h 11m 33s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- pools searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
- seed lines: 3295984
- distinct pieces: 31439102
- beginnings: 700
- endings: 4638
- ids hunted: 107595
- candidates tested: 102238041918778
- matches: 15345
- distinct names reached: 2945
- new here: 2915
- sketch beginnings: 00d1619a1a6d2ffb011bc5777ea53602027d47769d2e7293029fce5be32a4e1503de25cbb3445ea703f88180dfe7ae6304368b6ae25b3a0704551b318775f711045b997cbd8f138c04c8546099fd590b051c07fcae86ccdb052211a042611ba2055e1d80014ed2c4079e72201f11006807f1e3bbd3e73d71087ab3aa869f5c6b09d289302e2fce7e0aa7f530375b59100b81e93fd73a8d620bc67552b25d85fe0c04285ddee9926b0cbb3606f249820f0ce910035092d6000cf1339af0e750fc0dcbc746897133e10e51850ee6046c710e9bcfb5332201420ea6514405dd88650eb67b2f5bc94e1f0ee2eb6286d5695c0f619bbf0579699e100db404d9bc3c03
- sketch stems: 0000003d0b47de55000000d45e0ab3780000013723f320a30000016a4ab426f7000001bc85c24ba9000001c029a8efd70000024fa9031a32000002a3bce4ea7d0000034514625b510000038d3139e634000004259ad9a28900000491769b2dcb000004cf8f880bd40000069733a15329000007da7ab81343000008527395fce00000095ca492a028000009ac7953308b00000ab4ba1aeee400000ac9194dd2c300000b61d1f9c0d000000bf2fcc0175f00000c117bc1e74e00000c3f4f949a9e00000c5e26ddd31500000c76c90665c700000cb0e2df3f6900000d2f6c89fd3100000d4a310a34d800000d70dcf0d5eb00000dd14f3c6f1a00000e057fa6ef7c
- sketch endings: 00013f24e9c02312000e99746e60cb0c0021ad1c1ec69307006ef56eb12e99de0079e3b242d77715008388613f891ff3009072d9a0fdb056009a7b66951c5917009c15ec9396ebe7009f2d1508ebb20700c54a81d77e708d00c85aaad3ac2ef900e6571a83b53ecb00f216ca5435be4a00f6ff637612aa210104a330f10582350109de0acab502c20113f5c1bdd185dd01209e6672fa09ae0122426a4c250c7901257c80cacd49bb0140a72543eec36d014e5a7b64d98c35017b5fae025c739d017b69b311ad8d88017e3e9d07ed17e00186a019561fbcde0190916401b2b4ca019605d7d622c68601b2b53ee592a84b01b309ae5eed3d5801b3969741599017
- fingerprint: 1916db2667c98704

**Next:** this configuration is now exhausted, and what reopens it is different ground rather than a different name. Re-measuring the lists is not the remedy this line used to recommend: measured over three consecutive folds it returned 55 names, then 294, then 51, the last on a corpus two and a half times larger. It changes the fingerprint without changing what the search can reach, and following it is most of how the yield here collapsed. Run a method that reaches somewhere else -- METHODS.md says what each one gets at that nothing else does -- or invent one: `confirm_list` takes candidate names on standard input, so a method is a script that prints names.


## Tooling this run leaves behind

- `scripts/contributed/numbered_grids_20260821-054219.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.