### PR TITLE
[BLKOPS04] findings from Zakkary19, 20260824-003729 (2 names)

### DIFF
--- a/submissions/Zakkary19_BLKOPS04_20260824-003729/about_20260824-003729.md
+++ b/submissions/Zakkary19_BLKOPS04_20260824-003729/about_20260824-003729.md
@@ -1,0 +1,42 @@
+# Submission 20260824-003729
+
+- game: **BLKOPS04**
+- from: Zakkary19
+- names: 2
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- sound_alias: 2
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 0 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260824-000427_soundfiles
+- method: sound files and aliases (confirm_cw --sounds)
+- what it does: every seed cut to pieces at its marks and recombined as beginning + stem + ending, each candidate hashed and looked up among the game's unnamed ids
+- ran for: 32m 55s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- pools searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- seed lines: 3308172
+- distinct pieces: 31574356
+- beginnings: 700
+- endings: 2890
+- ids hunted: 84768
+- candidates tested: 63988305700396
+- matches: 174
+- distinct names reached: 23
+- new here: 2
+- sketch beginnings: 0144986374223e9c01aa23ff78c43bf70292cf42f42b4aea02d4b4351224cbfa03373c2108c69fff0396afaecc460bbc039dd5d99e2f9d1104ce2334f3e0deb10555ec5ec24c247c05ee597280f1d5a306612a8a75156bff06871617c79df54607101de92871b64407231e76b02644f30774cc8667cecc64077d0f86fe9f7aa7078a51db4589c13e07adf38428243a5607c66c9c56614c360808972299f305bd090022b3599273320907ad5a1855b48109d289302e2fce7e0a2b9e892b5ec77d0a50bf0b7d5463340a5a33ac9531bfbf0a8812dc36d6d0070a9d14b92833a9d20b0d4c2208bed6610b2a8b88a8bf9bdf0b777e1055572b650b792a25745e3147
+- sketch stems: 0000003d0b47de55000000d45e0ab3780000013723f320a30000016a4ab426f7000001bc85c24ba9000001c029a8efd70000024fa9031a32000002a3bce4ea7d0000034514625b510000038d3139e634000004259ad9a28900000491769b2dcb000004cf8f880bd40000069733a15329000007da7ab81343000008527395fce00000095ca492a028000009ac7953308b00000ab4ba1aeee400000ac9194dd2c300000b61d1f9c0d000000bf2fcc0175f00000c117bc1e74e00000c3f4f949a9e00000c5e26ddd31500000c76c90665c700000cb0e2df3f6900000d2f6c89fd3100000d4a310a34d800000d70dcf0d5eb00000dd14f3c6f1a00000e057fa6ef7c
+- sketch endings: 0021ad1c1ec6930700255f82a3722ab90067c12c53bd8af800756a1875f8f3310079e3b242d77715007ac06c033e18f2009072d9a0fdb05600ae971c503f3d9800c3cae55cbba0c800c4da67057742ff00fc46b2041ceec50113f5c1bdd185dd01209e6672fa09ae01499de0440f5952017b5fae025c739d0190916401b2b4ca01ba3a794398981301bc0d82939e166901f3231a898024470209afb75a2b7ec2021bdcd8518ed867025dbe9ead38bdb5025f7de0512cd85a0277fb222ccb4976027ab07d1457713c027d69e2d4f44b9402a31c384f5fc27c02d056c6cc92c88b03145f24dfbd79470339e127fb8b79f4034533951d9874cc0373d851957f0390
+- fingerprint: f9e54e95265c481c
+
+**Next:** this configuration is now exhausted, and what reopens it is different ground rather than a different name. Re-measuring the lists is not the remedy this line used to recommend: measured over three consecutive folds it returned 55 names, then 294, then 51, the last on a corpus two and a half times larger. It changes the fingerprint without changing what the search can reach, and following it is most of how the yield here collapsed. Run a method that reaches somewhere else -- METHODS.md says what each one gets at that nothing else does -- or invent one: `confirm_list` takes candidate names on standard input, so a method is a script that prints names.

--- a/submissions/Zakkary19_BLKOPS04_20260824-003729/sound_alias_20260824-003729.txt
+++ b/submissions/Zakkary19_BLKOPS04_20260824-003729/sound_alias_20260824-003729.txt
@@ -1,0 +1,2 @@
+582d4bdca23498f,zmb_oura_arrow_break_2_lfe
+3f466cfb8195da90,zmb_oura_arrow_break_3_lfe


### PR DESCRIPTION
**BLKOPS04** — 2 asset names, confirmed against that game's own loaded assets.

- sound_alias: 2

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Zakkary19

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260824-000427_soundfiles
- method: sound files and aliases (confirm_cw --sounds)
- what it does: every seed cut to pieces at its marks and recombined as beginning + stem + ending, each candidate hashed and looked up among the game's unnamed ids
- ran for: 32m 55s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- pools searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
- seed lines: 3308172
- distinct pieces: 31574356
- beginnings: 700
- endings: 2890
- ids hunted: 84768
- candidates tested: 63988305700396
- matches: 174
- distinct names reached: 23
- new here: 2
- sketch beginnings: 0144986374223e9c01aa23ff78c43bf70292cf42f42b4aea02d4b4351224cbfa03373c2108c69fff0396afaecc460bbc039dd5d99e2f9d1104ce2334f3e0deb10555ec5ec24c247c05ee597280f1d5a306612a8a75156bff06871617c79df54607101de92871b64407231e76b02644f30774cc8667cecc64077d0f86fe9f7aa7078a51db4589c13e07adf38428243a5607c66c9c56614c360808972299f305bd090022b3599273320907ad5a1855b48109d289302e2fce7e0a2b9e892b5ec77d0a50bf0b7d5463340a5a33ac9531bfbf0a8812dc36d6d0070a9d14b92833a9d20b0d4c2208bed6610b2a8b88a8bf9bdf0b777e1055572b650b792a25745e3147
- sketch stems: 0000003d0b47de55000000d45e0ab3780000013723f320a30000016a4ab426f7000001bc85c24ba9000001c029a8efd70000024fa9031a32000002a3bce4ea7d0000034514625b510000038d3139e634000004259ad9a28900000491769b2dcb000004cf8f880bd40000069733a15329000007da7ab81343000008527395fce00000095ca492a028000009ac7953308b00000ab4ba1aeee400000ac9194dd2c300000b61d1f9c0d000000bf2fcc0175f00000c117bc1e74e00000c3f4f949a9e00000c5e26ddd31500000c76c90665c700000cb0e2df3f6900000d2f6c89fd3100000d4a310a34d800000d70dcf0d5eb00000dd14f3c6f1a00000e057fa6ef7c
- sketch endings: 0021ad1c1ec6930700255f82a3722ab90067c12c53bd8af800756a1875f8f3310079e3b242d77715007ac06c033e18f2009072d9a0fdb05600ae971c503f3d9800c3cae55cbba0c800c4da67057742ff00fc46b2041ceec50113f5c1bdd185dd01209e6672fa09ae01499de0440f5952017b5fae025c739d0190916401b2b4ca01ba3a794398981301bc0d82939e166901f3231a898024470209afb75a2b7ec2021bdcd8518ed867025dbe9ead38bdb5025f7de0512cd85a0277fb222ccb4976027ab07d1457713c027d69e2d4f44b9402a31c384f5fc27c02d056c6cc92c88b03145f24dfbd79470339e127fb8b79f4034533951d9874cc0373d851957f0390
- fingerprint: f9e54e95265c481c

**Next:** this configuration is now exhausted, and what reopens it is different ground rather than a different name. Re-measuring the lists is not the remedy this line used to recommend: measured over three consecutive folds it returned 55 names, then 294, then 51, the last on a corpus two and a half times larger. It changes the fingerprint without changing what the search can reach, and following it is most of how the yield here collapsed. Run a method that reaches somewhere else -- METHODS.md says what each one gets at that nothing else does -- or invent one: `confirm_list` takes candidate names on standard input, so a method is a script that prints names.


## Tooling this run leaves behind

- `scripts/contributed/bo4snd_ends_20260823-192217.txt`
- `scripts/contributed/numbered_grids_20260821-054219.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.