### PR TITLE
[BLKOPSCW] findings from Dreadbread76, 20260824-055336 (6 names)

### DIFF
--- a/submissions/Dreadbread76_BLKOPSCW_20260824-055336/about_20260824-055336.md
+++ b/submissions/Dreadbread76_BLKOPSCW_20260824-055336/about_20260824-055336.md
@@ -1,0 +1,33 @@
+# Submission 20260824-055336
+
+- game: **BLKOPSCW**
+- from: Dreadbread76
+- names: 6
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 17 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260824-053114_soundfiles
+- method: sound files and aliases (confirm_cw --sounds)
+- what it does: every seed cut to pieces at its marks and recombined as beginning + stem + ending, each candidate hashed and looked up among the game's unnamed ids
+- ran for: 23m 00s
+- game: BLKOPSCW
+- pools searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- seed lines: 3305205
+- distinct pieces: 31530807
+- beginnings: 700
+- endings: 4800
+- ids hunted: 36773
+- matches: 6
+- distinct names reached: 6
+- new here: 6
+- fingerprint: 51e8ec03e344ac07
+
+**Next:** this configuration is now exhausted. Re-measure the lists with `python scripts/derive_lists.py` so the confirmed names widen them, which changes the fingerprint and reopens the method -- or run a method that reaches somewhere else entirely (METHODS.md).

--- a/submissions/Dreadbread76_BLKOPSCW_20260824-055336/sound_alias_20260824-055336.txt
+++ b/submissions/Dreadbread76_BLKOPSCW_20260824-055336/sound_alias_20260824-055336.txt
@@ -1,0 +1,6 @@
+2cb36ab34ce22fb,mpl_veh_recon_peel_ice
+3d88dbf172c2b042,mpl_veh_recon_slide_ice
+4bc7f99f578f1fb7,mpl_veh_recon_road_ice
+71ad7fbb0ab04ae8,mpl_veh_recon_road_plastic
+79a5e9d6de8d9d61,mpl_veh_recon_slide_plastic
+7ae49ed3043cd6d4,mpl_veh_recon_peel_plastic


### PR DESCRIPTION
**BLKOPSCW** — 6 asset names, confirmed against that game's own loaded assets.

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Dreadbread76

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260824-053114_soundfiles
- method: sound files and aliases (confirm_cw --sounds)
- what it does: every seed cut to pieces at its marks and recombined as beginning + stem + ending, each candidate hashed and looked up among the game's unnamed ids
- ran for: 23m 00s
- game: BLKOPSCW
- pools searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
- seed lines: 3305205
- distinct pieces: 31530807
- beginnings: 700
- endings: 4800
- ids hunted: 36773
- matches: 6
- distinct names reached: 6
- new here: 6
- fingerprint: 51e8ec03e344ac07

**Next:** this configuration is now exhausted. Re-measure the lists with `python scripts/derive_lists.py` so the confirmed names widen them, which changes the fingerprint and reopens the method -- or run a method that reaches somewhere else entirely (METHODS.md).
