### PR TITLE
[BLKOPSCW] findings from Zakkary19, 20260824-100430 (2 names)

### DIFF
--- a/submissions/Zakkary19_BLKOPSCW_20260824-100430/about_20260824-100430.md
+++ b/submissions/Zakkary19_BLKOPSCW_20260824-100430/about_20260824-100430.md
@@ -1,0 +1,38 @@
+# Submission 20260824-100430
+
+- game: **BLKOPSCW**
+- from: Zakkary19
+- names: 2
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- material: 2
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 18 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260824-100043_plan
+- method: heads of length 3
+- what it does: every known name cut short by 3 character(s), against every 3-character ending over the 38 characters names are measured to end in
+- ran for: 3m 32s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- beginnings: 54872
+- endings: 0
+- stems: 946914
+- ids hunted: 127933
+- candidates tested: 51959065008
+- new: 2
+- sketch beginnings: 0000065093d2ddcb000009a9246decd30000c0ee97a841da000105e496e34f73000221c75929fb3200024e1052ecac1e00046b3d1855840d0004ecba053210e00005ae639e926f5d000cbc01b480ab4c000cbec3f4c1a1f2000d92810ddcb5dc0010d8212032c16700110b28e22c5b000011482c992f9b36001280f6cd94de880012a5925ed9cdc700148fff58e34676001538998e20f3570015ecc7299627dc00171438b6fbe1d70017285349dcf2ba001798c7451b75ee001916f3aa09d066001a6f64968748f5001cec1662cf3c52001d2cad0ab0964c001e6153b65350ad001f0b5ecc97c959001fdc30529cddff0021ad1c1ec693070021bc0e48915ced
+- sketch stems: 000008527395fce000000f8b21e1f68a0000280096939c4300003587fbdf59ea00005759693831f100005ff5d08944070000c9671936cc360000cc8fcefa8c080000e423e14753ea0000ee245770b238000100bca9e76e4200010f0eb16da16d00011b32112129cc00012d5d458b056600013380aa5605d3000134d7ebba583300014819e5933c9700014a33b20211bf00015e27387520ae000161aabc58c81e00017dbf33daec9f000182bc023c79e20001a5020367abdb0001cefe3c2be5640001df6ac08d34280001e32129b676ce0001f304c37f471c0001f471377477a300021539218f96410002256d72181281000241ba50b866070002529e546300b9
+- sketch endings: 
+- fingerprint: 5bb28f83b426112b
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/Zakkary19_BLKOPSCW_20260824-100430/material_20260824-100430.txt
+++ b/submissions/Zakkary19_BLKOPSCW_20260824-100430/material_20260824-100430.txt
@@ -1,0 +1,2 @@
+2e165e89feb766b8,vd/charred_burntstain_02_dec_gfx_no_normal
+739291df3db458fc,mc/t9_fir_effect_white_emissive_01_fade_01


### PR DESCRIPTION
**BLKOPSCW** — 2 asset names, confirmed against that game's own loaded assets.

- material: 2

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Zakkary19

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260824-100043_plan
- method: heads of length 3
- what it does: every known name cut short by 3 character(s), against every 3-character ending over the 38 characters names are measured to end in
- ran for: 3m 32s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- beginnings: 54872
- endings: 0
- stems: 946914
- ids hunted: 127933
- candidates tested: 51959065008
- new: 2
- sketch beginnings: 0000065093d2ddcb000009a9246decd30000c0ee97a841da000105e496e34f73000221c75929fb3200024e1052ecac1e00046b3d1855840d0004ecba053210e00005ae639e926f5d000cbc01b480ab4c000cbec3f4c1a1f2000d92810ddcb5dc0010d8212032c16700110b28e22c5b000011482c992f9b36001280f6cd94de880012a5925ed9cdc700148fff58e34676001538998e20f3570015ecc7299627dc00171438b6fbe1d70017285349dcf2ba001798c7451b75ee001916f3aa09d066001a6f64968748f5001cec1662cf3c52001d2cad0ab0964c001e6153b65350ad001f0b5ecc97c959001fdc30529cddff0021ad1c1ec693070021bc0e48915ced
- sketch stems: 000008527395fce000000f8b21e1f68a0000280096939c4300003587fbdf59ea00005759693831f100005ff5d08944070000c9671936cc360000cc8fcefa8c080000e423e14753ea0000ee245770b238000100bca9e76e4200010f0eb16da16d00011b32112129cc00012d5d458b056600013380aa5605d3000134d7ebba583300014819e5933c9700014a33b20211bf00015e27387520ae000161aabc58c81e00017dbf33daec9f000182bc023c79e20001a5020367abdb0001cefe3c2be5640001df6ac08d34280001e32129b676ce0001f304c37f471c0001f471377477a300021539218f96410002256d72181281000241ba50b866070002529e546300b9
- sketch endings: 
- fingerprint: 5bb28f83b426112b

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/bo4snd_ends_20260823-192217.txt`
- `scripts/contributed/numbered_grids_20260821-054219.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.