### PR TITLE
[BLKOPSCW] findings from xDraxxis, 20260824-145555 (6 names)

### DIFF
--- a/submissions/xDraxxis_BLKOPSCW_20260824-145555/about_20260824-145555.md
+++ b/submissions/xDraxxis_BLKOPSCW_20260824-145555/about_20260824-145555.md
@@ -1,0 +1,35 @@
+# Submission 20260824-145555
+
+- game: **BLKOPSCW**
+- from: xDraxxis
+- names: 6
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- sound_asset: 6
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 4 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260824-145503_list
+- method: speaker grids re-run cw
+- what it does: a candidate list generated outside the search and confirmed here
+- ran for: 4s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- candidates tested: 1466925
+- matched: 6
+- new: 6
+- sketch stems: 00000cd8913c4e44000013330de34ae40000275515561cf8000029198a5492f800002c5002361f1000002e8b1122f1af000033d0f47fcaa100004dca55542d95000059c630db798100005c40605518b40000637d3659a94100006b9ce5ba543900006ced894d82f60000718c830d2f710000845b3a4de54b00009fd665fea5950000a2e9eae78ade0000a45d5d0d994d0000b0c62b7292190000ca8b3c8f692b0000cb2ff690e0f00000cc2fe2ee757c0000ce54f13c119a0000e22b9ff9f2f10000fb68f17bbaf0000101def6a17dbd00013af99ad5e49c00013c8fe86777c500014dd82730cdf900015d0d1afc71d300016a4997de70b600016d8e03f2a64e
+- ids hunted: 126770
+- throughput: 0.6M candidates/s
+- fingerprint: 9d548537d61f7170
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/xDraxxis_BLKOPSCW_20260824-145555/sound_asset_20260824-145555.txt
+++ b/submissions/xDraxxis_BLKOPSCW_20260824-145555/sound_asset_20260824-145555.txt
@@ -1,0 +1,6 @@
+5b66ff177654b1,vox/scripted/operators/rmbo/vox_rmbo_mtx_execute_rare_05.rn75.pc.en.snd
+2d578befc902557,vox/scripted/operators/rmbo/vox_rmbo_mtx_execute_rare_03.rn75.pc.en.snd
+4be81bdf4e72215,vox/scripted/operators/rmbo/vox_rmbo_mtx_execute_rare_01.rn75.pc.en.snd
+10abb31d8b3b52ba,vox/scripted/operators/rmbo/vox_rmbo_mtx_execute_rare_02.rn75.pc.en.snd
+393309a305de75f0,vox/scripted/operators/rmbo/vox_rmbo_mtx_execute_rare_00.rn75.pc.en.snd
+6e0871c52c039d0c,vox/scripted/operators/rmbo/vox_rmbo_mtx_execute_rare_04.rn75.pc.en.snd


### PR DESCRIPTION
**BLKOPSCW** — 6 asset names, confirmed against that game's own loaded assets.

- sound_asset: 6

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @xDraxxis

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260824-145503_list
- method: speaker grids re-run cw
- what it does: a candidate list generated outside the search and confirmed here
- ran for: 4s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- candidates tested: 1466925
- matched: 6
- new: 6
- sketch stems: 00000cd8913c4e44000013330de34ae40000275515561cf8000029198a5492f800002c5002361f1000002e8b1122f1af000033d0f47fcaa100004dca55542d95000059c630db798100005c40605518b40000637d3659a94100006b9ce5ba543900006ced894d82f60000718c830d2f710000845b3a4de54b00009fd665fea5950000a2e9eae78ade0000a45d5d0d994d0000b0c62b7292190000ca8b3c8f692b0000cb2ff690e0f00000cc2fe2ee757c0000ce54f13c119a0000e22b9ff9f2f10000fb68f17bbaf0000101def6a17dbd00013af99ad5e49c00013c8fe86777c500014dd82730cdf900015d0d1afc71d300016a4997de70b600016d8e03f2a64e
- ids hunted: 126770
- throughput: 0.6M candidates/s
- fingerprint: 9d548537d61f7170

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/speaker_grids_20260822-021342.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.