### PR TITLE
[BLKOPS04] findings from xDraxxis, 20260824-151017 (8 names)

### DIFF
--- a/scripts/contributed/char_edits_20260824-151017.py
+++ b/scripts/contributed/char_edits_20260824-151017.py
@@ -1,0 +1,138 @@
+"""Names one *character* away from a name we already have, where that character changes the length.
+
+    python contrib/char_edits.py --type image | bin\\windows\\confirm_list.exe - \
+        --label "character deletion and transposition" --script contrib/char_edits.py
+
+## The gap this fills
+
+`token_edits.py` opens its case by observing that every method in `METHODS.md` substitutes and
+none of them changes a name's length, then fixes that at *token* granularity -- a name plus or
+minus one whole word. The character granularity underneath it was never filled in, and the two do
+not overlap:
+
+  - `final_byte` solves the **last** character, `tails`/`heads` replace the first or last k
+    characters. All three are fixed-width substitutions: k characters in, k characters out.
+  - `confirm_variants` moves a number in place, `slotswap` and `templates` replace whole tokens.
+  - `token_edits` adds or removes a whole token between two underscores.
+
+So a name that is a known name with **one character dropped**, or with **two adjacent characters
+in the other order**, is unreachable by all of them however long they run:
+
+    wpn_ak47_scope_01
+    wpn_ak47_scope_001    <- an insertion, reachable by nothing (and expensive: alphabet x length)
+    wpn_ak47_scope_1      <- a deletion, reachable by nothing, and this file's business
+    wpn_ak47_scoep_01     <- a transposition, likewise
+
+Zero-padding is why this is worth a pass rather than a curiosity. A number written `_01` in one
+asset and `_1` in its sibling is a one-character deletion and nothing here can spell it, because
+every fixed-width method must return a string of the same length it took.
+
+## Why deletion and transposition, and not insertion
+
+Deletion and transposition are **free of an alphabet**: each position of each name yields exactly
+one candidate, so the whole corpus costs `names x length` rather than `names x length x |alphabet|`.
+That is tens of millions against tens of billions, and it is the entire reason this is cheap enough
+to be worth trying before anything expensive. Insertion is the same idea multiplied by 37 and
+belongs in a plan if either of these two pays.
+
+## What it does not touch
+
+**The directory is kept whole.** Editing characters inside `mc/` or `vox/scripted/` invents
+directories that do not exist -- the same closed-vocabulary argument `token_edits.split` makes --
+so edits are confined to everything after the final slash.
+"""
+
+import argparse
+import os
+import sys
+
+# Find `scripts/` wherever this file has been filed -- see scripts/README.md.
+_root = os.path.dirname(os.path.abspath(__file__))
+while _root != os.path.dirname(_root) and not os.path.isfile(
+    os.path.join(_root, "scripts", "snapshot.py")
+):
+    _root = os.path.dirname(_root)
+sys.path.insert(0, os.path.join(_root, "scripts"))
+
+import snapshot
+
+TYPES = {
+    "model": ("fnv1a_xmodels", "xmodel"),
+    "material": ("fnv1a_xmaterials", "material"),
+    "image": ("fnv1a_ximages", "image"),
+    "anim": ("fnv1a_xanims", "xanim"),
+}
+
+# Past this the basename is a generated identifier rather than a composed one -- a mesh tail is 26
+# base32 characters hashed from the mesh itself -- and editing one produces nothing.
+MAX_BASENAME = 96
+
+
+def corpus(kind):
+    table, confirmed = TYPES[kind]
+    names = list(snapshot.table_names(table)) + list(snapshot.confirmed_names(confirmed))
+
+    out = set()
+    for name in names:
+        name = name.strip().lower().replace("\\", "/")
+        if name:
+            out.add(name)
+    return out
+
+
+def edits(name, deletions, transpositions):
+    """Every one-character deletion and adjacent transposition of `name`, leaving its directory
+    alone. Deduplicated: repeated characters otherwise yield the same string twice."""
+    cut = name.rfind("/") + 1
+    head, base = name[:cut], name[cut:]
+    if not base or len(base) > MAX_BASENAME:
+        return
+
+    seen = set()
+    if deletions:
+        for i in range(len(base)):
+            edited = base[:i] + base[i + 1 :]
+            if edited and edited not in seen:
+                seen.add(edited)
+                yield head + edited
+    if transpositions:
+        for i in range(len(base) - 1):
+            if base[i] == base[i + 1]:
+                continue
+            edited = base[:i] + base[i + 1] + base[i] + base[i + 2 :]
+            if edited not in seen:
+                seen.add(edited)
+                yield head + edited
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--type", choices=sorted(TYPES), action="append")
+    parser.add_argument("--no-deletions", action="store_true")
+    parser.add_argument("--no-transpositions", action="store_true")
+    parser.add_argument("--size", action="store_true", help="count candidates, emit none")
+    args = parser.parse_args(argv)
+
+    kinds = args.type or sorted(TYPES)
+    deletions = not args.no_deletions
+    transpositions = not args.no_transpositions
+
+    total = 0
+    write = sys.stdout.write
+    for kind in kinds:
+        names = corpus(kind)
+        count = 0
+        for name in names:
+            for candidate in edits(name, deletions, transpositions):
+                count += 1
+                if not args.size:
+                    write(candidate + "\n")
+        print(f"{kind}: {len(names)} names, {count} candidates", file=sys.stderr)
+        total += count
+
+    print(f"{total} candidates", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/submissions/xDraxxis_BLKOPS04_20260824-151017/about_20260824-151017.md
+++ b/submissions/xDraxxis_BLKOPS04_20260824-151017/about_20260824-151017.md
@@ -1,0 +1,37 @@
+# Submission 20260824-151017
+
+- game: **BLKOPS04**
+- from: xDraxxis
+- names: 8
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- image: 4
+- material: 3
+- xmodel: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 2 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260824-150640_list
+- method: character deletion and transposition
+- what it does: a candidate list generated outside the search and confirmed here
+- ran for: 1m 07s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- candidates tested: 67243460
+- matched: 12
+- new: 8
+- sketch stems: 0000000055373b9b0000001a1d1dd9e200000044fc9a6d55000000d920540603000000ec248fe73c0000010a360d819d0000018672fcce750000018987fe691d000001937339b409000001970d54ba0a000001fe6cdfcb900000021254453ed30000025d0b35a01f0000026cd1b1792500000274b6a8cd59000002c30a9f6828000002cc7f47123e000002f4ddf070310000030ed9f3a65600000378f746a2d900000506cbfcdd980000051a9040c3f00000058f5f910aaa000005d5d102c13a000005ff11b985710000066419b3bc8c00000671b0f831100000067c32e4416a0000068c08c8cd73000006c8c73cf7bb0000077bf5f66b96000007bb950d77fc
+- ids hunted: 167094
+- throughput: 1.0M candidates/s
+- fingerprint: 25c2c1ee0ff831e5
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/xDraxxis_BLKOPS04_20260824-151017/image_20260824-151017.txt
+++ b/submissions/xDraxxis_BLKOPS04_20260824-151017/image_20260824-151017.txt
@@ -1,0 +1,4 @@
+1e10410bf5dabaea,uie_borderbutton_9s
+371701d443b1b800,ui_icon_crm_featured_ancientevil
+56db994776e784de,i_c_t8_mp_spe_engineer_body1_vestsnake_com1_m
+68f7745d3b7fecdd,ui_icon_crm_featured_firebreakbundle

--- a/submissions/xDraxxis_BLKOPS04_20260824-151017/material_20260824-151017.txt
+++ b/submissions/xDraxxis_BLKOPS04_20260824-151017/material_20260824-151017.txt
@@ -1,0 +1,3 @@
+5804f6b7f8b7cf9,mc/mtl_p8marble_statue_tile
+4138b2d5d5c9badd,mc/mtlc_t8_zmb_mob_hero_richtofen2_chainmail
+6dea2163b0abc7d3,mc/mtl_c_t8_wun_ar_braket

--- a/submissions/xDraxxis_BLKOPS04_20260824-151017/xmodel_20260824-151017.txt
+++ b/submissions/xDraxxis_BLKOPS04_20260824-151017/xmodel_20260824-151017.txt
@@ -1,0 +1,1 @@
+3e1e021586791f4e,p8_zm_zod_mil_pillar_righ_01


### PR DESCRIPTION
**BLKOPS04** — 8 asset names, confirmed against that game's own loaded assets.

- image: 4
- material: 3
- xmodel: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @xDraxxis

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260824-150640_list
- method: character deletion and transposition
- what it does: a candidate list generated outside the search and confirmed here
- ran for: 1m 07s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- candidates tested: 67243460
- matched: 12
- new: 8
- sketch stems: 0000000055373b9b0000001a1d1dd9e200000044fc9a6d55000000d920540603000000ec248fe73c0000010a360d819d0000018672fcce750000018987fe691d000001937339b409000001970d54ba0a000001fe6cdfcb900000021254453ed30000025d0b35a01f0000026cd1b1792500000274b6a8cd59000002c30a9f6828000002cc7f47123e000002f4ddf070310000030ed9f3a65600000378f746a2d900000506cbfcdd980000051a9040c3f00000058f5f910aaa000005d5d102c13a000005ff11b985710000066419b3bc8c00000671b0f831100000067c32e4416a0000068c08c8cd73000006c8c73cf7bb0000077bf5f66b96000007bb950d77fc
- ids hunted: 167094
- throughput: 1.0M candidates/s
- fingerprint: 25c2c1ee0ff831e5

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/char_edits_20260824-151017.py`
- `scripts/contributed/redecorations_20260823-023757.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.