### PR TITLE
[BLKOPSCW] findings from xDraxxis, 20260824-155735 (4 names)

### DIFF
--- a/submissions/xDraxxis_BLKOPSCW_20260824-155735/about_20260824-155735.md
+++ b/submissions/xDraxxis_BLKOPSCW_20260824-155735/about_20260824-155735.md
@@ -1,0 +1,35 @@
+# Submission 20260824-155735
+
+- game: **BLKOPSCW**
+- from: xDraxxis
+- names: 4
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- sound_alias: 4
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 1 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260824-154751_list
+- method: sound character insertion
+- what it does: a candidate list generated outside the search and confirmed here
+- ran for: 8m 39s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- candidates tested: 1016395829
+- matched: 4
+- new: 4
+- sketch stems: 00000005105e0f7f0000000d5ba12a090000000f18bd305200000011aaa04b9000000015e53d38f1000000166f7f69a0000000228d0937e20000002deafa43580000003216667a7e0000003577b8bd99000000381d6548fa0000003b4d10a47b00000047243da7b9000000475b4fba1a0000004abfe094d30000005ca39497cd0000005f42df392000000063449b35d300000066360b9b74000000668a702cef0000006746d9ff69000000696bf747e70000006a84f096780000007e95a1c40a00000080deebdb7700000083cdd07aaf000000850fe27cce00000088f9706b200000008e848402720000009274217144000000944761bd45000000953f8d606a
+- ids hunted: 126770
+- throughput: 2.0M candidates/s
+- fingerprint: 0b88516da63b6742
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/xDraxxis_BLKOPSCW_20260824-155735/sound_alias_20260824-155735.txt
+++ b/submissions/xDraxxis_BLKOPSCW_20260824-155735/sound_alias_20260824-155735.txt
@@ -1,0 +1,4 @@
+3bc920628127a67d,wpn_attack_helicopter_scannon_fire_npc
+5734969de22f59b8,amb_ztrain_lp_b
+5734979de22f5b6b,amb_ztrain_lp_c
+57349c9de22f63ea,amb_ztrain_lp_d


### PR DESCRIPTION
**BLKOPSCW** — 4 asset names, confirmed against that game's own loaded assets.

- sound_alias: 4

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @xDraxxis

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260824-154751_list
- method: sound character insertion
- what it does: a candidate list generated outside the search and confirmed here
- ran for: 8m 39s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- candidates tested: 1016395829
- matched: 4
- new: 4
- sketch stems: 00000005105e0f7f0000000d5ba12a090000000f18bd305200000011aaa04b9000000015e53d38f1000000166f7f69a0000000228d0937e20000002deafa43580000003216667a7e0000003577b8bd99000000381d6548fa0000003b4d10a47b00000047243da7b9000000475b4fba1a0000004abfe094d30000005ca39497cd0000005f42df392000000063449b35d300000066360b9b74000000668a702cef0000006746d9ff69000000696bf747e70000006a84f096780000007e95a1c40a00000080deebdb7700000083cdd07aaf000000850fe27cce00000088f9706b200000008e848402720000009274217144000000944761bd45000000953f8d606a
- ids hunted: 126770
- throughput: 2.0M candidates/s
- fingerprint: 0b88516da63b6742

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/char_edits_20260824-154800.py`
- `scripts/contributed/redecorations_20260823-023757.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.