### PR TITLE
[BLKOPS04] findings from KingslayerKyle, 20260824-164303 (4 names)

### DIFF
--- a/submissions/KingslayerKyle_BLKOPS04_20260824-164303/about_20260824-164303.md
+++ b/submissions/KingslayerKyle_BLKOPS04_20260824-164303/about_20260824-164303.md
@@ -1,0 +1,22 @@
+# Submission 20260824-164303
+
+- game: **BLKOPS04**
+- from: KingslayerKyle
+- names: 4
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: not recorded (run predates this field)
+- confirmed on: not recorded (run predates this field)
+- sound_alias: 2
+- xanim: 2
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 0 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260824-164251_recovered
+- method: not recorded (an older or interrupted run)

--- a/submissions/KingslayerKyle_BLKOPS04_20260824-164303/sound_alias_20260824-164303.txt
+++ b/submissions/KingslayerKyle_BLKOPS04_20260824-164303/sound_alias_20260824-164303.txt
@@ -1,0 +1,2 @@
+2aa743038b6910f7,mus_matchcomplete_04_intro
+47f9503151af5e71,fly_wpn_ads_up

--- a/submissions/KingslayerKyle_BLKOPS04_20260824-164303/xanim_20260824-164303.txt
+++ b/submissions/KingslayerKyle_BLKOPS04_20260824-164303/xanim_20260824-164303.txt
@@ -1,0 +1,2 @@
+15dc91796dccb42e,vm_shotgun_full_auto_inspect_stock_down
+7ea2371086975228,vm_smg_vmp_t8_grip_pose


### PR DESCRIPTION
**BLKOPS04** — 4 asset names, confirmed against that game's own loaded assets.

- sound_alias: 2
- xanim: 2

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @KingslayerKyle

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260824-164251_recovered
- method: not recorded (an older or interrupted run)


## Tooling this run leaves behind

- `scripts/contributed/borrowed_decorations.py`
- `scripts/contributed/cross_game_verbatim.py`
- `scripts/contributed/family_grid_20260824-000146.py`
- `scripts/contributed/harvest_bo3_20260822-030351.py`
- `scripts/contributed/harvest_bo3_assetlist.py`
- `scripts/contributed/harvest_bo4.py`
- `scripts/contributed/harvest_decorated_20260824-030747.py`
- `scripts/contributed/harvest_iwd.py`
- `scripts/contributed/harvest_tails_20260824-114138.py`
- `scripts/contributed/heads_slash_20260824-025001.py`
- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/keyword_sweep_20260822-020208.py`
- `scripts/contributed/mtx_bundle_grid.py`
- `scripts/contributed/redecorations_20260823-023757.py`
- `scripts/contributed/speaker_grids_20260822-021342.py`
- `scripts/contributed/typed_cross.py`
- `scripts/contributed/uncarried_beginnings_20260823-173831.py`
- `scripts/contributed/uncarried_endings_allboundary_20260823-134935.py`
- `scripts/contributed/unnamed_profile_20260823-182656.py`
- `scripts/contributed/zombie_models_20260821-163108.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.