### PR TITLE
[BLKOPSCW] findings from xDraxxis, 20260824-165148 (3 names)

### DIFF
--- a/submissions/xDraxxis_BLKOPSCW_20260824-165148/about_20260824-165148.md
+++ b/submissions/xDraxxis_BLKOPSCW_20260824-165148/about_20260824-165148.md
@@ -1,0 +1,22 @@
+# Submission 20260824-165148
+
+- game: **BLKOPSCW**
+- from: xDraxxis
+- names: 3
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: not recorded (run predates this field)
+- confirmed on: not recorded (run predates this field)
+- material: 2
+- image: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 2 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260824-165136_recovered
+- method: not recorded (an older or interrupted run)

--- a/submissions/xDraxxis_BLKOPSCW_20260824-165148/image_20260824-165148.txt
+++ b/submissions/xDraxxis_BLKOPSCW_20260824-165148/image_20260824-165148.txt
@@ -1,0 +1,1 @@
+7482d77b166cff71,ui_icon_featured_zcranked

--- a/submissions/xDraxxis_BLKOPSCW_20260824-165148/material_20260824-165148.txt
+++ b/submissions/xDraxxis_BLKOPSCW_20260824-165148/material_20260824-165148.txt
@@ -1,0 +1,2 @@
+25db85ac5d4b7933,mc/mtl_p9_usa_street_pole_metal_color_wet
+7b1262115cd20549,mc/mtl_p9_usa_hotel_sundown_deco_corner


### PR DESCRIPTION
**BLKOPSCW** — 3 asset names, confirmed against that game's own loaded assets.

- material: 2
- image: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @xDraxxis

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260824-165136_recovered
- method: not recorded (an older or interrupted run)


## Tooling this run leaves behind

- `scripts/contributed/char_edits_20260824-165142.py`
- `scripts/contributed/redecorations_20260823-023757.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.