### PR TITLE
[BLKOPSCW] findings from Zakkary19, 20260824-213206 (1 names)

### DIFF
--- a/submissions/Zakkary19_BLKOPSCW_20260824-213206/about_20260824-213206.md
+++ b/submissions/Zakkary19_BLKOPSCW_20260824-213206/about_20260824-213206.md
@@ -1,0 +1,35 @@
+# Submission 20260824-213206
+
+- game: **BLKOPSCW**
+- from: Zakkary19
+- names: 1
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- xmodel: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 10 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260824-211118_list
+- method: char double deletions cw
+- what it does: a candidate list generated outside the search and confirmed here
+- ran for: 20m 22s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- candidates tested: 780126906
+- matched: 1
+- new: 1
+- sketch stems: 0000000055373b9b0000000ba7da57a400000011744cf90b00000013620c7edf00000013ca92672600000016cf4915fb000000180dff1ca40000001a1d1dd9e20000001eef673fd60000001f722a3cf10000002077819c6d00000021ee0fffcf0000002215950bd40000002701d865570000002ca8ab43da00000035fe526c17000000447c8f003300000044fc9a6d550000004bd97af5030000004c0576b07200000056ff2f900000000057fd5de0400000005c4a05f7410000006563f5273200000069c04449270000006b2793089b0000006b8a1f481000000077a2bf0563000000786b698ab50000007ca2a7077800000088eafea572000000917ecb56b2
+- ids hunted: 125297
+- throughput: 0.6M candidates/s
+- fingerprint: 2f9bfa75c7a8a8de
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/Zakkary19_BLKOPSCW_20260824-213206/xmodel_20260824-213206.txt
+++ b/submissions/Zakkary19_BLKOPSCW_20260824-213206/xmodel_20260824-213206.txt
@@ -1,0 +1,1 @@
+34ed1f5d567b7518,p9_ech_pipe_painted_01_straight_8_01


### PR DESCRIPTION
**BLKOPSCW** — 1 asset names, confirmed against that game's own loaded assets.

- xmodel: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Zakkary19

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260824-211118_list
- method: char double deletions cw
- what it does: a candidate list generated outside the search and confirmed here
- ran for: 20m 22s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- candidates tested: 780126906
- matched: 1
- new: 1
- sketch stems: 0000000055373b9b0000000ba7da57a400000011744cf90b00000013620c7edf00000013ca92672600000016cf4915fb000000180dff1ca40000001a1d1dd9e20000001eef673fd60000001f722a3cf10000002077819c6d00000021ee0fffcf0000002215950bd40000002701d865570000002ca8ab43da00000035fe526c17000000447c8f003300000044fc9a6d550000004bd97af5030000004c0576b07200000056ff2f900000000057fd5de0400000005c4a05f7410000006563f5273200000069c04449270000006b2793089b0000006b8a1f481000000077a2bf0563000000786b698ab50000007ca2a7077800000088eafea572000000917ecb56b2
- ids hunted: 125297
- throughput: 0.6M candidates/s
- fingerprint: 2f9bfa75c7a8a8de

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/char_edits_20260824-165142.py`
- `scripts/contributed/bo4snd_ends_20260823-192217.txt`
- `scripts/contributed/numbered_grids_20260821-054219.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.