### PR TITLE
[BLKOPS04] findings from Zakkary19, 20260824-222119 (2 names)

### DIFF
--- a/submissions/Zakkary19_BLKOPS04_20260824-222119/about_20260824-222119.md
+++ b/submissions/Zakkary19_BLKOPS04_20260824-222119/about_20260824-222119.md
@@ -1,0 +1,21 @@
+# Submission 20260824-222119
+
+- game: **BLKOPS04**
+- from: Zakkary19
+- names: 2
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: not recorded (run predates this field)
+- confirmed on: not recorded (run predates this field)
+- material: 2
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 14 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260824-222106_recovered
+- method: not recorded (an older or interrupted run)

--- a/submissions/Zakkary19_BLKOPS04_20260824-222119/material_20260824-222119.txt
+++ b/submissions/Zakkary19_BLKOPS04_20260824-222119/material_20260824-222119.txt
@@ -1,0 +1,2 @@
+24215220d1452004,mc/mtl_veh_t8_civ_truck_pickup_interior3_seat_rubber2_dead
+7b4c7af5a5ece6e3,mc/mtl_veh_t8_civ_truck_pickup_interior3_seat_rubber2_clean


### PR DESCRIPTION
**BLKOPS04** — 2 asset names, confirmed against that game's own loaded assets.

- material: 2

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Zakkary19

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260824-222106_recovered
- method: not recorded (an older or interrupted run)


## Tooling this run leaves behind

- `scripts/contributed/bo4snd_ends_20260823-192217.txt`
- `scripts/contributed/numbered_grids_20260821-054219.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.