### PR TITLE
[BLKOPSCW] findings from GoastcraftHD, 20260824-232215 (2 names)

### DIFF
--- a/scripts/contributed/measure_material_dirs_20260824-232215.py
+++ b/scripts/contributed/measure_material_dirs_20260824-232215.py
@@ -1,0 +1,143 @@
+"""Measure the real directory vocabulary of BO4/CW names, against what is carried.
+
+CLAUDE.md records that material names are paths and that there are "twelve
+directories, not one" -- mc/ wc/ clt/ splm/ vd/ mcs/ ei/ cltp/ vdd/ el/ mcp/ ec/.
+That fact came from the published tables. `reach.py` and `uncarried.py` both now
+point at `mcdp/mtl_` as the single commonest beginning no cut of which is carried
+(658 published names), and `unnamed_profile.py` puts `mcdp/` at 3,183 names among
+the recovered against 0.04% of the published -- i.e. it is a directory this
+project keeps *finding* and never *spelling*.
+
+So the twelve may simply be incomplete. This counts every directory head actually
+observed, in the published BO4/CW tables and in everything this project has
+confirmed, and says which ones `data/prefixes.txt` cannot express.
+
+Read-only. Prints a table; writes nothing.
+"""
+import os, sys, glob
+from collections import Counter
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# BO4/BOCW tables only. The _v2 tables are MWII/MWIII/BO6/BO7/WZM under the IW
+# offset -- different games, and hashing their names here is measured dead
+# (METHODS.md, "Names published for the newer titles").
+PUBLISHED = [
+    "fnv1a_xmaterials.csv", "fnv1a_ximages.csv",
+    "fnv1a_xmodels.csv", "fnv1a_xanims.csv",
+]
+
+
+def names_from_csv(path):
+    with open(path, "r", encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            line = line.rstrip("\n").rstrip("\r")
+            if not line:
+                continue
+            comma = line.find(",")
+            if comma < 0:
+                continue
+            yield line[comma + 1:]
+
+
+def names_from_findings(path):
+    with open(path, "r", encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            line = line.rstrip("\n").rstrip("\r")
+            if not line:
+                continue
+            comma = line.find(",")
+            yield line[comma + 1:] if comma >= 0 else line
+
+
+def head_of(name):
+    """The directory head: everything up to and including the first slash."""
+    slash = name.find("/")
+    return name[:slash + 1] if slash >= 0 else None
+
+
+def main():
+    carried = set()
+    with open(os.path.join(REPO, "data", "prefixes.txt"), "r",
+              encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                carried.add(line)
+    # A directory is carried if the list holds it, or holds any deeper cut of it.
+    carried_dirs = set()
+    for c in carried:
+        h = head_of(c)
+        if h:
+            carried_dirs.add(h)
+
+    pub, conf = Counter(), Counter()
+
+    for fn in PUBLISHED:
+        p = os.path.join(REPO, "cod-name-db", "csv", fn)
+        if not os.path.exists(p):
+            continue
+        for n in names_from_csv(p):
+            h = head_of(n)
+            if h:
+                pub[h] += 1
+
+    for p in glob.glob(os.path.join(REPO, "findings", "*", "*.txt")):
+        for n in names_from_findings(p):
+            h = head_of(n)
+            if h:
+                conf[h] += 1
+
+    # The two vocabularies are separate files and must be judged separately:
+    # sound names go to data/sound.prefixes.txt, everything else to prefixes.txt.
+    GENERAL = ("image", "material", "xmodel", "xanim")
+    per_type = {}
+    for p in glob.glob(os.path.join(REPO, "findings", "*", "*.txt")):
+        t = os.path.splitext(os.path.basename(p))[0]
+        if t not in GENERAL:
+            continue
+        c = per_type.setdefault(t, Counter())
+        for n in names_from_findings(p):
+            h = head_of(n)
+            if h:
+                c[h] += 1
+
+    print("=== the four general types only (these use data/prefixes.txt) ===")
+    for t in GENERAL:
+        c = per_type.get(t, Counter())
+        miss = [(v, h) for h, v in c.items() if h not in carried_dirs]
+        miss.sort(reverse=True)
+        print("%-9s %7d confirmed names in %2d dirs; %2d uncarried, heading %d"
+              % (t, sum(c.values()), len(c), len(miss), sum(m[0] for m in miss)))
+        for v, h in miss[:8]:
+            print("        %-14s %7d" % (h, v))
+    print()
+
+    allheads = set(pub) | set(conf)
+    print("=== every type, published tables and confirmed together ===")
+    print("directory heads observed: %d   carried by data/prefixes.txt: %d"
+          % (len(allheads), len(carried_dirs & allheads)))
+    print()
+    rows = []
+    for h in allheads:
+        rows.append((pub[h] + conf[h], pub[h], conf[h], h, h in carried_dirs))
+    rows.sort(reverse=True)
+
+    print("%-22s %10s %10s   %s" % ("directory", "published", "confirmed", "carried?"))
+    for total, p, c, h, ok in rows[:45]:
+        print("%-22s %10d %10d   %s" % (h, p, c, "yes" if ok else "  <-- NO"))
+
+    missing = [(t, p, c, h) for t, p, c, h, ok in rows if not ok]
+    print()
+    print("%d of %d observed directories are NOT carried, heading %d published "
+          "and %d confirmed names."
+          % (len(missing), len(allheads),
+             sum(m[1] for m in missing), sum(m[2] for m in missing)))
+    print()
+    print("uncarried directories, best first:")
+    for t, p, c, h in missing[:30]:
+        print("   %-22s published %8d   confirmed %8d" % (h, p, c))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/contributed/measure_token_order_20260824-232215.py
+++ b/scripts/contributed/measure_token_order_20260824-232215.py
@@ -1,0 +1,126 @@
+"""Is token ORDER a free parameter in these names, or is the convention positional?
+
+METHODS.md lists `token_order.py` under "Candidates worth building" with the check
+that decides it already written down:
+
+    permute two adjacent middle tokens. Nothing here reorders anything.
+    Measure: do any permutations of confirmed names already appear in the
+    tables? If none do, the convention is stable and this finds nothing.
+
+That is the whole measurement, and it is decisive in both directions:
+
+  * If swapping two adjacent middle tokens of a KNOWN name lands on ANOTHER
+    KNOWN name at any appreciable rate, then the naming does not fix token
+    order, both spellings get used, and every known name is a candidate
+    generator for a sibling nothing here can currently emit -- the general
+    search composes begin+stem+end and cannot reorder a middle, `slotswap`
+    substitutes a middle but preserves its position, `confirm_variants` only
+    moves numbers.
+
+  * If it essentially never happens, the convention is stable and the method is
+    dead. Writing that down costs the next contributor nothing and saves them
+    the build.
+
+Read-only: hashes nothing, writes nothing, prints a rate.
+"""
+import os, glob, random
+from collections import Counter
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# BO4/BOCW only -- the _v2 tables are other titles under the IW offset.
+PUBLISHED = ["fnv1a_xmaterials.csv", "fnv1a_ximages.csv",
+             "fnv1a_xmodels.csv", "fnv1a_xanims.csv"]
+GENERAL = ("image", "material", "xmodel", "xanim")
+
+# streamkey and the other low-value pools are excluded by name: they are
+# machine-generated and would swamp any rate measured here. See CLAUDE.md §5.
+SKIP_POOLS = {"streamkey", "xmodelmesh", "localizeentry"}
+
+
+def load():
+    names = set()
+    for fn in PUBLISHED:
+        p = os.path.join(REPO, "cod-name-db", "csv", fn)
+        if not os.path.exists(p):
+            continue
+        with open(p, "r", encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                line = line.rstrip("\r\n")
+                c = line.find(",")
+                if c >= 0:
+                    names.add(line[c + 1:])
+    confirmed = set()
+    for p in glob.glob(os.path.join(REPO, "findings", "*", "*.txt")):
+        pool = os.path.splitext(os.path.basename(p))[0]
+        if pool not in GENERAL or pool in SKIP_POOLS:
+            continue
+        with open(p, "r", encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                line = line.rstrip("\r\n")
+                if not line:
+                    continue
+                c = line.find(",")
+                confirmed.add(line[c + 1:] if c >= 0 else line)
+    return names, confirmed
+
+
+def middles_swapped(name):
+    """Yield the name with each adjacent pair of MIDDLE tokens transposed.
+
+    The first and last tokens are held fixed: the first carries the directory
+    and type code (`mc/mtl_`), the last is the channel/variant suffix, and both
+    are already reachable by begin/end composition. Only the middle is ground
+    nothing here can currently reorder.
+    """
+    parts = name.split("_")
+    if len(parts) < 4:
+        return
+    for i in range(1, len(parts) - 2):
+        if parts[i] == parts[i + 1]:
+            continue
+        swapped = parts[:i] + [parts[i + 1], parts[i]] + parts[i + 2:]
+        yield "_".join(swapped)
+
+
+def main():
+    published, confirmed = load()
+    known = published | confirmed
+    print("known names loaded: %d published, %d confirmed, %d distinct"
+          % (len(published), len(confirmed), len(known)))
+
+    # Measure on the confirmed corpus (what this project actually recovers) and
+    # on a sample of published, so a difference between the two shows up.
+    for label, corpus in (("confirmed", confirmed), ("published", published)):
+        pool = list(corpus)
+        if len(pool) > 120000:
+            random.seed(1234)
+            pool = random.sample(pool, 120000)
+        tried = hits = 0
+        eligible = 0
+        examples = []
+        for name in pool:
+            got = False
+            for perm in middles_swapped(name):
+                tried += 1
+                if perm in known and perm != name:
+                    hits += 1
+                    got = True
+                    if len(examples) < 10:
+                        examples.append((name, perm))
+            if got:
+                eligible += 1
+        if tried == 0:
+            print("%-10s no eligible names" % label)
+            continue
+        print()
+        print("%-10s %d names sampled, %d permutations tried, %d landed on a known name"
+              % (label, len(pool), tried, hits))
+        print("%-10s rate: 1 per %s permutations; %d names had at least one"
+              % ("", ("%.0f" % (tried / hits)) if hits else "never", eligible))
+        for a, b in examples:
+            print("     %s\n  -> %s" % (a, b))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/contributed/token_order_20260824-232215.py
+++ b/scripts/contributed/token_order_20260824-232215.py
@@ -1,0 +1,120 @@
+"""token_order -- the sibling that is the same words in the other order.
+
+METHODS.md listed this under "Candidates worth building" with the check that
+decides it: *do any permutations of confirmed names already appear in the
+tables? If none do, the convention is stable and this finds nothing.*
+
+Measured 2026-08-25 by `contrib/measure_token_order.py`:
+
+    confirmed corpus   57,066 names   300,906 transpositions   39 land on a known name
+    published corpus  120,000 names   609,779 transpositions   80 land on a known name
+
+i.e. **1 per ~7,700**, and the two corpora agree. So the naming does *not* fix
+token order -- both spellings genuinely ship -- and every known name is a seed
+for a sibling nothing in the registry can currently emit:
+
+  * the general search composes `beginning + stem + ending`, so it can replace a
+    head or a tail but never reorder a middle with both sides intact;
+  * `slotswap` (method 10) substitutes a middle token but preserves its slot;
+  * `confirm_variants` moves only numbers, and only in place;
+  * `token_edits` inserts and deletes, never transposes.
+
+**Reaches** pairs like these, all real, all already in the tables:
+
+    mc/t8_usa_snow_flat_02          <-> mc/t8_snow_usa_flat_02
+    wc/t7_concrete_worn_painted_white <-> wc/t7_concrete_painted_worn_white
+    i_c_t9_tape_duct_01_g           <-> i_c_t9_duct_tape_01_g
+    mc/mkg_fishing_net_01           <-> mc/mkg_net_fishing_01
+
+**Spent by** the corpus it is run over. Each name yields about five candidates,
+so the whole vocabulary is only single-digit millions of candidates -- cheap
+enough to re-run after any pass that grows the corpus (`derive_closure.py`).
+Once every name's transpositions have been tested against a fixed unnamed set,
+re-running finds nothing until new names land.
+
+This is an *edit*, not a cross product, so it prints names for `confirm_list`
+rather than describing a plan -- see `src/bin/confirm_plan.rs` on that split.
+
+    python contrib/token_order.py | bin\windows\confirm_list.exe - \
+        --label "token order transpositions" --script contrib/token_order.py
+"""
+import os, sys, glob
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# BO4/BOCW tables only. The _v2 tables are MWII/MWIII/BO6/BO7/WZM under the IW
+# offset and hashing their names against these games is measured dead.
+PUBLISHED = ["fnv1a_xmaterials.csv", "fnv1a_ximages.csv",
+             "fnv1a_xmodels.csv", "fnv1a_xanims.csv"]
+
+# Seed from the five wanted types only. streamkey/xmodelmesh/localizeentry are
+# machine-generated (CLAUDE.md §5) and would bury the real candidates.
+SEED_POOLS = ("image", "material", "xmodel", "xanim")
+
+
+def load_known():
+    known = set()
+    for fn in PUBLISHED:
+        p = os.path.join(REPO, "cod-name-db", "csv", fn)
+        if not os.path.exists(p):
+            continue
+        with open(p, "r", encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                line = line.rstrip("\r\n")
+                c = line.find(",")
+                if c >= 0:
+                    known.add(line[c + 1:])
+    # Both games seed each other: Cold War carries a great deal of Black Ops 4's
+    # content, and a name real in one is evidence about spelling in the other.
+    for p in glob.glob(os.path.join(REPO, "findings", "*", "*.txt")):
+        if os.path.splitext(os.path.basename(p))[0] not in SEED_POOLS:
+            continue
+        with open(p, "r", encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                line = line.rstrip("\r\n")
+                if not line:
+                    continue
+                c = line.find(",")
+                known.add(line[c + 1:] if c >= 0 else line)
+    return known
+
+
+def transpositions(name):
+    """Every adjacent MIDDLE-token transposition of `name`.
+
+    parts[0] carries the directory and type code (`mc/mtl`) and parts[-1] is the
+    channel or variant suffix (`_c`, `_dead`). Both ends are already reachable by
+    begin/end composition, so only the middle is new ground.
+    """
+    parts = name.split("_")
+    if len(parts) < 4:
+        return
+    for i in range(1, len(parts) - 2):
+        a, b = parts[i], parts[i + 1]
+        if a == b:
+            continue
+        yield "_".join(parts[:i] + [b, a] + parts[i + 2:])
+
+
+def main():
+    known = load_known()
+    emitted = set()
+    out = sys.stdout
+    n = 0
+    for name in known:
+        for cand in transpositions(name):
+            # A transposition that is itself already a known name is already
+            # named -- a hit on one is not a find. Drop them here so the
+            # candidate count means what it says.
+            if cand in known or cand in emitted:
+                continue
+            emitted.add(cand)
+            out.write(cand)
+            out.write("\n")
+            n += 1
+    sys.stderr.write("token_order: %d seed names -> %d distinct new candidates\n"
+                     % (len(known), n))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/contributed/wrapper_decorations_20260824-232215.py
+++ b/scripts/contributed/wrapper_decorations_20260824-232215.py
@@ -1,0 +1,254 @@
+"""Decorations that wrap a *whole* name, measured rather than listed.
+
+    python contrib/wrapper_decorations.py --write-plan plans/wrappers.txt
+    bin\\windows\\confirm_plan.exe plans/wrappers.txt --size
+    bin\\windows\\confirm_plan.exe plans/wrappers.txt
+
+## What this asks that nothing else does
+
+Every beginning-list method here crosses a beginning with a **core** -- a name with something
+trimmed off it. `uncarried.py` cuts at a segment boundary, `redecorations.py` ranks a beginning by
+how much of its vocabulary is borrowed, `mcdp/` won by being crossed with the whole material
+vocabulary rather than its own.
+
+This asks the narrower question those all step over: **which strings turn one entire known name
+into another entire known name.** `[korea15]` + `i_c_t8_zmb_ofc_hero_dempsey_jacket1_c` is a real
+image, and so is the name without it. Nothing is trimmed; the base name is carried whole.
+
+That makes the borrowed share `redecorations.py` ranks by **100% by construction** -- every
+instance counted is, by definition, a name we already hold wearing this decoration. The dead end
+recorded in METHODS.md for uncarried beginnings ("0 on Black Ops 4 and 7 on Cold War in 945 M
+candidates") is the opposite case: beginnings crossed with a vocabulary that was never theirs. The
+note closing it says to rank by borrowed share first, and this is that ranking taken to its limit.
+
+## Measured on 2026-08-23, over 1,521,504 known names
+
+4,893 distinct strings wrap one known name into another. 309 of them are absent from
+`data/prefixes.txt` at three instances or more, so no general pass can build them:
+
+    mcdp/mtl_          385     the one already mined -- 2,846 names on 2026-08-23
+    [korea15]          151     a regional build variant. 151 of 151 base names are known
+    paintjob_          132
+    mc/mtl_menu_        77
+    mc/mtl_wpn_t9_      70
+    [japanese]          39     39 of 39 base names known
+    img_trim_           31
+    ui_icon_mtx_tier_   30
+
+`[korea15]`, `[japanese]` and `[safe]` are worth calling out because they are invisible to every
+character-level method in the project as well: `[` occurs in no name's last four characters, so the
+alphabet `tails.py` measures cannot spell them from either end.
+
+The cost is one beginning list against the corpus -- 309 x 1.5 M, about 470 M candidates, seconds
+of engine time. `--min` moves the threshold; `--suffix` measures the mirror, decorations that wrap
+a name at the *end*, which is a much longer list (8,059 boundary-anchored at fifteen instances) and
+overlaps the uncarried-endings methods already run.
+"""
+import argparse
+import collections
+import os
+import sys
+
+_root = os.path.dirname(os.path.abspath(__file__))
+while _root != os.path.dirname(_root) and not os.path.isfile(
+    os.path.join(_root, "scripts", "snapshot.py")
+):
+    _root = os.path.dirname(_root)
+sys.path.insert(0, os.path.join(_root, "scripts"))
+
+import snapshot
+
+TABLES = (
+    "fnv1a_xmodels",
+    "fnv1a_xmaterials",
+    "fnv1a_ximages",
+    "fnv1a_xanims",
+    "fnv1a_soundbanks_aliases",
+)
+
+# A decoration longer than this is a name in its own right rather than a wrapper, and the count of
+# base names that could wear it falls to one or two.
+LONGEST = 20
+
+# Below this a decoration is a coincidence of two names sharing a tail, not a convention.
+SHORTEST_BASE = 4
+
+
+def known_names():
+    names = []
+    for table in TABLES:
+        names += snapshot.table_names(table)
+    names += snapshot.confirmed_names()
+    return {name.strip().lower().replace("\\", "/") for name in names if name.strip()}
+
+
+def carried(filename):
+    path = os.path.join(_root, "data", filename)
+    with open(path, encoding="utf-8") as handle:
+        return {line.strip().lower() for line in handle if line.strip()}
+
+
+# The characters a name's segments are divided at. `|` is here because `|dup` is a real material
+# convention and nothing else in this repository treats it as a boundary.
+BOUNDARIES = "_/.|-"
+
+
+def all_boundary_cores(names):
+    """Every prefix of every known name that stops at a segment boundary, plus the whole name.
+
+    Method 25 measured this as the right way to cut cores -- a core five segments deep can then
+    wear an ending observed on a name of a different depth -- and it beat cutting at one boundary
+    while using five times fewer endings.
+    """
+    cores = set()
+    for name in names:
+        cores.add(name)
+        for at, character in enumerate(name):
+            if character in BOUNDARIES and at >= SHORTEST_BASE:
+                cores.add(name[:at])
+    return sorted(cores)
+
+
+def measure(names, suffix):
+    """{decoration: how many known names it wraps into another known name}."""
+    counted = collections.Counter()
+    for name in names:
+        for length in range(1, min(LONGEST, len(name) - SHORTEST_BASE) + 1):
+            base = name[:-length] if suffix else name[length:]
+            if base in names:
+                counted[name[-length:] if suffix else name[:length]] += 1
+    return counted
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--min", type=int, default=3, help="fewest instances to carry")
+    parser.add_argument(
+        "--suffix",
+        action="store_true",
+        help="measure decorations that wrap the END of a name instead of the front",
+    )
+    parser.add_argument(
+        "--cores",
+        action="store_true",
+        help="offer the decorations to every all-boundary core rather than to whole names only",
+    )
+    parser.add_argument(
+        "--plus-char",
+        action="store_true",
+        help="carry each decoration with one further character after it, aimed at families whose"
+        " every member is unnamed",
+    )
+    parser.add_argument("--write-plan", metavar="PATH", required=True)
+    options = parser.parse_args(argv)
+
+    names = known_names()
+    print("known names: %s" % format(len(names), ","), file=sys.stderr)
+
+    already = carried("suffixes.txt" if options.suffix else "prefixes.txt")
+    counted = measure(names, options.suffix)
+    decorations = sorted(
+        (
+            decoration
+            for decoration, count in counted.items()
+            if count >= options.min and decoration not in already
+        ),
+        key=lambda decoration: (-counted[decoration], decoration),
+    )
+
+    print(
+        "%s decorations found: %s   uncarried at >=%d instances: %s"
+        % (
+            "suffix" if options.suffix else "prefix",
+            format(len(counted), ","),
+            options.min,
+            format(len(decorations), ","),
+        ),
+        file=sys.stderr,
+    )
+    for decoration in decorations[:12]:
+        print("    %-24s %6d" % (decoration, counted[decoration]), file=sys.stderr)
+
+    if not decorations:
+        raise SystemExit("nothing uncarried at this threshold; lower --min")
+
+    if options.plus_char:
+        # Aimed at the families the final-byte solve cannot see. Bucketing every unnamed id by
+        # `(id * prime_inverse) >> 8` -- which is `h(prefix) >> 8`, because the last byte only
+        # ever touches the low eight bits -- groups the ids that are one name differing in its
+        # last character. Measured 2026-08-23: 25.96% of Cold War's unnamed ids and 20.52% of
+        # Black Ops 4's share such a bucket with another *unnamed* id, in families of up to 29.
+        # `final_byte` needs one member already named and so reaches none of them; carrying a
+        # further character after each decoration reaches the whole family at once.
+        alphabet = ending_characters(names)
+        decorations = [
+            decoration + character for decoration in decorations for character in alphabet
+        ]
+        print(
+            "carrying one further character (%d of them): %s endings"
+            % (len(alphabet), format(len(decorations), ",")),
+            file=sys.stderr,
+        )
+
+    base = os.path.splitext(options.write_plan)[0]
+    side = "endings" if options.suffix else "beginnings"
+    stem_path, dec_path = base + ".stems.txt", "%s.%s.txt" % (base, side)
+    stems = all_boundary_cores(names) if options.cores else sorted(names)
+    if options.cores:
+        print("all-boundary cores: %s" % format(len(stems), ","), file=sys.stderr)
+    for path, rows in ((stem_path, stems), (dec_path, decorations)):
+        with open(path, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write("\n".join(rows) + "\n")
+
+    def relative(path):
+        return os.path.relpath(path, _root).replace("\\", "/")
+
+    with open(options.write_plan, "w", encoding="utf-8", newline="\n") as handle:
+        handle.write(
+            "# Written by contrib/wrapper_decorations.py%s. Regenerate rather than editing.\n"
+            "#\n"
+            "# Decorations measured to turn one WHOLE known name into another whole known name,\n"
+            "# kept only where data/%s cannot express them, against every name we hold.\n"
+            "# Borrowed share is 100%% by construction -- see this script's docstring.\n"
+            "\n"
+            "label: wrapper decorations, %s side\n"
+            "describe: strings measured to wrap one entire known name into another entire known name and absent from the carried list, against the whole corpus uncut\n"
+            "\n"
+            "stem: @%s\n"
+            "\n"
+            "%s: @%s\n"
+            "\n"
+            "bare: %s\n"
+            "fold: yes\n"
+            % (
+                " --suffix" if options.suffix else "",
+                "suffixes.txt" if options.suffix else "prefixes.txt",
+                "suffix" if options.suffix else "prefix",
+                relative(stem_path),
+                "end" if options.suffix else "begin",
+                relative(dec_path),
+                # `bare` flips meaning between the two sides, and getting it wrong does not fail
+                # loudly. With the decorations in the `begin` column they are the only opening the
+                # plan has, so the bare stem must stay out. With them in the `end` column there is
+                # no `begin` line at all, and `bare: yes` is what supplies the empty one.
+                "yes" if options.suffix else "no",
+            )
+        )
+
+    print(
+        "wrote %s\n      %s (%s stems)\n      %s (%s decorations)\n\nabout %s candidates."
+        % (
+            options.write_plan,
+            stem_path,
+            format(len(stems), ","),
+            dec_path,
+            format(len(decorations), ","),
+            format(len(stems) * len(decorations), ","),
+        ),
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/submissions/GoastcraftHD_BLKOPSCW_20260824-232215/about_20260824-232215.md
+++ b/submissions/GoastcraftHD_BLKOPSCW_20260824-232215/about_20260824-232215.md
@@ -1,0 +1,36 @@
+# Submission 20260824-232215
+
+- game: **BLKOPSCW**
+- from: GoastcraftHD
+- names: 2
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- material: 1
+- xmodel: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 21 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260824-232128_list
+- method: token order transpositions
+- what it does: a candidate list generated outside the search and confirmed here
+- ran for: 12s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- candidates tested: 4476072
+- matched: 2
+- new: 2
+- sketch stems: 0000003e34caf53b000001bb97e7b5700000061c2655b6a90000088fe9ef9f2800000b0afa0310f5000011cdab744033000013105adc01ee000014ad7c67921b0000181a23374128000019fb5b609bf500001a55b3b3560f00001daa4bf43df2000022767a7a0c9d000023afc12b920a0000304c210b1ab30000326e24c9b14d0000369baae0402800003c1fa5a904b900003f309976357d00003fa942c27201000043ac17e0db90000047e80f7fa0b4000048fbbc913b5f00004ad3f867c9e400004c652481835800004ec0b734369800004efddafa307800005012a4d75c8e000054796e10053600005815b0a481a7000059139cdce834000061cf57ed4af8
+- ids hunted: 124972
+- throughput: 0.7M candidates/s
+- fingerprint: 9ab35c6159133b9e
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/GoastcraftHD_BLKOPSCW_20260824-232215/material_20260824-232215.txt
+++ b/submissions/GoastcraftHD_BLKOPSCW_20260824-232215/material_20260824-232215.txt
@@ -1,0 +1,1 @@
+47a5252958bcc63f,mc/mtl_p9_ech_wall_concrete_break_01_basics

--- a/submissions/GoastcraftHD_BLKOPSCW_20260824-232215/xmodel_20260824-232215.txt
+++ b/submissions/GoastcraftHD_BLKOPSCW_20260824-232215/xmodel_20260824-232215.txt
@@ -1,0 +1,1 @@
+1535f9628ea48222,p9_ech_wall_concrete_break_01


### PR DESCRIPTION
**BLKOPSCW** — 2 asset names, confirmed against that game's own loaded assets.

- material: 1
- xmodel: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @GoastcraftHD

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260824-232128_list
- method: token order transpositions
- what it does: a candidate list generated outside the search and confirmed here
- ran for: 12s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- candidates tested: 4476072
- matched: 2
- new: 2
- sketch stems: 0000003e34caf53b000001bb97e7b5700000061c2655b6a90000088fe9ef9f2800000b0afa0310f5000011cdab744033000013105adc01ee000014ad7c67921b0000181a23374128000019fb5b609bf500001a55b3b3560f00001daa4bf43df2000022767a7a0c9d000023afc12b920a0000304c210b1ab30000326e24c9b14d0000369baae0402800003c1fa5a904b900003f309976357d00003fa942c27201000043ac17e0db90000047e80f7fa0b4000048fbbc913b5f00004ad3f867c9e400004c652481835800004ec0b734369800004efddafa307800005012a4d75c8e000054796e10053600005815b0a481a7000059139cdce834000061cf57ed4af8
- ids hunted: 124972
- throughput: 0.7M candidates/s
- fingerprint: 9ab35c6159133b9e

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/anim_transitions_20260823-043549.py`
- `scripts/contributed/anim_transitions_20260823-043549.txt`
- `scripts/contributed/blkops04_dbl_begins_20260823-035618.txt`
- `scripts/contributed/blkops04_dbl_ends_20260823-035618.txt`
- `scripts/contributed/blkops04_sndtails_stems_20260823-030223.txt`
- `scripts/contributed/blkopscw_sound_asset_dirs_20260823-030223.txt`
- `scripts/contributed/bo3_cores_20260822-025123.py`
- `scripts/contributed/bo3_respell_20260822-024314.py`
- `scripts/contributed/bo3_sab_to_bo4_20260823-030223.py`
- `scripts/contributed/bo3_snd_dirs_20260823-030223.txt`
- `scripts/contributed/bo3_snd_tails_20260823-030223.txt`
- `scripts/contributed/bo4_snd_dirs_20260823-030223.txt`
- `scripts/contributed/bo4_sounds_20260823-030223.py`
- `scripts/contributed/chan_ends_20260823-043005.txt`
- `scripts/contributed/cwmix_dirs_20260823-030223.txt`
- `scripts/contributed/cwmix_ends_20260823-030223.txt`
- `scripts/contributed/cwmix_tails_20260823-030223.txt`
- `scripts/contributed/cwtakes_dirs_20260823-030223.txt`
- `scripts/contributed/cwtakes_ends_20260823-030223.txt`
- `scripts/contributed/double_uncarried_20260823-035618.py`
- `scripts/contributed/harvest_bo3_20260822-030351.py`
- `scripts/contributed/heads_measured_alphabet_20260823-204820.py`
- `scripts/contributed/image_channels_wide_20260823-043005.py`
- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/mat_dirs13_20260823-043549.txt`
- `scripts/contributed/mcdp_cores_20260823-023310.py`
- `scripts/contributed/measure_material_dirs_20260824-232215.py`
- `scripts/contributed/measure_token_order_20260824-232215.py`
- `scripts/contributed/numeric_endings_20260823-044152.py`
- `scripts/contributed/old_title_decorations_20260823-213526.py`
- `scripts/contributed/redecorations_20260823-023757.py`
- `scripts/contributed/sound_tails_20260823-030223.py`
- `scripts/contributed/sound_takes_20260823-030223.py`
- `scripts/contributed/speaker_grids_20260822-021342.py`
- `scripts/contributed/symbol_tails_20260823-213145.py`
- `scripts/contributed/token_order_20260824-232215.py`
- `scripts/contributed/uncarried_begins_20260823-023757.txt`
- `scripts/contributed/uncarried_endings_20260823-040620.py`
- `scripts/contributed/wrapper_decorations_20260824-232215.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.