### PR TITLE
[BLKOPSCW] findings from GoastcraftHD, 20260824-232748 (2 names)

### DIFF
--- a/scripts/contributed/bo2_ipak_typed_20260824-232748.py
+++ b/scripts/contributed/bo2_ipak_typed_20260824-232748.py
@@ -1,0 +1,62 @@
+"""bo2_ipak as a TYPED image corpus for the typed cross (method 18).
+
+`borrowed/bo2_ipak.txt` is 10,677 Black Ops 2 image-package names. METHODS.md
+records it dead -- but dead *verbatim*, in the row that hashed
+
+    bo2_ipak, cod_constants, cod_semantics, cod_techsets, fnv1a_strings,
+    944,345 names: 0
+
+and method 18 is precisely the finding that **verbatim is the wrong test**. The
+`_v2` tables are recorded dead the same way -- "all eight, 1,175,524 names hashed
+verbatim against 336,505 unnamed ids, zero" -- and typed they returned hundreds,
+because nothing about the corpus changed, "only whether an image core was asked
+to wear image decorations".
+
+`bo2_ipak` has never been tried typed, and it is the cleanest typed corpus on the
+disk: an ipak *is* an image package, so every row is an image with no
+classification needed and no community content mixed in. Its structure is the
+familiar one a generation earlier --
+
+    p6_...                 the map prefix, one generation before p7_/p8_/p9_
+    em_bg_wpn_attach_...   attachment emblem backgrounds
+    mtl_..., hud_..., menu_..., veh_..., zm_...
+
+-- so its cores are exactly the kind of thing Black Ops 4 and Cold War reuse.
+
+Emits a `type,name` manifest on stdout for `scripts/typed_cross.py --source`.
+
+    python contrib/bo2_ipak_typed.py > plans/bo2_ipak.manifest.csv
+    python scripts/typed_cross.py --source plans/bo2_ipak.manifest.csv \
+        --write-plans plans/bo2ipak
+    bin\windows\confirm_plan.exe plans/bo2ipak.image.txt --size
+"""
+import os, sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SRC = os.path.join(REPO, "borrowed", "bo2_ipak.txt")
+
+
+def main():
+    out = sys.stdout
+    kept = dropped = 0
+    with open(SRC, "r", encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            name = line.rstrip("\r\n").strip()
+            if not name:
+                continue
+            # `*lightmap0_secondary` and friends are generated per-map images,
+            # named from map content rather than from vocabulary. They are the
+            # ipak equivalent of a streamkey and carry nothing transferable.
+            if name.startswith("*"):
+                dropped += 1
+                continue
+            kept += 1
+            out.write("image,")
+            out.write(name)
+            out.write("\n")
+    sys.stderr.write("bo2_ipak_typed: %d image rows (%d generated names dropped)\n"
+                     % (kept, dropped))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/contributed/measure_normalisation_20260824-232748.py
+++ b/scripts/contributed/measure_normalisation_20260824-232748.py
@@ -1,0 +1,113 @@
+"""Does every pool really normalise the same way? Test case and slash, per pool.
+
+CLAUDE.md §6 states the rule: the name is **lower cased, and backslash folded to
+forward slash**, then FNV-1a 64, compared at 63 bits. §5 then records the one
+place that rule is wrong -- Black Ops 4 `sound_asset` ids are the hash of the
+name with its backslashes INTACT (8,385 of 8,385 reproduce unfolded, 0 folded),
+and until somebody found that, the largest pool in either game matched nothing
+"while looking perfectly healthy".
+
+That was one normalisation rule hiding one whole pool. This asks the obvious
+next question nobody has: **is any pool hiding behind the OTHER half of the
+rule -- the lower casing?** And is any other pool unfolded like BO4 sound?
+
+The test is decisive and costs nothing, because we already hold the answer key:
+`all_names/<game>/<type>.txt` is `id,name` for names whose ids are known. So for
+every pool, hash its known names four ways and count which variant reproduces
+the stored id:
+
+    fold+lower   the documented rule
+    fold only    case preserved
+    lower only   backslashes intact  <- the BO4 sound_asset case
+    neither
+
+A pool where "fold+lower" scores 100% is confirmed normal. A pool where some
+other variant wins is a pool whose ids nothing here can currently reach.
+
+Read-only: reads name lists, prints a table, writes nothing.
+"""
+import os, glob
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+BASIS = 0xCBF29CE484222325
+PRIME = 0x100000001B3
+MASK64 = (1 << 64) - 1
+MASK63 = (1 << 63) - 1
+
+
+def fnv1a(data):
+    h = BASIS
+    for b in data:
+        h ^= b
+        h = (h * PRIME) & MASK64
+    return h
+
+
+VARIANTS = (
+    ("fold+lower", True, True),
+    ("fold only", True, False),
+    ("lower only", False, True),
+    ("neither", False, False),
+)
+
+
+def hashed(name, fold, lower):
+    s = name
+    if fold:
+        s = s.replace("\\", "/")
+    if lower:
+        s = s.lower()
+    return fnv1a(s.encode("utf-8", "replace")) & MASK63
+
+
+def main():
+    print("%-10s %-13s %8s  %s" % ("game", "pool", "names", "which normalisation reproduces the id"))
+    print("-" * 92)
+    for gamedir in sorted(glob.glob(os.path.join(REPO, "all_names", "*"))):
+        if not os.path.isdir(gamedir):
+            continue
+        game = os.path.basename(gamedir)
+        for path in sorted(glob.glob(os.path.join(gamedir, "*.txt"))):
+            pool = os.path.splitext(os.path.basename(path))[0]
+            scores = {v[0]: 0 for v in VARIANTS}
+            total = 0
+            has_backslash = 0
+            has_upper = 0
+            with open(path, "r", encoding="utf-8", errors="replace") as fh:
+                for line in fh:
+                    line = line.rstrip("\r\n")
+                    if not line:
+                        continue
+                    c = line.find(",")
+                    if c < 0:
+                        continue
+                    try:
+                        want = int(line[:c], 16) & MASK63
+                    except ValueError:
+                        continue
+                    name = line[c + 1:]
+                    total += 1
+                    if "\\" in name:
+                        has_backslash += 1
+                    if name != name.lower():
+                        has_upper += 1
+                    for label, fold, lower in VARIANTS:
+                        if hashed(name, fold, lower) == want:
+                            scores[label] += 1
+            if not total:
+                continue
+            best = max(scores.items(), key=lambda kv: kv[1])
+            detail = "  ".join("%s %5.1f%%" % (lab, 100.0 * scores[lab] / total)
+                               for lab, _, _ in VARIANTS)
+            flag = ""
+            if best[1] < total:
+                flag = "   <-- %d of %d unexplained" % (total - best[1], total)
+            print("%-10s %-13s %8d  %s%s" % (game, pool, total, detail, flag))
+            if has_backslash or has_upper:
+                print("%-10s %-13s %8s  (%d names carry a backslash, %d carry upper case)"
+                      % ("", "", "", has_backslash, has_upper))
+
+
+if __name__ == "__main__":
+    main()

--- a/submissions/GoastcraftHD_BLKOPSCW_20260824-232748/about_20260824-232748.md
+++ b/submissions/GoastcraftHD_BLKOPSCW_20260824-232748/about_20260824-232748.md
@@ -1,0 +1,38 @@
+# Submission 20260824-232748
+
+- game: **BLKOPSCW**
+- from: GoastcraftHD
+- names: 2
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- image: 2
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 23 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260824-232623_plan
+- method: image cores borrowed, image decorations measured
+- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
+- ran for: 45s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- beginnings: 250
+- endings: 1200
+- stems: 7446
+- ids hunted: 124972
+- candidates tested: 2235661500
+- new: 2
+- sketch beginnings: 004037bfc6e4b6d500964b7b60e9b8a003de25cbb3445ea703f88180dfe7ae63045bcb01475b6381052211a042611ba207b9b45130b0dc910cf1339af0e750fc0e8cc75b217099260ed1904edccd3fe010642c7cec3821f8112ce61f5bcf54ce118aee5b1b8842c611a6f123b67debc5126a996037287f7d12fa6c72a303b39613cc3dfe91ce33d813ffd1adc362ad43154dd53d7614845415b9ceb43ca7f5a3166b62c93f781b421701c895e02adff0190c63fa2163dbef19d54d0e5d9347d51b41eee51593c9861c0dee6a6d419ba91fb5bf7e0755bb94210f77cfa666328a22184586e87e041322c56cbb2db8b6532417a41bde824908267fb0e5b531435b
+- sketch stems: 00097043c70cb7f0000ab115a9ca3129000d320a06dfd3310017f316f74016080027a6449dc23ef4002dc96c08a2e8d60045395c3b47ff85005b400475fff4750088b75a2f3b34e3009267ece0cc0d6b009967ceecd05b13009b3b8e6352943f00ab51144275661d00ab5dd3cfd3f58100b629551ee9569400b7361822d24a8400bc42abed3e1cd800c3af27b672be1200d08d52055b4cd300d19f4fe3d3379200d95bd6c808cb3400f52ed117d602ab0113e5625ad424ba0114442ce68427b20118adc2daab39be01243424e31ddd7201337db20e5414fd0134afb54887f1f1013e3062f8ed299301406f32c5f86ae00144f9c3d9cf44e40151ab83fb9ed5ab
+- sketch endings: 0021ad1c1ec693070061e60e1b193b3a006ef56eb12e99de009072d9a0fdb05600dfa82e1d4a4b240122426a4c250c790186a019561fbcde018b82996934426701b2b53ee592a84b01d840291efc869d021e0284837e616c025f7de0512cd85a02ac31368bc9f24102c71debb019b26a03531b1631d7150a03887a375cd1ac5603e840a9d79da95e046967dbacce40f7047c050db6c1792104fa42c08ac8950d051e47d323b43413053b6107615c399d057033defc48776d057bc21d16d04d65057d9cf5440830f00599cd5985585f2c05ce03d301bb4d2705d0bbe9840c240505f5669c641a3b89061356ad6c960fde065ac1170e4bf5cf06863fad8c902517
+- fingerprint: 19903682104d8c82
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/GoastcraftHD_BLKOPSCW_20260824-232748/image_20260824-232748.txt
+++ b/submissions/GoastcraftHD_BLKOPSCW_20260824-232748/image_20260824-232748.txt
@@ -1,0 +1,2 @@
+31ee677e6e326184,ui_icon_medal_playmaker_large
+735a3c0aade64e08,ui_icon_medal_playmaker


### PR DESCRIPTION
**BLKOPSCW** — 2 asset names, confirmed against that game's own loaded assets.

- image: 2

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @GoastcraftHD

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260824-232623_plan
- method: image cores borrowed, image decorations measured
- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
- ran for: 45s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- beginnings: 250
- endings: 1200
- stems: 7446
- ids hunted: 124972
- candidates tested: 2235661500
- new: 2
- sketch beginnings: 004037bfc6e4b6d500964b7b60e9b8a003de25cbb3445ea703f88180dfe7ae63045bcb01475b6381052211a042611ba207b9b45130b0dc910cf1339af0e750fc0e8cc75b217099260ed1904edccd3fe010642c7cec3821f8112ce61f5bcf54ce118aee5b1b8842c611a6f123b67debc5126a996037287f7d12fa6c72a303b39613cc3dfe91ce33d813ffd1adc362ad43154dd53d7614845415b9ceb43ca7f5a3166b62c93f781b421701c895e02adff0190c63fa2163dbef19d54d0e5d9347d51b41eee51593c9861c0dee6a6d419ba91fb5bf7e0755bb94210f77cfa666328a22184586e87e041322c56cbb2db8b6532417a41bde824908267fb0e5b531435b
- sketch stems: 00097043c70cb7f0000ab115a9ca3129000d320a06dfd3310017f316f74016080027a6449dc23ef4002dc96c08a2e8d60045395c3b47ff85005b400475fff4750088b75a2f3b34e3009267ece0cc0d6b009967ceecd05b13009b3b8e6352943f00ab51144275661d00ab5dd3cfd3f58100b629551ee9569400b7361822d24a8400bc42abed3e1cd800c3af27b672be1200d08d52055b4cd300d19f4fe3d3379200d95bd6c808cb3400f52ed117d602ab0113e5625ad424ba0114442ce68427b20118adc2daab39be01243424e31ddd7201337db20e5414fd0134afb54887f1f1013e3062f8ed299301406f32c5f86ae00144f9c3d9cf44e40151ab83fb9ed5ab
- sketch endings: 0021ad1c1ec693070061e60e1b193b3a006ef56eb12e99de009072d9a0fdb05600dfa82e1d4a4b240122426a4c250c790186a019561fbcde018b82996934426701b2b53ee592a84b01d840291efc869d021e0284837e616c025f7de0512cd85a02ac31368bc9f24102c71debb019b26a03531b1631d7150a03887a375cd1ac5603e840a9d79da95e046967dbacce40f7047c050db6c1792104fa42c08ac8950d051e47d323b43413053b6107615c399d057033defc48776d057bc21d16d04d65057d9cf5440830f00599cd5985585f2c05ce03d301bb4d2705d0bbe9840c240505f5669c641a3b89061356ad6c960fde065ac1170e4bf5cf06863fad8c902517
- fingerprint: 19903682104d8c82

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/anim_transitions_20260823-043549.py`
- `scripts/contributed/anim_transitions_20260823-043549.txt`
- `scripts/contributed/blkops04_dbl_begins_20260823-035618.txt`
- `scripts/contributed/blkops04_dbl_ends_20260823-035618.txt`
- `scripts/contributed/blkops04_sndtails_stems_20260823-030223.txt`
- `scripts/contributed/blkopscw_sound_asset_dirs_20260823-030223.txt`
- `scripts/contributed/bo2_ipak_typed_20260824-232748.py`
- `scripts/contributed/bo3_cores_20260822-025123.py`
- `scripts/contributed/bo3_respell_20260822-024314.py`
- `scripts/contributed/bo3_sab_to_bo4_20260823-030223.py`
- `scripts/contributed/bo3_snd_dirs_20260823-030223.txt`
- `scripts/contributed/bo3_snd_tails_20260823-030223.txt`
- `scripts/contributed/bo4_snd_dirs_20260823-030223.txt`
- `scripts/contributed/bo4_sounds_20260823-030223.py`
- `scripts/contributed/chan_ends_20260823-043005.txt`
- `scripts/contributed/cwmix_dirs_20260823-030223.txt`
- `scripts/contributed/cwmix_ends_20260823-030223.txt`
- `scripts/contributed/cwmix_tails_20260823-030223.txt`
- `scripts/contributed/cwtakes_dirs_20260823-030223.txt`
- `scripts/contributed/cwtakes_ends_20260823-030223.txt`
- `scripts/contributed/double_uncarried_20260823-035618.py`
- `scripts/contributed/harvest_bo3_20260822-030351.py`
- `scripts/contributed/heads_measured_alphabet_20260823-204820.py`
- `scripts/contributed/image_channels_wide_20260823-043005.py`
- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/mat_dirs13_20260823-043549.txt`
- `scripts/contributed/mcdp_cores_20260823-023310.py`
- `scripts/contributed/measure_material_dirs_20260824-232215.py`
- `scripts/contributed/measure_normalisation_20260824-232748.py`
- `scripts/contributed/measure_token_order_20260824-232215.py`
- `scripts/contributed/numeric_endings_20260823-044152.py`
- `scripts/contributed/old_title_decorations_20260823-213526.py`
- `scripts/contributed/redecorations_20260823-023757.py`
- `scripts/contributed/sound_tails_20260823-030223.py`
- `scripts/contributed/sound_takes_20260823-030223.py`
- `scripts/contributed/speaker_grids_20260822-021342.py`
- `scripts/contributed/symbol_tails_20260823-213145.py`
- `scripts/contributed/token_order_20260824-232215.py`
- `scripts/contributed/uncarried_begins_20260823-023757.txt`
- `scripts/contributed/uncarried_endings_20260823-040620.py`
- `scripts/contributed/wrapper_decorations_20260824-232215.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.