### PR TITLE
[BLKOPSCW] findings from GoastcraftHD, 20260825-010822 (1 names)

### DIFF
--- a/scripts/contributed/measure_tail_alphabet_20260825-010822.py
+++ b/scripts/contributed/measure_tail_alphabet_20260825-010822.py
@@ -1,0 +1,113 @@
+"""What characters actually occur in the last few characters of a name?
+
+`tails.py` enumerates every k-character string over one alphabet of 37 characters
+-- the ones names end in -- which is what makes the ladder explode: k=4 is 1.87 M
+endings, k=5 is 69.3 M and about 42 T candidates, a seven-hour pass per game.
+
+But that alphabet is measured over the last character only and then applied to
+all k positions, and the positions are not alike. The final character of a name
+is a channel code or a digit; five from the end is far more often `_`. Enumerating
+all 37 at every position spends most of the pass on strings the naming never
+produces.
+
+So this measures the alphabet **per position**, and reports how small a set covers
+99% / 99.9% of real names at each one. The product of those per-position sizes is
+what a position-aware k=5 would actually cost.
+
+Read-only. Prints a table.
+"""
+import os, glob, sys
+from collections import Counter
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PUBLISHED = ["fnv1a_xmaterials.csv", "fnv1a_ximages.csv",
+             "fnv1a_xmodels.csv", "fnv1a_xanims.csv"]
+GENERAL = ("image", "material", "xmodel", "xanim")
+K = 5
+
+
+def load():
+    names = set()
+    for fn in PUBLISHED:
+        p = os.path.join(REPO, "cod-name-db", "csv", fn)
+        if not os.path.exists(p):
+            continue
+        with open(p, encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                line = line.rstrip("\r\n")
+                c = line.find(",")
+                if c >= 0:
+                    names.add(line[c + 1:])
+    for p in glob.glob(os.path.join(REPO, "findings", "*", "*.txt")):
+        if os.path.splitext(os.path.basename(p))[0] not in GENERAL:
+            continue
+        with open(p, encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                line = line.rstrip("\r\n")
+                if not line:
+                    continue
+                c = line.find(",")
+                names.add(line[c + 1:] if c >= 0 else line)
+    return names
+
+
+def cover(counter, share):
+    """Smallest set of characters covering `share` of occurrences."""
+    total = sum(counter.values())
+    got, chars = 0, []
+    for ch, n in counter.most_common():
+        chars.append(ch)
+        got += n
+        if got >= total * share:
+            break
+    return chars
+
+
+def main():
+    names = [n for n in load() if len(n) >= K]
+    sys.stderr.write("names of length >= %d: %d\n" % (K, len(names)))
+
+    per_pos = [Counter() for _ in range(K)]
+    for n in names:
+        for j in range(K):
+            per_pos[j][n[-(j + 1)]] += 1
+
+    print("position 0 = the final character, %d = %d from the end" % (K - 1, K - 1))
+    print()
+    print("%-10s %8s %10s %10s   %s" % ("position", "distinct", "99% needs", "99.9% needs", "commonest"))
+    sizes99, sizes999 = [], []
+    for j in range(K):
+        c99 = cover(per_pos[j], 0.99)
+        c999 = cover(per_pos[j], 0.999)
+        sizes99.append(len(c99))
+        sizes999.append(len(c999))
+        top = "".join(ch for ch, _ in per_pos[j].most_common(12))
+        print("%-10d %8d %10d %10d   %r" % (j, len(per_pos[j]), len(c99), len(c999), top))
+
+    full = 1
+    for j in range(K):
+        full *= len(per_pos[j])
+    p99 = 1
+    for s in sizes99:
+        p99 *= s
+    p999 = 1
+    for s in sizes999:
+        p999 *= s
+
+    print()
+    print("k=%d endings, all characters seen at each position: %s" % (K, "{:,}".format(full)))
+    print("k=%d endings, 99%%   alphabet per position:          %s  (%.1fx cheaper)"
+          % (K, "{:,}".format(p99), full / float(p99)))
+    print("k=%d endings, 99.9%% alphabet per position:          %s  (%.1fx cheaper)"
+          % (K, "{:,}".format(p999), full / float(p999)))
+    print()
+    print("one flat alphabet of 37 at every position (what tails.py does): %s"
+          % "{:,}".format(37 ** K))
+    print()
+    print("the 99%% alphabets, position %d..0 (deepest first) -- this is the ending set:" % (K - 1))
+    for j in range(K - 1, -1, -1):
+        print("   pos %d  %r" % (j, "".join(sorted(cover(per_pos[j], 0.99)))))
+
+
+if __name__ == "__main__":
+    main()

--- a/submissions/GoastcraftHD_BLKOPSCW_20260825-010822/about_20260825-010822.md
+++ b/submissions/GoastcraftHD_BLKOPSCW_20260825-010822/about_20260825-010822.md
@@ -1,0 +1,21 @@
+# Submission 20260825-010822
+
+- game: **BLKOPSCW**
+- from: GoastcraftHD
+- names: 1
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: not recorded (run predates this field)
+- confirmed on: not recorded (run predates this field)
+- material: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 30 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260825-010743_recovered
+- method: not recorded (an older or interrupted run)

--- a/submissions/GoastcraftHD_BLKOPSCW_20260825-010822/material_20260825-010822.txt
+++ b/submissions/GoastcraftHD_BLKOPSCW_20260825-010822/material_20260825-010822.txt
@@ -1,0 +1,1 @@
+26c905620c59a77c,mcs/mtl_p9_ech_cable_protector_set_01_rubber_01


### PR DESCRIPTION
**BLKOPSCW** — 1 asset names, confirmed against that game's own loaded assets.

- material: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @GoastcraftHD

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260825-010743_recovered
- method: not recorded (an older or interrupted run)


## Tooling this run leaves behind

- `scripts/contributed/anim_transitions_20260823-043549.py`
- `scripts/contributed/anim_transitions_20260823-043549.txt`
- `scripts/contributed/blkops04_dbl_begins_20260823-035618.txt`
- `scripts/contributed/blkops04_dbl_ends_20260823-035618.txt`
- `scripts/contributed/blkops04_sndtails_stems_20260823-030223.txt`
- `scripts/contributed/blkopscw_sound_asset_dirs_20260823-030223.txt`
- `scripts/contributed/bo2_ipak_typed_20260824-232748.py`
- `scripts/contributed/bo3_build_sounds_20260824-233745.py`
- `scripts/contributed/bo3_build_to_bo4_sounds_20260824-233745.py`
- `scripts/contributed/bo3_cores_20260822-025123.py`
- `scripts/contributed/bo3_respell_20260822-024314.py`
- `scripts/contributed/bo3_sab_to_bo4_20260823-030223.py`
- `scripts/contributed/bo3_snd_dirs_20260823-030223.txt`
- `scripts/contributed/bo3_snd_tails_20260823-030223.txt`
- `scripts/contributed/bo4_snd_dirs_20260823-030223.txt`
- `scripts/contributed/bo4_sounds_20260823-030223.py`
- `scripts/contributed/chan_ends_20260823-043005.txt`
- `scripts/contributed/cwmix_dirs_20260823-030223.txt`
- `scripts/contributed/cwmix_ends_20260823-030223.txt`
- `scripts/contributed/cwmix_tails_20260823-030223.txt`
- `scripts/contributed/cwtakes_dirs_20260823-030223.txt`
- `scripts/contributed/cwtakes_ends_20260823-030223.txt`
- `scripts/contributed/double_uncarried_20260823-035618.py`
- `scripts/contributed/harvest_bo3_20260822-030351.py`
- `scripts/contributed/heads_measured_alphabet_20260823-204820.py`
- `scripts/contributed/image_channels_wide_20260823-043005.py`
- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/mat_dirs13_20260823-043549.txt`
- `scripts/contributed/mcdp_cores_20260823-023310.py`
- `scripts/contributed/measure_build_typing_20260824-233745.py`
- `scripts/contributed/measure_material_dirs_20260824-232215.py`
- `scripts/contributed/measure_mid_substitution_20260824-235738.py`
- `scripts/contributed/measure_normalisation_20260824-232748.py`
- `scripts/contributed/measure_tail_alphabet_20260825-010822.py`
- `scripts/contributed/measure_token_order_20260824-232215.py`
- `scripts/contributed/numeric_endings_20260823-044152.py`
- `scripts/contributed/old_title_decorations_20260823-213526.py`
- `scripts/contributed/redecorations_20260823-023757.py`
- `scripts/contributed/respelled_typed_20260824-233745.py`
- `scripts/contributed/sound_tails_20260823-030223.py`
- `scripts/contributed/sound_takes_20260823-030223.py`
- `scripts/contributed/speaker_grids_20260822-021342.py`
- `scripts/contributed/symbol_tails_20260823-213145.py`
- `scripts/contributed/token_order_20260824-232215.py`
- `scripts/contributed/uncarried_begins_20260823-023757.txt`
- `scripts/contributed/uncarried_endings_20260823-040620.py`
- `scripts/contributed/wrapper_decorations_20260824-232215.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.