### PR TITLE
[BLKOPS04] findings from Dreadbread76, 20260825-043950 (1 names)

### DIFF
--- a/submissions/Dreadbread76_BLKOPS04_20260825-043950/about_20260825-043950.md
+++ b/submissions/Dreadbread76_BLKOPS04_20260825-043950/about_20260825-043950.md
@@ -1,0 +1,33 @@
+# Submission 20260825-043950
+
+- game: **BLKOPS04**
+- from: Dreadbread76
+- names: 1
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 47 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260825-040910_soundfiles
+- method: sound files and aliases (confirm_cw --sounds)
+- what it does: every seed cut to pieces at its marks and recombined as beginning + stem + ending, each candidate hashed and looked up among the game's unnamed ids
+- ran for: 51m 38s
+- game: BLKOPS04
+- pools searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- seed lines: 3311743
+- distinct pieces: 31566807
+- beginnings: 700
+- endings: 4800
+- ids hunted: 85533
+- matches: 53
+- distinct names reached: 19
+- new here: 1
+- fingerprint: b9e0522c54a67dda
+
+**Next:** this configuration is now exhausted. Re-measure the lists with `python scripts/derive_lists.py` so the confirmed names widen them, which changes the fingerprint and reopens the method -- or run a method that reaches somewhere else entirely (METHODS.md).

--- a/submissions/Dreadbread76_BLKOPS04_20260825-043950/sound_alias_20260825-043950.txt
+++ b/submissions/Dreadbread76_BLKOPS04_20260825-043950/sound_alias_20260825-043950.txt
@@ -1,0 +1,1 @@
+2a7451c18bcdd409,zmb_escape_cell_door_slide_down


### PR DESCRIPTION
**BLKOPS04** — 1 asset names, confirmed against that game's own loaded assets.

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Dreadbread76

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260825-040910_soundfiles
- method: sound files and aliases (confirm_cw --sounds)
- what it does: every seed cut to pieces at its marks and recombined as beginning + stem + ending, each candidate hashed and looked up among the game's unnamed ids
- ran for: 51m 38s
- game: BLKOPS04
- pools searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
- seed lines: 3311743
- distinct pieces: 31566807
- beginnings: 700
- endings: 4800
- ids hunted: 85533
- matches: 53
- distinct names reached: 19
- new here: 1
- fingerprint: b9e0522c54a67dda

**Next:** this configuration is now exhausted. Re-measure the lists with `python scripts/derive_lists.py` so the confirmed names widen them, which changes the fingerprint and reopens the method -- or run a method that reaches somewhere else entirely (METHODS.md).
