### PR TITLE
[BLKOPSCW] findings from Dreadbread76, 20260825-071409 (4 names)

### DIFF
--- a/submissions/Dreadbread76_BLKOPSCW_20260825-071409/about_20260825-071409.md
+++ b/submissions/Dreadbread76_BLKOPSCW_20260825-071409/about_20260825-071409.md
@@ -1,0 +1,39 @@
+# Submission 20260825-071409
+
+- game: **BLKOPSCW**
+- from: Dreadbread76
+- names: 4
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- xmodel: 3
+- image: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 54 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260825-071250_plan
+- method: material cores spelled as image (no head / no ends)
+- what it does: cores present in material under `no head` and absent from image under `no ends`, spelled with the 24 commonest leading and trailing segments image is measured to wear
+- ran for: 4s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- beginnings: 24
+- endings: 24
+- stems: 193682
+- ids hunted: 123564
+- candidates tested: 121051250
+- new: 4
+- sketch beginnings: 166b62c93f781b42210f77cfa666328a2924f89bb0cdacfd2f5a3a5458fb56bd3d9854fe4d70bc94406e815df20580004188c06eda68504946107d1377883e795174aa775a5b873d714ecc22537e47107267057331fbaab9792a801c128570a37c4ca9e6a705bc4c80832bd71a4fc94e9344dc3447d765fd94d4067fe642526da38316bced21cbaac33309c454ab86cec58462ec39df00b8c601dac81cfa869dd6f923ee36673614dce8234e5263458af3be2a24062c9a51f5fb22720466a846
+- sketch stems: 0000024fa9031a3200000e568910f7e100001d691584a89e000063a33732586900009d6043da5beb00014c13b6fed3850001ac37da90ab200001bd9b892eb6790002a0635eee56f20002a789d78439440002d170e3084a6500031042dcffb2f0000346cb26c4555500035a6d588aa7560003e13f5000e2580003edfa4c81ce830003fbac3d603b1f00046af80c8ef419000517c279732fcd00057685986533e2000579d002e6f23a00059867563d51920005f15e218cf9c700069d83370d16da0007ece0eca7d58f00081346fda8193a0008427c2b21c862000865a4673221f60008a3ae2363359b0008d4d51b05c884000a5d1374f8322b000ac5c63aaefac7
+- sketch endings: 0122426a4c250c79119d3f33d6e53a0916f3b215812372281cb11c25292432633992232ec3d7a7524094784a6c16a75f443b71013d43f7f74910e22d084d3b994ee09fa9ed1e393a54c949f2b30c388d663e4868e951660f6d32a238f62577066e7e84755b3a020e71b8ead21b8fb99e79a3f8ff9149ce157d842189de6bd83aa1c055b5843cb405c56f5e2600583eb3c67e2d61e03be404d4b488209e57c276dbe481f771ddb0c2e12ea24756a366bffb8063fec73f35e3ff4cda01d9aad2bb
+- fingerprint: 3274baa426d8ee0e
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/Dreadbread76_BLKOPSCW_20260825-071409/image_20260825-071409.txt
+++ b/submissions/Dreadbread76_BLKOPSCW_20260825-071409/image_20260825-071409.txt
@@ -1,0 +1,1 @@
+4efc74530cb4284c,i_wpn_t9_smg_standard_cb_glow_decal_nature_e

--- a/submissions/Dreadbread76_BLKOPSCW_20260825-071409/xmodel_20260825-071409.txt
+++ b/submissions/Dreadbread76_BLKOPSCW_20260825-071409/xmodel_20260825-071409.txt
@@ -1,0 +1,3 @@
+cc1a9388bd99cb,p9_rm_wmd_container_gas_01
+3447a03325c7e09e,p9_rm_pai_paint_banners_01
+6393f11e330b5354,p9_zm_tungsten_phase_boundary_01


### PR DESCRIPTION
**BLKOPSCW** — 4 asset names, confirmed against that game's own loaded assets.

- xmodel: 3
- image: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Dreadbread76

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260825-071250_plan
- method: material cores spelled as image (no head / no ends)
- what it does: cores present in material under `no head` and absent from image under `no ends`, spelled with the 24 commonest leading and trailing segments image is measured to wear
- ran for: 4s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- beginnings: 24
- endings: 24
- stems: 193682
- ids hunted: 123564
- candidates tested: 121051250
- new: 4
- sketch beginnings: 166b62c93f781b42210f77cfa666328a2924f89bb0cdacfd2f5a3a5458fb56bd3d9854fe4d70bc94406e815df20580004188c06eda68504946107d1377883e795174aa775a5b873d714ecc22537e47107267057331fbaab9792a801c128570a37c4ca9e6a705bc4c80832bd71a4fc94e9344dc3447d765fd94d4067fe642526da38316bced21cbaac33309c454ab86cec58462ec39df00b8c601dac81cfa869dd6f923ee36673614dce8234e5263458af3be2a24062c9a51f5fb22720466a846
- sketch stems: 0000024fa9031a3200000e568910f7e100001d691584a89e000063a33732586900009d6043da5beb00014c13b6fed3850001ac37da90ab200001bd9b892eb6790002a0635eee56f20002a789d78439440002d170e3084a6500031042dcffb2f0000346cb26c4555500035a6d588aa7560003e13f5000e2580003edfa4c81ce830003fbac3d603b1f00046af80c8ef419000517c279732fcd00057685986533e2000579d002e6f23a00059867563d51920005f15e218cf9c700069d83370d16da0007ece0eca7d58f00081346fda8193a0008427c2b21c862000865a4673221f60008a3ae2363359b0008d4d51b05c884000a5d1374f8322b000ac5c63aaefac7
- sketch endings: 0122426a4c250c79119d3f33d6e53a0916f3b215812372281cb11c25292432633992232ec3d7a7524094784a6c16a75f443b71013d43f7f74910e22d084d3b994ee09fa9ed1e393a54c949f2b30c388d663e4868e951660f6d32a238f62577066e7e84755b3a020e71b8ead21b8fb99e79a3f8ff9149ce157d842189de6bd83aa1c055b5843cb405c56f5e2600583eb3c67e2d61e03be404d4b488209e57c276dbe481f771ddb0c2e12ea24756a366bffb8063fec73f35e3ff4cda01d9aad2bb
- fingerprint: 3274baa426d8ee0e

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/char_edits_20260824-165142.py`
- `scripts/contributed/heads_slash_20260824-025001.py`
- `scripts/contributed/symbol_tails_20260823-213145.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.