### PR TITLE
[BLKOPS04] findings from Hexeption, 20260825-102343 (1 names)

### DIFF
--- a/scripts/contributed/v2_typed_borrowed_endings_range_20260825-102343.py
+++ b/scripts/contributed/v2_typed_borrowed_endings_range_20260825-102343.py
@@ -1,0 +1,123 @@
+"""Write a typed borrowed-ending plan over a disjoint ending rank band.
+
+    python contrib/v2_typed_borrowed_endings_range.py --kind xanim --skip-ends 8000 \
+        --ends 8000 --write-plan plans/v2_xanim_ends_8001_16000.txt
+
+This is `typed_borrowed_endings.py` aimed at `_v2` typed source rows, with a rank slice on the
+borrowed endings so a follow-up pass does not spend half its candidates rerunning the previous
+band.
+"""
+import argparse
+import collections
+import os
+import sys
+
+_root = os.path.dirname(os.path.abspath(__file__))
+while _root != os.path.dirname(_root) and not os.path.isfile(
+    os.path.join(_root, "scripts", "snapshot.py")
+):
+    _root = os.path.dirname(_root)
+sys.path.insert(0, os.path.join(_root, "scripts"))
+
+from typed_cross import TYPES, cores, decorations, ours
+
+
+def external_by_type(path):
+    external = collections.defaultdict(set)
+    with open(os.path.join(_root, path), encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            kind, _, name = line.partition(",")
+            kind = kind.strip().lower()
+            name = name.strip().strip('"').replace("\\", "/").lower()
+            if name and kind in TYPES:
+                external[kind].add(name)
+    return external
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--source", default=os.path.join("borrowed", "v2_typed.txt"))
+    parser.add_argument("--kind", default="xanim", choices=sorted(TYPES))
+    parser.add_argument("--begins", type=int, default=1500)
+    parser.add_argument("--ends", type=int, default=8000)
+    parser.add_argument("--skip-ends", type=int, default=0)
+    parser.add_argument("--depth", type=int, default=4)
+    parser.add_argument("--strip-depth", type=int, default=3)
+    parser.add_argument("--strip-begins", type=int, default=250)
+    parser.add_argument("--strip-ends", type=int, default=1200)
+    parser.add_argument("--write-plan", required=True)
+    options = parser.parse_args(argv)
+
+    external = external_by_type(options.source)
+    theirs = external.get(options.kind)
+    if not theirs:
+        raise SystemExit("%s has no %s rows" % (options.source, options.kind))
+
+    mine = ours(options.kind, TYPES[options.kind])
+    our_heads, our_tails = decorations(mine, options.depth, options.begins, options.ends)
+
+    strip_h, strip_t = decorations(
+        mine, options.strip_depth, options.strip_begins, options.strip_ends
+    )
+    stems = sorted(cores(mine, strip_h, strip_t))
+
+    _, their_tails = decorations(theirs, options.depth, options.begins, 200000)
+    carried = set(our_tails)
+    borrowed_all = [tail for tail in their_tails if tail not in carried]
+    borrowed = borrowed_all[options.skip_ends : options.skip_ends + options.ends]
+
+    plan_path = os.path.join(_root, options.write_plan)
+    base = os.path.splitext(plan_path)[0]
+    os.makedirs(os.path.dirname(plan_path), exist_ok=True)
+
+    for suffix, rows in (("begins", our_heads), ("stems", stems), ("ends", borrowed)):
+        with open("%s.%s.txt" % (base, suffix), "w", encoding="utf-8", newline="\n") as handle:
+            handle.write("\n".join(rows) + "\n")
+
+    def rel(path):
+        return os.path.relpath(path, _root).replace("\\", "/")
+
+    with open(plan_path, "w", encoding="utf-8", newline="\n") as handle:
+        handle.write(
+            "# Written by contrib/v2_typed_borrowed_endings_range.py. Regenerate rather than editing.\n"
+            "#\n"
+            "# OUR %s cores and beginnings, under `_v2` %s endings ranked %d-%d after removing\n"
+            "# endings our corpus already carries. This is disjoint from lower ending bands.\n"
+            "\n"
+            "label: _v2 %s borrowed endings, ranks %d-%d\n"
+            "begin: @%s\n"
+            "stem:  @%s\n"
+            "end:   @%s\n"
+            "bare:  no\n"
+            % (
+                options.kind,
+                options.kind,
+                options.skip_ends + 1,
+                options.skip_ends + len(borrowed),
+                options.kind,
+                options.skip_ends + 1,
+                options.skip_ends + len(borrowed),
+                rel(base + ".begins.txt"),
+                rel(base + ".stems.txt"),
+                rel(base + ".ends.txt"),
+            )
+        )
+
+    print(
+        "%s: %s cores x %s begins x %s endings, ranks %s-%s -> %s candidates"
+        % (
+            options.kind,
+            format(len(stems), ","),
+            format(len(our_heads), ","),
+            format(len(borrowed), ","),
+            format(options.skip_ends + 1, ","),
+            format(options.skip_ends + len(borrowed), ","),
+            format(len(stems) * len(our_heads) * len(borrowed), ","),
+        ),
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/submissions/Hexeption_BLKOPS04_20260825-102343/about_20260825-102343.md
+++ b/submissions/Hexeption_BLKOPS04_20260825-102343/about_20260825-102343.md
@@ -1,0 +1,38 @@
+# Submission 20260825-102343
+
+- game: **BLKOPS04**
+- from: Hexeption
+- names: 1
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- xanim: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 65 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260825-101955_plan
+- method: _v2 xanim borrowed endings, ranks 8001-16000
+- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
+- ran for: 2m 53s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- beginnings: 1500
+- endings: 8000
+- stems: 9073
+- ids hunted: 162838
+- candidates tested: 108889609500
+- new: 1
+- sketch beginnings: 000fc8c79c7c49ea0020827dba0df4e6005990dd0d3b363b008239b90999bf180098b615974373250119a347d380e9b2011bc5777ea5360201341ad290b43153018d7a123421d6cd0192cde7dcc31dae01c74a82188c591801da85b090e454150202a1357e8f2a6502371e2055b11fcd027d47769d2e729302b6009a484f7d5e02d24f422726554802e7b6a411789f9b02f484df4f983cc10358bf0fa7f91c6703acf04c20a48f8203d502075e1ab46c03fc72a0f79baa35045b997cbd8f138c048a1e6c3be283410495d72b31863c38050b62da0ae5aa900516d5eb6fe5fccc0523afead2ee113a052e50b0280d6ecf053c59eacd40f39105430a46bf9a5597
+- sketch stems: 000a9af65b41e5a50022fa2cd1f4743c00298120d730b5c80031b5a6fc96b144003651949be6c5e10039878ae0c98d70003acf017d2fca1d0041c1e60b539f7700422a1923c49411004336bbd4dfae520048c22615d27a3f00494f789eec381b004a85482f889bb60051eff89596d29e0053d76675da1c9e005f95058f59a2d40078cc7efc63f24d008e4e20ff7016250092c607e827f92d00974e0004bbc6d0009d7e4fb856bf7900a6aa81fa43536e00abfbbc7cc3759900ae91c761dcd27700bb97275fb4492500bfada269acb13600cae7a76fcb6a5500cd7992e01ca93700d19847ac982de000d3d483d16967b600d6a05609db7a4d00d7693f4aa56235
+- sketch endings: 0004d12221e372280018c70472a5d35b001a05e71794d076001c6658ccad8cd1001ce2d90c678bd80023362ca0776c910053337cbd38f17c00543672ab2fe6910055066a693d25c20057dbd957642ddd005ddf0c1ef671a900655e12ed64b1d900674237619ad12a006d1b9f11d3753e007a7924dc1d8a72007c43014e781d47007c73904ecbf319008ae491ce21a1c70093b1a32a3e32ac009e05dc524d08b900a0b77e899cf97c00b680995e56476800ba4ba5c236cea000bbb29a3f7d247500d082b7fd92fc1900d386704938379400d5918e50e137c900eee12ddd39048300f247309f8ff8dc01022294f65ffd630108a6c4bdec27f8011ad7f77f30264b
+- fingerprint: 122d6b4deef967f5
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/Hexeption_BLKOPS04_20260825-102343/xanim_20260825-102343.txt
+++ b/submissions/Hexeption_BLKOPS04_20260825-102343/xanim_20260825-102343.txt
@@ -1,0 +1,1 @@
+54d0395c8908dbeb,pt_brawler_prone_grab_gesture


### PR DESCRIPTION
**BLKOPS04** — 1 asset names, confirmed against that game's own loaded assets.

- xanim: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Hexeption

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260825-101955_plan
- method: _v2 xanim borrowed endings, ranks 8001-16000
- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
- ran for: 2m 53s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- beginnings: 1500
- endings: 8000
- stems: 9073
- ids hunted: 162838
- candidates tested: 108889609500
- new: 1
- sketch beginnings: 000fc8c79c7c49ea0020827dba0df4e6005990dd0d3b363b008239b90999bf180098b615974373250119a347d380e9b2011bc5777ea5360201341ad290b43153018d7a123421d6cd0192cde7dcc31dae01c74a82188c591801da85b090e454150202a1357e8f2a6502371e2055b11fcd027d47769d2e729302b6009a484f7d5e02d24f422726554802e7b6a411789f9b02f484df4f983cc10358bf0fa7f91c6703acf04c20a48f8203d502075e1ab46c03fc72a0f79baa35045b997cbd8f138c048a1e6c3be283410495d72b31863c38050b62da0ae5aa900516d5eb6fe5fccc0523afead2ee113a052e50b0280d6ecf053c59eacd40f39105430a46bf9a5597
- sketch stems: 000a9af65b41e5a50022fa2cd1f4743c00298120d730b5c80031b5a6fc96b144003651949be6c5e10039878ae0c98d70003acf017d2fca1d0041c1e60b539f7700422a1923c49411004336bbd4dfae520048c22615d27a3f00494f789eec381b004a85482f889bb60051eff89596d29e0053d76675da1c9e005f95058f59a2d40078cc7efc63f24d008e4e20ff7016250092c607e827f92d00974e0004bbc6d0009d7e4fb856bf7900a6aa81fa43536e00abfbbc7cc3759900ae91c761dcd27700bb97275fb4492500bfada269acb13600cae7a76fcb6a5500cd7992e01ca93700d19847ac982de000d3d483d16967b600d6a05609db7a4d00d7693f4aa56235
- sketch endings: 0004d12221e372280018c70472a5d35b001a05e71794d076001c6658ccad8cd1001ce2d90c678bd80023362ca0776c910053337cbd38f17c00543672ab2fe6910055066a693d25c20057dbd957642ddd005ddf0c1ef671a900655e12ed64b1d900674237619ad12a006d1b9f11d3753e007a7924dc1d8a72007c43014e781d47007c73904ecbf319008ae491ce21a1c70093b1a32a3e32ac009e05dc524d08b900a0b77e899cf97c00b680995e56476800ba4ba5c236cea000bbb29a3f7d247500d082b7fd92fc1900d386704938379400d5918e50e137c900eee12ddd39048300f247309f8ff8dc01022294f65ffd630108a6c4bdec27f8011ad7f77f30264b
- fingerprint: 122d6b4deef967f5

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/v2_typed_borrowed_endings_range_20260825-102343.py`
- `scripts/contributed/v2_typed_source_20260825-101559.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.