### PR TITLE
[BLKOPS04] findings from GoastcraftHD, 20260825-110557 (1 names)

### DIFF
--- a/scripts/contributed/mined_axes_20260825-110557.py
+++ b/scripts/contributed/mined_axes_20260825-110557.py
@@ -1,0 +1,313 @@
+r"""Relations mined out of the corpus instead of guessed one at a time -- the finished version.
+
+**This supersedes `mined_subs.py`.** That file is the first cut of the same idea and is carried in
+an earlier pull request; `submit` will not send an updated copy of a script it has already sent, so
+the two extensions measured after it went up -- `--classes` and `--indels` -- live here. Prefer
+this file; `mined_subs.py` is kept only because run records name it as their `--script`.
+
+Measured 2026-08-25, both games: pairwise **716**, equivalence classes **192 more on Black Ops 4
+alone**. See METHODS.md method 35.
+
+
+
+    python contrib/mined_axes.py --top 400 | bin/windows/confirm_list.exe - \
+        --label "corpus-mined substitutions" --script contrib/mined_axes.py
+
+    python contrib/mined_axes.py --report      just print what it mined, and stop
+    python contrib/mined_axes.py --classes     cross each equivalence class instead
+    python contrib/mined_axes.py --indels      anchored insertions and deletions too
+
+## The gap this exists for
+
+Every relation this project exploits was **thought of by a person**, one at a time, and then
+built: image siblings, image channels, materials from image cores, the language codes, family
+gaps, token order, numeric repadding. `derive_closure.py` is a list of seven such guesses. The
+good ones are the densest methods here -- `final_byte` at 1 per 18, siblings at 1 per 394 -- so
+the guessing works. What nothing does is **ask the corpus which relations exist.**
+
+It can be asked directly, and cheaply. Sort every known name; two names that sit next to each
+other in sorted order usually share a long prefix, so the part where they differ is a
+substitution the naming actually performs. Do it again over the names sorted by their *reverse*
+to catch the pairs that share a suffix instead. Count the substitutions. The ones that recur are
+the game's own axes.
+
+Run over 1,531,805 names on 2026-08-25 it recovers, unprompted and in order:
+
+    '1' -> '2', '0' -> '1', ...     the numeric axis      (confirm_variants, families --gaps)
+    ''  -> 'i_'                     the image sibling     (image siblings)
+    'i' -> 'mtl'                    image <-> material    (materials from image cores)
+    'c' -> 'g', 'c' -> 'n', ...     the channel codes     (image channel completion)
+
+which is four of the seven hand-built relations, found without being told they exist. That is the
+control: a miner that could not re-derive the known axes would not be worth pointing at the
+unknown ones.
+
+And then it keeps going, into axes nothing here lists:
+
+    'austr' -> 'milit'   21,450 pairs        'view'    -> 'world'   6,962
+    'levati' -> 'chel'    5,760              'morocc'  -> 'casin'   5,177
+
+Those are **map codenames**. The same asset exists under several maps, and no method here
+substitutes one map for another -- `map_sets.py` was proposed for something adjacent and never
+built, and `slotswap` cannot reach it because these are not whole tokens (`austr` is a cut of
+`australia`, sitting inside a longer token).
+
+## How it generates
+
+The top `--top` substitutions by evidence, applied to every known name that contains the left
+side, one occurrence at a time. Pure-digit substitutions are dropped: they are the numeric axis,
+which `confirm_variants` already walks properly, and including them buries everything else.
+Candidates already in the corpus are dropped.
+
+Each candidate is therefore one substitution away from a name known to be real, which is the
+shape METHODS records as live -- and unlike `splice`, the substitution itself is one the corpus
+was observed to perform rather than one the generator invented.
+"""
+import argparse, os, sys
+from collections import Counter
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(REPO, "scripts"))
+import snapshot  # noqa: E402
+
+TABLES = ("fnv1a_xmodels", "fnv1a_xmaterials", "fnv1a_ximages", "fnv1a_xanims",
+          "fnv1a_soundbanks_aliases")
+
+
+LANGUAGES = ("americanspanish", "brazilianportugese", "chinese", "english", "french", "german",
+             "italian", "japanese", "korean", "polish", "russian", "spanish")
+SOUND_TABLES = (("fnv1a_xsounds", "fnv1a_soundbanks_aliases")
+                + tuple("fnv1a_%s_xsounds" % lang for lang in LANGUAGES))
+BS = chr(92)
+
+
+def sound_corpus(nofold):
+    """Every sound name known to be real, in the spelling the target game hashes.
+
+    The mined axes come from the general corpus and have never been applied to these names -- the
+    sound tables are not in `TABLES`, so 861,019 sound paths were never offered as a name to
+    substitute *into*. This is not the recombination METHODS records dead: that transplanted a
+    basename verbatim under a different directory. A mined substitution changes one thing inside
+    one real path and leaves the rest of it alone, which is the shape that works everywhere else.
+    """
+    names = set(snapshot.table_names(*SOUND_TABLES))
+    for pool in ("sound_asset", "sound_alias"):
+        names |= {n.strip() for n in snapshot.confirmed_names(pool) if n.strip()}
+    out = set()
+    for name in names:
+        name = name.strip().lower()
+        if name:
+            out.add(name.replace("/", BS) if nofold else name.replace(BS, "/"))
+    return sorted(out)
+
+
+def corpus():
+    names = set(snapshot.table_names(*TABLES))
+    names |= {n.strip() for n in snapshot.confirmed_names() if n.strip()}
+    return sorted({n.lower() for n in names if n})
+
+
+def difference(a, b, where=False):
+    """The middles of a and b, once their common prefix and common suffix are removed."""
+    n = min(len(a), len(b))
+    i = 0
+    while i < n and a[i] == b[i]:
+        i += 1
+    j = 0
+    while j < n - i and a[len(a) - 1 - j] == b[len(b) - 1 - j]:
+        j += 1
+    if where:
+        return a[i:len(a) - j], b[i:len(b) - j], i
+    return a[i:len(a) - j], b[i:len(b) - j]
+
+
+def mine(names, longest, indels=False, context=0):
+    subs = Counter()
+    for order in (names, sorted(names, key=lambda s: s[::-1])):
+        for left, right in zip(order, order[1:]):
+            u, v, at = difference(left, right, where=True)
+            if not u and not v:
+                continue
+            if not u or not v:
+                # An insertion or a deletion has no anchor of its own -- there is no way to know
+                # where in a name to put it. Borrowing the character in front turns it into an
+                # ordinary substitution that can only fire where the corpus saw it fire:
+                # inserting `_lod1` after `y` becomes `y` -> `y_lod1`. Without this the whole
+                # class is discarded, and `token_edits` only covers the token-boundary case.
+                if not indels or at == 0:
+                    continue
+                anchor = left[at - 1]
+                u, v = anchor + u, anchor + v
+            if len(u) > longest or len(v) > longest:
+                continue
+            if context and at >= context:
+                # Fold the characters in front into both sides. `c` -> `n` fires at every `c` in
+                # every name and needs a cap to stay affordable; `_c` -> `_n` fires only at a
+                # token boundary, which is the only place the corpus was ever seen to do it. The
+                # substitution is the same relation, stated where it actually holds.
+                lead = left[at - context:at]
+                u, v = lead + u, lead + v
+            # The numeric axis is real and already walked properly by `confirm_variants`, which
+            # knows a number is a number. Left in, it is nine tenths of the ranking.
+            if u.isdigit() and v.isdigit():
+                continue
+            subs[(u, v)] += 1
+    return subs
+
+
+def classes(subs, min_seen, max_class):
+    """The mined pairs are edges of an equivalence class; return every ordered pair in each.
+
+    `miami -> cartel`, `miami -> tank` and `tank -> cartel` are three observations of one axis --
+    the map codename -- and the axis has more members than any single pair shows. Taking connected
+    components and crossing each one recovers the substitutions the corpus implies but never
+    happened to put next to each other in sorted order.
+
+    Multi-character sides only, and that is not a tidiness rule: single letters chain (`a`->`b`,
+    `b`->`c`, `c`->`d`) until every letter of the alphabet is one component, which crosses to 650
+    substitutions applied at every position of every name and is pure noise. At three characters
+    and up the components come out semantically clean -- weapon parts, factions, specialists,
+    stances, channel codes -- and the one that does over-merge is visible because it is huge.
+    """
+    parent = {}
+
+    def find(x):
+        parent.setdefault(x, x)
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    for (u, v), count in subs.items():
+        if count >= min_seen and len(u) >= 3 and len(v) >= 3:
+            ru, rv = find(u), find(v)
+            if ru != rv:
+                parent[ru] = rv
+
+    groups = {}
+    for member in list(parent):
+        groups.setdefault(find(member), set()).add(member)
+
+    out = []
+    for group in groups.values():
+        if len(group) < 2 or len(group) > max_class:
+            continue
+        members = sorted(group)
+        for u in members:
+            for v in members:
+                if u != v:
+                    out.append((u, v, len(members)))
+    return out
+
+
+def compose(names, kept, cap):
+    """Every name with two mined substitutions applied at once, at non-overlapping positions."""
+    known = set(names)
+    seen = set()
+    emitted = 0
+    pairs = [(u, v) for u, v, _c in kept]
+    for name in names:
+        applicable = [(u, v, name.find(u)) for u, v in pairs]
+        applicable = [(u, v, at) for u, v, at in applicable if at >= 0]
+        if len(applicable) < 2:
+            continue
+        for i in range(len(applicable)):
+            ui, vi, ai = applicable[i]
+            for j in range(len(applicable)):
+                if i == j:
+                    continue
+                uj, vj, aj = applicable[j]
+                if aj < ai + len(ui):
+                    continue          # overlapping edits describe one substitution, not two
+                candidate = (name[:ai] + vi + name[ai + len(ui):aj]
+                             + vj + name[aj + len(uj):])
+                if candidate in known or candidate in seen:
+                    continue
+                seen.add(candidate)
+                try:
+                    print(candidate)
+                except (OSError, ValueError):
+                    sys.stderr.write("consumer went away after %s candidates" % emitted)
+                    return
+                emitted += 1
+                if emitted >= cap:
+                    sys.stderr.write("stopped at the cap: %s candidates%s"
+                                     % ("{:,}".format(emitted), chr(10)))
+                    return
+    sys.stderr.write("composed candidates: %s%s" % ("{:,}".format(emitted), chr(10)))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--top", type=int, default=400, help="how many mined substitutions to apply")
+    ap.add_argument("--longest", type=int, default=6, help="longest side of a substitution")
+    ap.add_argument("--min-seen", type=int, default=20)
+    ap.add_argument("--cap", type=int, default=200000, help="candidates per substitution")
+    ap.add_argument("--report", action="store_true", help="print the mined table and stop")
+    ap.add_argument("--classes", action="store_true",
+                    help="cross each equivalence class rather than using the observed pairs only")
+    ap.add_argument("--compose", action="store_true",
+                    help="apply TWO mined substitutions to each name rather than one")
+    ap.add_argument("--compose-top", type=int, default=150,
+                    help="how many substitutions to draw the pairs from")
+    ap.add_argument("--sound", choices=("fold", "nofold"), default=None,
+                    help="apply the mined axes to the SOUND corpus instead; nofold for Black Ops 4")
+    ap.add_argument("--context", type=int, default=0,
+                    help="fold this many characters of left context into every substitution")
+    ap.add_argument("--indels", action="store_true",
+                    help="also mine insertions and deletions, anchored on the character in front")
+    ap.add_argument("--max-class", type=int, default=40,
+                    help="drop a component bigger than this -- it has over-merged")
+    args = ap.parse_args()
+
+    names = corpus()
+    sys.stderr.write("corpus: %s\n" % "{:,}".format(len(names)))
+    subs = mine(names, args.longest, args.indels, args.context)
+    sys.stderr.write("distinct substitutions mined: %s\n" % "{:,}".format(len(subs)))
+
+    if args.classes:
+        kept = classes(subs, args.min_seen, args.max_class)
+        sys.stderr.write(("substitutions from equivalence classes: %s" + chr(10))
+                         % "{:,}".format(len(kept)))
+    else:
+        kept = [(u, v, c) for (u, v), c in subs.most_common() if c >= args.min_seen][:args.top]
+    if args.report:
+        for u, v, c in kept:
+            print("%8d  %-8s -> %s" % (c, u, v))
+        return
+
+    if args.sound:
+        names = sound_corpus(args.sound == "nofold")
+        sys.stderr.write("applying to the sound corpus instead: %s names%s"
+                         % ("{:,}".format(len(names)), chr(10)))
+    if args.compose:
+        # A name two mined edits from a real one. `token_edits` reaches two-edit ground only for
+        # whole tokens; these edits are the corpus's own substitutions, applied at a character
+        # offset. The cost is not quadratic in practice because most names carry only a handful of
+        # the top substitutions at all -- the pairs are formed per name, not globally.
+        compose(names, kept[:args.compose_top], args.cap)
+        return
+
+    known = set(names)
+    seen = set()
+    emitted = 0
+    for u, v, _count in kept:
+        made = 0
+        for name in names:
+            start = name.find(u)
+            while start >= 0 and made < args.cap:
+                candidate = name[:start] + v + name[start + len(u):]
+                if candidate not in known and candidate not in seen:
+                    seen.add(candidate)
+                    print(candidate)
+                    emitted += 1
+                    made += 1
+                start = name.find(u, start + 1)
+            if made >= args.cap:
+                break
+    sys.stderr.write("substitutions applied: %d   candidates: %s\n"
+                     % (len(kept), "{:,}".format(emitted)))
+
+
+if __name__ == "__main__":
+    main()

--- a/submissions/GoastcraftHD_BLKOPS04_20260825-110557/about_20260825-110557.md
+++ b/submissions/GoastcraftHD_BLKOPS04_20260825-110557/about_20260825-110557.md
@@ -1,0 +1,35 @@
+# Submission 20260825-110557
+
+- game: **BLKOPS04**
+- from: GoastcraftHD
+- names: 1
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- image: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 70 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260825-110320_list
+- method: two mined substitutions composed
+- what it does: a candidate list generated outside the search and confirmed here
+- ran for: 1m 17s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- candidates tested: 45000000
+- matched: 1
+- new: 1
+- sketch stems: 0000000bf3cb573d00000192e35ad4780000019ac5db6b93000001e162c9272a000002a99a6c370b000002c85b3f54e0000003d28b9392cc0000045a03052f290000048c59c775f2000004c22a981eb8000004e524d6d7df000004e9f2c4b8f900000502827410ab000005e133ed60920000071d8f0a91830000075f237e8527000007cab357041f00000825f8318e4c000008bf1f83ec18000009d8761014bc00000a712516c12900000abb9f62ebc900000af82d5ee4b000000b6a1bbd2aa900000b82156d72d300000c3dbde2d3b900000c86a3e7040f00000ce65cb7495b00000cf33580a09600000d06a603cb7100000d0bfb8989d200000d203213d9bd
+- ids hunted: 164831
+- throughput: 0.6M candidates/s
+- fingerprint: 0cb850fd7bb424c2
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/GoastcraftHD_BLKOPS04_20260825-110557/image_20260825-110557.txt
+++ b/submissions/GoastcraftHD_BLKOPS04_20260825-110557/image_20260825-110557.txt
@@ -1,0 +1,1 @@
+17bb85ea67ccdcad,i_mtl_p8_aut_foliage_tree_elm_english_snow_lrg_01_fall_yellow_proxy_depth


### PR DESCRIPTION
**BLKOPS04** — 1 asset names, confirmed against that game's own loaded assets.

- image: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @GoastcraftHD

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260825-110320_list
- method: two mined substitutions composed
- what it does: a candidate list generated outside the search and confirmed here
- ran for: 1m 17s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- candidates tested: 45000000
- matched: 1
- new: 1
- sketch stems: 0000000bf3cb573d00000192e35ad4780000019ac5db6b93000001e162c9272a000002a99a6c370b000002c85b3f54e0000003d28b9392cc0000045a03052f290000048c59c775f2000004c22a981eb8000004e524d6d7df000004e9f2c4b8f900000502827410ab000005e133ed60920000071d8f0a91830000075f237e8527000007cab357041f00000825f8318e4c000008bf1f83ec18000009d8761014bc00000a712516c12900000abb9f62ebc900000af82d5ee4b000000b6a1bbd2aa900000b82156d72d300000c3dbde2d3b900000c86a3e7040f00000ce65cb7495b00000cf33580a09600000d06a603cb7100000d0bfb8989d200000d203213d9bd
- ids hunted: 164831
- throughput: 0.6M candidates/s
- fingerprint: 0cb850fd7bb424c2

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/anim_transitions_20260823-043549.py`
- `scripts/contributed/anim_transitions_20260823-043549.txt`
- `scripts/contributed/blkops04_dbl_begins_20260823-035618.txt`
- `scripts/contributed/blkops04_dbl_ends_20260823-035618.txt`
- `scripts/contributed/blkops04_sndtails_stems_20260823-030223.txt`
- `scripts/contributed/blkopscw_sound_asset_dirs_20260823-030223.txt`
- `scripts/contributed/bo2_ipak_typed_20260824-232748.py`
- `scripts/contributed/bo3_build_sounds_20260824-233745.py`
- `scripts/contributed/bo3_build_to_bo4_sounds_20260824-233745.py`
- `scripts/contributed/bo3_cores_20260822-025123.py`
- `scripts/contributed/bo3_respell_20260822-024314.py`
- `scripts/contributed/bo3_sab_to_bo4_20260823-030223.py`
- `scripts/contributed/bo3_snd_dirs_20260823-030223.txt`
- `scripts/contributed/bo3_snd_tails_20260823-030223.txt`
- `scripts/contributed/bo4_snd_dirs_20260823-030223.txt`
- `scripts/contributed/bo4_sounds_20260823-030223.py`
- `scripts/contributed/chan_ends_20260823-043005.txt`
- `scripts/contributed/cwmix_dirs_20260823-030223.txt`
- `scripts/contributed/cwmix_ends_20260823-030223.txt`
- `scripts/contributed/cwmix_tails_20260823-030223.txt`
- `scripts/contributed/cwtakes_dirs_20260823-030223.txt`
- `scripts/contributed/cwtakes_ends_20260823-030223.txt`
- `scripts/contributed/double_uncarried_20260823-035618.py`
- `scripts/contributed/harvest_bo3_20260822-030351.py`
- `scripts/contributed/heads_measured_alphabet_20260823-204820.py`
- `scripts/contributed/image_channels_wide_20260823-043005.py`
- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/mat_dirs13_20260823-043549.txt`
- `scripts/contributed/mcdp_cores_20260823-023310.py`
- `scripts/contributed/measure_build_typing_20260824-233745.py`
- `scripts/contributed/measure_material_dirs_20260824-232215.py`
- `scripts/contributed/measure_mid_substitution_20260824-235738.py`
- `scripts/contributed/measure_normalisation_20260824-232748.py`
- `scripts/contributed/measure_tail_alphabet_20260825-010822.py`
- `scripts/contributed/measure_token_order_20260824-232215.py`
- `scripts/contributed/measured_heads_20260825-043818.py`
- `scripts/contributed/measured_offsets_20260825-110144.py`
- `scripts/contributed/measured_shells_20260825-045514.py`
- `scripts/contributed/measured_tails_20260825-012300.py`
- `scripts/contributed/mined_axes_20260825-110557.py`
- `scripts/contributed/mined_subs_20260825-062734.py`
- `scripts/contributed/numeric_endings_20260823-044152.py`
- `scripts/contributed/old_title_decorations_20260823-213526.py`
- `scripts/contributed/redecorations_20260823-023757.py`
- `scripts/contributed/repad_20260825-045514.py`
- `scripts/contributed/respelled_typed_20260824-233745.py`
- `scripts/contributed/run_deep_heads_20260825-091348.sh`
- `scripts/contributed/run_deeper_20260825-094430.sh`
- `scripts/contributed/run_heads_half_20260825-084858.sh`
- `scripts/contributed/run_mheads_bo4_20260825-043818.sh`
- `scripts/contributed/run_mheads_cw_20260825-043818.sh`
- `scripts/contributed/run_shells_20260825-062734.sh`
- `scripts/contributed/run_sound_ladder_20260825-110144.sh`
- `scripts/contributed/run_wide_20260825-062734.sh`
- `scripts/contributed/run_wide_ladder_20260825-062734.sh`
- `scripts/contributed/sound_final_byte_20260825-043818.py`
- `scripts/contributed/sound_tails_20260823-030223.py`
- `scripts/contributed/sound_takes_20260823-030223.py`
- `scripts/contributed/speaker_grids_20260822-021342.py`
- `scripts/contributed/symbol_tails_20260823-213145.py`
- `scripts/contributed/token_order_20260824-232215.py`
- `scripts/contributed/uncarried_begins_20260823-023757.txt`
- `scripts/contributed/uncarried_endings_20260823-040620.py`
- `scripts/contributed/wrapper_decorations_20260824-232215.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.