### PR TITLE
[BLKOPSCW] findings from Hexeption, 20260825-203541 (6 names)

### DIFF
--- a/submissions/Hexeption_BLKOPSCW_20260825-203541/about_20260825-203541.md
+++ b/submissions/Hexeption_BLKOPSCW_20260825-203541/about_20260825-203541.md
@@ -1,0 +1,35 @@
+# Submission 20260825-203541
+
+- game: **BLKOPSCW**
+- from: Hexeption
+- names: 6
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- sound_asset: 6
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 95 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260825-200311_list
+- method: sound character substitution current
+- what it does: a candidate list generated outside the search and confirmed here
+- ran for: 31m 14s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- candidates tested: 985045956
+- matched: 6
+- new: 6
+- sketch stems: 00000001d03800330000000322407dc00000000996c195b40000000df6babbf00000000fe231816f00000010a00906190000001b2fe60a760000001c61df90ef00000024d01684220000002fe52c1907000000304990e63e0000003514f4a0e70000003b345c869a0000003c7be594d9000000461c7ec1c4000000489867ad7d0000004bf72238110000004fbdd04f25000000538cd7fb350000005cff0ee124000000651c40040b0000006742a08a2000000068a7c7d58900000068e7019d990000006e8ab57c4b0000006ff19e97fb0000007764a4644900000078545904c20000007bb4a6a0710000007bc9c35d900000007c7a131d350000007c7c594a13
+- ids hunted: 122873
+- throughput: 0.5M candidates/s
+- fingerprint: c1ba4406834537a0
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/Hexeption_BLKOPSCW_20260825-203541/sound_asset_20260825-203541.txt
+++ b/submissions/Hexeption_BLKOPSCW_20260825-203541/sound_asset_20260825-203541.txt
@@ -1,0 +1,6 @@
+4481fb6bd7adcda,uin/2k20/battlepass/tier_purchase/battlepass_tier_purch_s6.sn75.pc.all.snd
+227c8c3299796a09,uin/2k20/battlepass/tier_purchase/battlepass_tier_purch_s3.sn75.pc.all.snd
+3443fbe0eb4359f3,uin/2k20/battlepass/tier_purchase/battlepass_tier_purch_s5.sn75.pc.all.snd
+35586e45c48dade0,uin/2k20/battlepass/tier_purchase/battlepass_tier_purch_s4.sn75.pc.all.snd
+3f47b044418b7fd4,uin/2k20/battlepass/tier_purchase/battlepass_tier_purch_s8.sn75.pc.all.snd
+4691d5e947151d1d,uin/2k20/battlepass/tier_purchase/battlepass_tier_purch_s7.sn75.pc.all.snd


### PR DESCRIPTION
**BLKOPSCW** — 6 asset names, confirmed against that game's own loaded assets.

- sound_asset: 6

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Hexeption

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260825-200311_list
- method: sound character substitution current
- what it does: a candidate list generated outside the search and confirmed here
- ran for: 31m 14s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- candidates tested: 985045956
- matched: 6
- new: 6
- sketch stems: 00000001d03800330000000322407dc00000000996c195b40000000df6babbf00000000fe231816f00000010a00906190000001b2fe60a760000001c61df90ef00000024d01684220000002fe52c1907000000304990e63e0000003514f4a0e70000003b345c869a0000003c7be594d9000000461c7ec1c4000000489867ad7d0000004bf72238110000004fbdd04f25000000538cd7fb350000005cff0ee124000000651c40040b0000006742a08a2000000068a7c7d58900000068e7019d990000006e8ab57c4b0000006ff19e97fb0000007764a4644900000078545904c20000007bb4a6a0710000007bc9c35d900000007c7a131d350000007c7c594a13
- ids hunted: 122873
- throughput: 0.5M candidates/s
- fingerprint: c1ba4406834537a0

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/char_edits_20260824-154800.py`
- `scripts/contributed/v2_typed_borrowed_endings_range_20260825-102343.py`
- `scripts/contributed/v2_typed_source_20260825-101559.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.