### PR TITLE
[BLKOPS04] findings from Hexeption, 20260826-024031 (1 names)

### DIFF
--- a/submissions/Hexeption_BLKOPS04_20260826-024031/about_20260826-024031.md
+++ b/submissions/Hexeption_BLKOPS04_20260826-024031/about_20260826-024031.md
@@ -1,0 +1,38 @@
+# Submission 20260826-024031
+
+- game: **BLKOPS04**
+- from: Hexeption
+- names: 1
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- material: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 100 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260826-021936_plan
+- method: _v2 material borrowed endings, ranks 64001-72000
+- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
+- ran for: 19m 43s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- beginnings: 1500
+- endings: 8000
+- stems: 141262
+- ids hunted: 161802
+- candidates tested: 1695355893000
+- new: 1
+- sketch beginnings: 0017508c03aa4965001992a453043620002077a4869f1dee0068998358af9e5b008ee6ca6afb793d00cce989d0bd829d00ee39546466a8d700f1c4f37093b1f90111fffafec700300165eda0929e98400173cda7a1ad26fd0226390522e17a550238eba73322cd430255cc417c8b51bf02776b5cf63e18be028c000be8a9b4e502c4861aaf3a528e030cac5545522334031531371845a9b2038f56c793bd46fb03ae19ff79a0cfa2042aeac7b4044a500463444e7fcb3328046b2d7f4feea2a004a79d21cd36800704ab024de5294f7104db6b37ce17405104e864492525469904edb8e31dea6fdd0511c525b6b177ec051c07fcae86ccdb051ff11f935345c9
+- sketch stems: 00027448b320e6f200032890a1f89172000384f783c9b577000521269c8d4cc70005ff73c658380d0005ff9b504864f60007e0c12f6b47350007f86027198f3600085810b476429700085e56c85e3af00008c245776950120008df536db543b100093fde16809e8d00098dabb28fb7940009909509b235e20009d17f6dc2770a0009d90288255c97000aa1205e466352000b260da2a9c1c1000b8f8ae0217931000c7217359cfc92000d1cea1123f1a5000d2f8ece55d85f000d320a06dfd331000e850e9e4819aa000e9bee79dc839d000f96d731644207000fe105d77c5f560010330193c9306800105acbe35e234f001153660d7cb8c50012a6725822e148
+- sketch endings: 00000437e7e3265d000fb89832bf9ddf001145cc353bfebb001226f8c13d113f00152cce7054eb06001abbff55b42bda0027772229346c3000282ed8591cbac80036412f63085a47003ca73657dd650b004c94bb0d661993004dee8671f98814005ec6428eaa6621005f91b7921d94f40061b96a7e720c990067ce5cd52aed4f0075a77fae37f1130085dbd0643a0b70008a3dbd48a2f43e008ec6ed7592612b0097639bc59165c0009fe1bccd34093a00a41fdc73e32a6100a52ee3684cfda300bf15ca1914b9e200cd7a34e0070ddf00d0458551d3b78300d57b90bcc99d4500eb4badd1d47d9c00f4c46ce7f2f94500f4d57f185e59a000f788985b003118
+- fingerprint: 0e5b4ea5bc07a76d
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/Hexeption_BLKOPS04_20260826-024031/material_20260826-024031.txt
+++ b/submissions/Hexeption_BLKOPS04_20260826-024031/material_20260826-024031.txt
@@ -1,0 +1,1 @@
+40008ee1a22849eb,mc/mtl_p8_zm_man_courtyard_fountain_pillar_stone_marble


### PR DESCRIPTION
**BLKOPS04** — 1 asset names, confirmed against that game's own loaded assets.

- material: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Hexeption

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260826-021936_plan
- method: _v2 material borrowed endings, ranks 64001-72000
- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
- ran for: 19m 43s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- beginnings: 1500
- endings: 8000
- stems: 141262
- ids hunted: 161802
- candidates tested: 1695355893000
- new: 1
- sketch beginnings: 0017508c03aa4965001992a453043620002077a4869f1dee0068998358af9e5b008ee6ca6afb793d00cce989d0bd829d00ee39546466a8d700f1c4f37093b1f90111fffafec700300165eda0929e98400173cda7a1ad26fd0226390522e17a550238eba73322cd430255cc417c8b51bf02776b5cf63e18be028c000be8a9b4e502c4861aaf3a528e030cac5545522334031531371845a9b2038f56c793bd46fb03ae19ff79a0cfa2042aeac7b4044a500463444e7fcb3328046b2d7f4feea2a004a79d21cd36800704ab024de5294f7104db6b37ce17405104e864492525469904edb8e31dea6fdd0511c525b6b177ec051c07fcae86ccdb051ff11f935345c9
- sketch stems: 00027448b320e6f200032890a1f89172000384f783c9b577000521269c8d4cc70005ff73c658380d0005ff9b504864f60007e0c12f6b47350007f86027198f3600085810b476429700085e56c85e3af00008c245776950120008df536db543b100093fde16809e8d00098dabb28fb7940009909509b235e20009d17f6dc2770a0009d90288255c97000aa1205e466352000b260da2a9c1c1000b8f8ae0217931000c7217359cfc92000d1cea1123f1a5000d2f8ece55d85f000d320a06dfd331000e850e9e4819aa000e9bee79dc839d000f96d731644207000fe105d77c5f560010330193c9306800105acbe35e234f001153660d7cb8c50012a6725822e148
- sketch endings: 00000437e7e3265d000fb89832bf9ddf001145cc353bfebb001226f8c13d113f00152cce7054eb06001abbff55b42bda0027772229346c3000282ed8591cbac80036412f63085a47003ca73657dd650b004c94bb0d661993004dee8671f98814005ec6428eaa6621005f91b7921d94f40061b96a7e720c990067ce5cd52aed4f0075a77fae37f1130085dbd0643a0b70008a3dbd48a2f43e008ec6ed7592612b0097639bc59165c0009fe1bccd34093a00a41fdc73e32a6100a52ee3684cfda300bf15ca1914b9e200cd7a34e0070ddf00d0458551d3b78300d57b90bcc99d4500eb4badd1d47d9c00f4c46ce7f2f94500f4d57f185e59a000f788985b003118
- fingerprint: 0e5b4ea5bc07a76d

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/v2_typed_borrowed_endings_range_20260825-102343.py`
- `scripts/contributed/v2_typed_source_20260825-101559.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.