### PR TITLE
[BLKOPS04] findings from Zakkary19, 20260826-024803 (3 names)

### DIFF
--- a/submissions/Zakkary19_BLKOPS04_20260826-024803/about_20260826-024803.md
+++ b/submissions/Zakkary19_BLKOPS04_20260826-024803/about_20260826-024803.md
@@ -1,0 +1,39 @@
+# Submission 20260826-024803
+
+- game: **BLKOPS04**
+- from: Zakkary19
+- names: 3
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- image: 2
+- material: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 100 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260826-021849_plan
+- method: all-boundary cores x uncarried endings
+- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
+- ran for: 11m 20s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- beginnings: 0
+- endings: 100000
+- stems: 1789675
+- ids hunted: 161910
+- candidates tested: 178969289675
+- new: 3
+- sketch beginnings: 
+- sketch stems: 000006e18d650fb900000ab4ba1aeee400000c977c5d672200000feaf9e727be000012c311da10ff0000169f01f264ce00002b1519e1ded4000037218d8ac72000003b9f496e1f3100004e56e3fbb0ec000054c6c2049ef9000054e2e1aff6700000595d5e43b51e0000612ff46513d0000062e7cbfd19140000673d5ec1845600006c06f143465600006dfd9719897600007cbaa17ccc8d0000953fd0beca160000b9a20339b21f0000bb7c449703510000bdf5ddb3c7270000c951a42bde610000d86305422c730000d86ce7b41ecb0000dff33e0893840000ef4a2113a6a70000f0d2d965b07e0000f0e6510e13400000f8739296b6aa00010c5b5e86db17
+- sketch endings: 00009dfedd6101880001102abccb0b120001e65666957caf0002137df7c0dc58000226deeb9e866200022a0dfc451bd900026b8d89f5aa910002a79f7fb6c1fa0002e90a8e1715b4000300e32bc7ff9300033efde976b4850005f88d5695d1b000060668f6f996020006203e8cfad33800068b12a3675d7800070a724df955800007e18bae0a9a89000926d4cde1d6c10009f1432718b884000a9af4240446ca000bad932248b753000c4e54c5dc1271000cdf7fc896d537000d1308c062ac96000d43eeaefd485e000e2f65e04ea0de000f2656abca81dd000f5623cc66c6a500103fe5bb23ea230010ed214e961c3900117133fa95dc4a00125acf916d2fb5
+- fingerprint: be6015b5e6c5ecf0
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/Zakkary19_BLKOPS04_20260826-024803/image_20260826-024803.txt
+++ b/submissions/Zakkary19_BLKOPS04_20260826-024803/image_20260826-024803.txt
@@ -1,0 +1,2 @@
+4fe64307b3ac145c,i_mtl_p8_afr_window_32x16_grate_metal_inner_05_m
+4fe64607b3ac1975,i_mtl_p8_afr_window_32x16_grate_metal_inner_05_n

--- a/submissions/Zakkary19_BLKOPS04_20260826-024803/material_20260826-024803.txt
+++ b/submissions/Zakkary19_BLKOPS04_20260826-024803/material_20260826-024803.txt
@@ -1,0 +1,1 @@
+f18602229c0fc6a,wc/mtl_p8_zm_off_decal_damage_marble_cracks_01_offset


### PR DESCRIPTION
**BLKOPS04** — 3 asset names, confirmed against that game's own loaded assets.

- image: 2
- material: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Zakkary19

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260826-021849_plan
- method: all-boundary cores x uncarried endings
- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
- ran for: 11m 20s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- beginnings: 0
- endings: 100000
- stems: 1789675
- ids hunted: 161910
- candidates tested: 178969289675
- new: 3
- sketch beginnings: 
- sketch stems: 000006e18d650fb900000ab4ba1aeee400000c977c5d672200000feaf9e727be000012c311da10ff0000169f01f264ce00002b1519e1ded4000037218d8ac72000003b9f496e1f3100004e56e3fbb0ec000054c6c2049ef9000054e2e1aff6700000595d5e43b51e0000612ff46513d0000062e7cbfd19140000673d5ec1845600006c06f143465600006dfd9719897600007cbaa17ccc8d0000953fd0beca160000b9a20339b21f0000bb7c449703510000bdf5ddb3c7270000c951a42bde610000d86305422c730000d86ce7b41ecb0000dff33e0893840000ef4a2113a6a70000f0d2d965b07e0000f0e6510e13400000f8739296b6aa00010c5b5e86db17
- sketch endings: 00009dfedd6101880001102abccb0b120001e65666957caf0002137df7c0dc58000226deeb9e866200022a0dfc451bd900026b8d89f5aa910002a79f7fb6c1fa0002e90a8e1715b4000300e32bc7ff9300033efde976b4850005f88d5695d1b000060668f6f996020006203e8cfad33800068b12a3675d7800070a724df955800007e18bae0a9a89000926d4cde1d6c10009f1432718b884000a9af4240446ca000bad932248b753000c4e54c5dc1271000cdf7fc896d537000d1308c062ac96000d43eeaefd485e000e2f65e04ea0de000f2656abca81dd000f5623cc66c6a500103fe5bb23ea230010ed214e961c3900117133fa95dc4a00125acf916d2fb5
- fingerprint: be6015b5e6c5ecf0

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/bo4snd_ends_20260826-004415.txt`
- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/numbered_grids_20260821-054219.py`
- `scripts/contributed/overnight_suite_20260826-004415.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.