### PR TITLE
[BLKOPSCW] findings from Hexeption, 20260826-041334 (2 names)

### DIFF
--- a/scripts/contributed/adjacent_token_order_20260826-041334.py
+++ b/scripts/contributed/adjacent_token_order_20260826-041334.py
@@ -1,0 +1,102 @@
+"""Test and generate locally evidenced adjacent-token order variants.
+
+    python contrib/adjacent_token_order.py --measure
+    python contrib/adjacent_token_order.py | bin\\windows\\confirm_list.exe - \
+        --label "locally evidenced adjacent token order" \
+        --script contrib/adjacent_token_order.py
+
+This asks a relation none of the substitution methods asks: whether two adjacent interior
+tokens can reverse position.  It only emits a swap when the same ordered token pair occurs
+both ways elsewhere in real names, so candidates are recombinations of observed conventions
+rather than arbitrary word permutations.
+
+Reads the five target tables and confirmed findings through scripts/snapshot.py.  Writes only
+candidate names on standard output; --measure writes a positive-control summary to stderr.
+Reusable: rerun when the confirmed corpus grows.
+"""
+import argparse
+import collections
+import os
+import sys
+
+_root = os.path.dirname(os.path.abspath(__file__))
+while _root != os.path.dirname(_root) and not os.path.isfile(
+    os.path.join(_root, "scripts", "snapshot.py")
+):
+    _root = os.path.dirname(_root)
+sys.path.insert(0, os.path.join(_root, "scripts"))
+
+import snapshot
+
+TABLES = (
+    "fnv1a_ximages",
+    "fnv1a_xmaterials",
+    "fnv1a_xmodels",
+    "fnv1a_xanims",
+    "fnv1a_soundbanks_aliases",
+    "fnv1a_xsounds",
+)
+
+
+def names():
+    known = set()
+    for table in TABLES:
+        known.update(n.strip().lower().replace("\\", "/") for n in snapshot.table_names(table))
+    for kind in ("image", "material", "xmodel", "xanim", "sound_alias", "sound_asset"):
+        known.update(n.strip().lower().replace("\\", "/") for n in snapshot.confirmed_names(kind))
+    return {n for n in known if n}
+
+
+def pairs(known):
+    observed = collections.Counter()
+    for name in known:
+        tokens = name.split("_")
+        # The first and final tokens encode directories/prefixes and channels/variants often
+        # enough that swapping them is a different spelling relation, not token order.
+        for index in range(1, len(tokens) - 2):
+            if tokens[index] and tokens[index + 1]:
+                observed[(tokens[index], tokens[index + 1])] += 1
+    return observed
+
+
+def candidates(known, reversible):
+    for name in known:
+        tokens = name.split("_")
+        for index in range(1, len(tokens) - 2):
+            pair = (tokens[index], tokens[index + 1])
+            if pair not in reversible:
+                continue
+            changed = tokens[:]
+            changed[index], changed[index + 1] = changed[index + 1], changed[index]
+            candidate = "_".join(changed)
+            if candidate not in known:
+                yield candidate
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--measure", action="store_true")
+    options = parser.parse_args(argv)
+
+    known = names()
+    observed = pairs(known)
+    reversible = {pair for pair in observed if (pair[1], pair[0]) in observed}
+    offered = set(candidates(known, reversible))
+    controls = sum(count for pair, count in observed.items() if pair in reversible)
+
+    print(
+        "%s real names; %s interior ordered pairs; %s reversible pairs; "
+        "%s observed-name controls; %s unseen candidates"
+        % tuple(format(value, ",") for value in (
+            len(known), len(observed), len(reversible), controls, len(offered)
+        )),
+        file=sys.stderr,
+    )
+    if not options.measure:
+        sys.stdout.write("\n".join(sorted(offered)))
+        if offered:
+            sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/scripts/contributed/separator_variants_20260826-041334.py
+++ b/scripts/contributed/separator_variants_20260826-041334.py
@@ -1,0 +1,114 @@
+"""Try observed underscore, dot and hyphen spelling variants between real tokens.
+
+    python contrib/separator_variants.py --count
+    python contrib/separator_variants.py | target\\release\\confirm_list.exe - --game BLKOPSCW \\
+        --label "observed separator variants" --script contrib/separator_variants.py --anyway
+
+This is a bounded spelling method.  It replaces a separator only if both separator spellings
+between the same two token strings occur in the known corpus at least twice.  It therefore tests
+an observed naming convention, not arbitrary punctuation substitutions.
+
+Reads the five target tables and confirmed names through ``snapshot.py``.  Writes candidates to
+stdout; ``--count`` only reports the size and known-name positive controls.  Reusable.
+"""
+import argparse
+import collections
+import os
+import re
+import sys
+
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+while ROOT != os.path.dirname(ROOT) and not os.path.isfile(
+    os.path.join(ROOT, "scripts", "snapshot.py")
+):
+    ROOT = os.path.dirname(ROOT)
+sys.path.insert(0, os.path.join(ROOT, "scripts"))
+
+import snapshot
+
+
+TABLES = (
+    "fnv1a_xmodels",
+    "fnv1a_xmaterials",
+    "fnv1a_ximages",
+    "fnv1a_xanims",
+    "fnv1a_xsounds",
+    "fnv1a_soundbanks_aliases",
+)
+SEPARATOR = re.compile(r"([_.-])")
+
+
+def corpus():
+    names = set(snapshot.table_names(*TABLES))
+    names.update(snapshot.confirmed_names())
+    return {
+        name.strip().lower().replace("\\\\", "/")
+        for name in names
+        if name.strip() and len(name) <= 160
+    }
+
+
+def pieces(name):
+    """Return only editable separators, never a slash in a hashed directory."""
+    directory, marker, base = name.rpartition("/")
+    directory = directory + marker if marker else ""
+    fields = SEPARATOR.split(base)
+    return directory, fields
+
+
+def alternatives(parsed):
+    """{(left, right): separators} only where the convention repeats."""
+    seen = collections.defaultdict(collections.Counter)
+    for _, fields in parsed:
+        for index in range(1, len(fields), 2):
+            left, separator, right = fields[index - 1 : index + 2]
+            if left and right:
+                seen[(left, right)][separator] += 1
+    return {
+        pair: tuple(separator for separator, count in counts.items() if count >= 2)
+        for pair, counts in seen.items()
+        if len([count for count in counts.values() if count >= 2]) >= 2
+    }
+
+
+def make(parsed, known, choices):
+    output = set()
+    controls = 0
+    for directory, fields in parsed:
+        for index in range(1, len(fields), 2):
+            left, current, right = fields[index - 1 : index + 2]
+            for replacement in choices.get((left, right), ()):
+                if replacement == current:
+                    continue
+                changed = list(fields)
+                changed[index] = replacement
+                candidate = directory + "".join(changed)
+                if candidate in known:
+                    controls += 1
+                else:
+                    output.add(candidate)
+    return output, controls
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--count", action="store_true")
+    options = parser.parse_args(argv)
+
+    known = corpus()
+    parsed = [pieces(name) for name in known]
+    choices = alternatives(parsed)
+    output, controls = make(parsed, known, choices)
+    print(
+        "%s known names; %s observed separator relations; %s known-name controls; %s new candidates"
+        % (format(len(known), ","), format(len(choices), ","), format(controls, ","), format(len(output), ",")),
+        file=sys.stderr,
+    )
+    if not options.count:
+        print("\n".join(sorted(output)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/contributed/token_boundaries_20260826-041334.py
+++ b/scripts/contributed/token_boundaries_20260826-041334.py
@@ -1,0 +1,142 @@
+"""Try observed merged-versus-separated token spellings.
+
+    python contrib/token_boundaries.py --count
+    python contrib/token_boundaries.py | target\\release\\confirm_list.exe - --game BLKOPSCW \\
+        --label "observed token-boundary variants" --script contrib/token_boundaries.py --anyway
+
+Names in this corpus are conventionally underscore-separated, but some concepts are spelled both
+ways: a token pair such as ``dual_optic`` can also be a single token, ``dualoptic``.  The existing
+token-edit generator inserts, deletes and substitutes whole tokens; it cannot change this boundary.
+
+This generator is deliberately bounded by observed vocabulary.  A split is offered only when both
+the fused token and its two-token spelling occur in real, known names.  That makes it a test of a
+measured naming convention rather than arbitrary word segmentation.
+
+It reads the five target tables and confirmed submissions through ``snapshot.py`` and writes
+candidate names to stdout.  ``--count`` reports candidate and positive-control counts without
+writing candidates.  Reusable: new confirmed names can supply new observed boundary pairs.
+"""
+import argparse
+import collections
+import os
+import sys
+
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+while ROOT != os.path.dirname(ROOT) and not os.path.isfile(
+    os.path.join(ROOT, "scripts", "snapshot.py")
+):
+    ROOT = os.path.dirname(ROOT)
+sys.path.insert(0, os.path.join(ROOT, "scripts"))
+
+import snapshot
+
+
+TABLES = (
+    "fnv1a_xmodels",
+    "fnv1a_xmaterials",
+    "fnv1a_ximages",
+    "fnv1a_xanims",
+    "fnv1a_xsounds",
+    "fnv1a_soundbanks_aliases",
+)
+
+
+def split(name):
+    """Keep a directory whole; token boundaries only mean underscores."""
+    directory, marker, base = name.rpartition("/")
+    return (directory + marker if marker else ""), tuple(part for part in base.split("_") if part)
+
+
+def names():
+    found = set(snapshot.table_names(*TABLES))
+    found.update(snapshot.confirmed_names())
+    return {
+        name.strip().lower().replace("\\\\", "/")
+        for name in found
+        if name.strip() and len(name) <= 160
+    }
+
+
+def boundary_pairs(parsed):
+    """Return only pair <-> fused spellings both evidenced by the corpus."""
+    tokens = collections.Counter()
+    pairs = collections.Counter()
+    for _, parts in parsed:
+        tokens.update(parts)
+        pairs.update(zip(parts, parts[1:]))
+
+    fused_to_pairs = collections.defaultdict(list)
+    pair_to_fused = collections.defaultdict(list)
+    for pair, seen in pairs.items():
+        fused = "".join(pair)
+        # A once-seen pair or a once-seen fused spelling is too close to a typo.  These floors
+        # are a precision gate, not a ranking; all qualifying alternatives are carried.
+        if seen >= 2 and tokens[fused] >= 2:
+            pair_to_fused[pair].append(fused)
+            fused_to_pairs[fused].append(pair)
+    return pair_to_fused, fused_to_pairs
+
+
+def candidates(parsed, known, pair_to_fused, fused_to_pairs):
+    seen = set()
+    controls = 0
+    for directory, parts in parsed:
+        for index in range(len(parts) - 1):
+            for fused in pair_to_fused.get((parts[index], parts[index + 1]), ()):
+                candidate = directory + "_".join(parts[:index] + (fused,) + parts[index + 2:])
+                if candidate in known:
+                    controls += 1
+                elif candidate not in seen:
+                    seen.add(candidate)
+                    yield candidate
+
+        for index, token in enumerate(parts):
+            for left, right in fused_to_pairs.get(token, ()):
+                candidate = directory + "_".join(parts[:index] + (left, right) + parts[index + 1:])
+                if candidate in known:
+                    controls += 1
+                elif candidate not in seen:
+                    seen.add(candidate)
+                    yield candidate
+
+    return controls
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--count", action="store_true", help="report sizing and known-name controls")
+    options = parser.parse_args(argv)
+
+    known = names()
+    parsed = [split(name) for name in known]
+    pair_to_fused, fused_to_pairs = boundary_pairs(parsed)
+
+    # Materialise once so that `--count` has an exact candidate total and the generator remains
+    # deterministic for the run fingerprint.
+    output = list(candidates(parsed, known, pair_to_fused, fused_to_pairs))
+    controls = 0
+    for directory, parts in parsed:
+        for index in range(len(parts) - 1):
+            for fused in pair_to_fused.get((parts[index], parts[index + 1]), ()):
+                if directory + "_".join(parts[:index] + (fused,) + parts[index + 2:]) in known:
+                    controls += 1
+        for index, token in enumerate(parts):
+            for left, right in fused_to_pairs.get(token, ()):
+                if directory + "_".join(parts[:index] + (left, right) + parts[index + 1:]) in known:
+                    controls += 1
+
+    print(
+        "%s known names; %s observed boundary pairs; %s known-name controls; %s new candidates"
+        % (format(len(known), ","), format(len(pair_to_fused), ","), format(controls, ","), format(len(output), ",")),
+        file=sys.stderr,
+    )
+    if options.count:
+        return 0
+    for candidate in sorted(output):
+        print(candidate)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/submissions/Hexeption_BLKOPSCW_20260826-041334/about_20260826-041334.md
+++ b/submissions/Hexeption_BLKOPSCW_20260826-041334/about_20260826-041334.md
@@ -1,0 +1,36 @@
+# Submission 20260826-041334
+
+- game: **BLKOPSCW**
+- from: Hexeption
+- names: 2
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- material: 1
+- xmodel: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 100 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260826-041110_list
+- method: locally evidenced adjacent token order
+- what it does: a candidate list generated outside the search and confirmed here
+- ran for: 11s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- candidates tested: 1205866
+- matched: 2
+- new: 2
+- sketch stems: 0000003e34caf53b000013105adc01ee000019fb5b609bf500001daa4bf43df20000304c210b1ab300003c1fa5a904b900003fa942c27201000043ac17e0db90000047e80f7fa0b4000048fbbc913b5f00004ad3f867c9e400004ec0b734369800005012a4d75c8e000054796e100536000059139cdce834000065ea81c65138000068a070497a5e00006bf0e2399ebb000070f5d67988dd0000731a686b9ee800008379f1f484cb00009b0a20fe3f9b00009c1fcb07dcf10000b82ac6c75be20000b928319c7d230000cf8f81a0c9520000d6632db4fde80000e53f0f183c700000f0dac18e5b470000fcad9b23a9f70000fefded9f270f00010fa15f532c8b
+- ids hunted: 122525
+- throughput: 0.2M candidates/s
+- fingerprint: fef443725d09d655
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/Hexeption_BLKOPSCW_20260826-041334/material_20260826-041334.txt
+++ b/submissions/Hexeption_BLKOPSCW_20260826-041334/material_20260826-041334.txt
@@ -1,0 +1,1 @@
+47a5252958bcc63f,mc/mtl_p9_ech_wall_concrete_break_01_basics

--- a/submissions/Hexeption_BLKOPSCW_20260826-041334/xmodel_20260826-041334.txt
+++ b/submissions/Hexeption_BLKOPSCW_20260826-041334/xmodel_20260826-041334.txt
@@ -1,0 +1,1 @@
+1535f9628ea48222,p9_ech_wall_concrete_break_01


### PR DESCRIPTION
**BLKOPSCW** — 2 asset names, confirmed against that game's own loaded assets.

- material: 1
- xmodel: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Hexeption

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260826-041110_list
- method: locally evidenced adjacent token order
- what it does: a candidate list generated outside the search and confirmed here
- ran for: 11s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- candidates tested: 1205866
- matched: 2
- new: 2
- sketch stems: 0000003e34caf53b000013105adc01ee000019fb5b609bf500001daa4bf43df20000304c210b1ab300003c1fa5a904b900003fa942c27201000043ac17e0db90000047e80f7fa0b4000048fbbc913b5f00004ad3f867c9e400004ec0b734369800005012a4d75c8e000054796e100536000059139cdce834000065ea81c65138000068a070497a5e00006bf0e2399ebb000070f5d67988dd0000731a686b9ee800008379f1f484cb00009b0a20fe3f9b00009c1fcb07dcf10000b82ac6c75be20000b928319c7d230000cf8f81a0c9520000d6632db4fde80000e53f0f183c700000f0dac18e5b470000fcad9b23a9f70000fefded9f270f00010fa15f532c8b
- ids hunted: 122525
- throughput: 0.2M candidates/s
- fingerprint: fef443725d09d655

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/adjacent_token_order_20260826-041334.py`
- `scripts/contributed/bo4_source_literals_20260826-030006.py`
- `scripts/contributed/separator_variants_20260826-041334.py`
- `scripts/contributed/token_boundaries_20260826-041334.py`
- `scripts/contributed/v2_typed_borrowed_endings_range_20260825-102343.py`
- `scripts/contributed/v2_typed_source_20260825-101559.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.