### PR TITLE
[BLKOPSCW] findings from Hexeption, 20260826-051937 (2 names)

### DIFF
--- a/submissions/Hexeption_BLKOPSCW_20260826-051937/about_20260826-051937.md
+++ b/submissions/Hexeption_BLKOPSCW_20260826-051937/about_20260826-051937.md
@@ -1,0 +1,38 @@
+# Submission 20260826-051937
+
+- game: **BLKOPSCW**
+- from: Hexeption
+- names: 2
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- material: 2
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 100 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260826-045800_plan
+- method: _v2 material borrowed endings, ranks 72001-80000
+- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
+- ran for: 20m 03s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- beginnings: 1500
+- endings: 8000
+- stems: 141276
+- ids hunted: 122523
+- candidates tested: 1695523914000
+- new: 2
+- sketch beginnings: 0017508c03aa4965001992a453043620002077a4869f1dee0068998358af9e5b008ee6ca6afb793d00cce989d0bd829d00ee39546466a8d700f1c4f37093b1f90111fffafec700300165eda0929e98400173cda7a1ad26fd0226390522e17a550238eba73322cd430255cc417c8b51bf02776b5cf63e18be028c000be8a9b4e502c4861aaf3a528e030cac5545522334031531371845a9b2038f56c793bd46fb03ae19ff79a0cfa2042aeac7b4044a500463444e7fcb3328046b2d7f4feea2a004a79d21cd36800704ab024de5294f7104db6b37ce17405104e864492525469904edb8e31dea6fdd0511c525b6b177ec051c07fcae86ccdb051ff11f935345c9
+- sketch stems: 00027448b320e6f200032890a1f89172000384f783c9b577000521269c8d4cc70005ff73c658380d0005ff9b504864f60007e0c12f6b47350007f86027198f3600085810b476429700085e56c85e3af00008c245776950120008df536db543b100093fde16809e8d00098dabb28fb7940009909509b235e20009d17f6dc2770a0009d90288255c97000aa1205e466352000b260da2a9c1c1000b8f8ae0217931000c7217359cfc92000d1cea1123f1a5000d2f8ece55d85f000d320a06dfd331000e850e9e4819aa000e9bee79dc839d000f96d731644207000fe105d77c5f560010330193c9306800105acbe35e234f001153660d7cb8c50012a6725822e148
+- sketch endings: 00017539d5109bf90004158e27fd0bff0013a3a0559d57a10016482c18d815df001854f17ca6491200241a03774ebe65002475d778786e3f003585f2f8df51e400384b966f90315c003dec75cb90b4910047384ed01d83b6004c4db8afe3b93a0066b4a29608adfb007852b6df6c926d007a64a4133b3513007ac89efe76799a0082ccdcb3ca95130088178027794ed6008e630c720691ae00aab0ec0085083c00abe3676709adfd00bb77e3201b18a700c33fb617282e0400c7c8ecbc74af4300ce53e9b0515bd800d0ae4b507e809600e102214e1f49d600e65bbfc742644800eba784e8d956e7010035f304f92e45010d13458d2082e3010d343cf3c874d6
+- fingerprint: ebac8eb25de63ec7
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/Hexeption_BLKOPSCW_20260826-051937/material_20260826-051937.txt
+++ b/submissions/Hexeption_BLKOPSCW_20260826-051937/material_20260826-051937.txt
@@ -1,0 +1,2 @@
+4b76ae6cad02a27,wc/t7_brick_irregular_dmg_01_rvl
+415da30db3ec4a49,mc/plaster_tan_dmg_02_soft_rvl


### PR DESCRIPTION
**BLKOPSCW** — 2 asset names, confirmed against that game's own loaded assets.

- material: 2

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Hexeption

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260826-045800_plan
- method: _v2 material borrowed endings, ranks 72001-80000
- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
- ran for: 20m 03s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- beginnings: 1500
- endings: 8000
- stems: 141276
- ids hunted: 122523
- candidates tested: 1695523914000
- new: 2
- sketch beginnings: 0017508c03aa4965001992a453043620002077a4869f1dee0068998358af9e5b008ee6ca6afb793d00cce989d0bd829d00ee39546466a8d700f1c4f37093b1f90111fffafec700300165eda0929e98400173cda7a1ad26fd0226390522e17a550238eba73322cd430255cc417c8b51bf02776b5cf63e18be028c000be8a9b4e502c4861aaf3a528e030cac5545522334031531371845a9b2038f56c793bd46fb03ae19ff79a0cfa2042aeac7b4044a500463444e7fcb3328046b2d7f4feea2a004a79d21cd36800704ab024de5294f7104db6b37ce17405104e864492525469904edb8e31dea6fdd0511c525b6b177ec051c07fcae86ccdb051ff11f935345c9
- sketch stems: 00027448b320e6f200032890a1f89172000384f783c9b577000521269c8d4cc70005ff73c658380d0005ff9b504864f60007e0c12f6b47350007f86027198f3600085810b476429700085e56c85e3af00008c245776950120008df536db543b100093fde16809e8d00098dabb28fb7940009909509b235e20009d17f6dc2770a0009d90288255c97000aa1205e466352000b260da2a9c1c1000b8f8ae0217931000c7217359cfc92000d1cea1123f1a5000d2f8ece55d85f000d320a06dfd331000e850e9e4819aa000e9bee79dc839d000f96d731644207000fe105d77c5f560010330193c9306800105acbe35e234f001153660d7cb8c50012a6725822e148
- sketch endings: 00017539d5109bf90004158e27fd0bff0013a3a0559d57a10016482c18d815df001854f17ca6491200241a03774ebe65002475d778786e3f003585f2f8df51e400384b966f90315c003dec75cb90b4910047384ed01d83b6004c4db8afe3b93a0066b4a29608adfb007852b6df6c926d007a64a4133b3513007ac89efe76799a0082ccdcb3ca95130088178027794ed6008e630c720691ae00aab0ec0085083c00abe3676709adfd00bb77e3201b18a700c33fb617282e0400c7c8ecbc74af4300ce53e9b0515bd800d0ae4b507e809600e102214e1f49d600e65bbfc742644800eba784e8d956e7010035f304f92e45010d13458d2082e3010d343cf3c874d6
- fingerprint: ebac8eb25de63ec7

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/adjacent_token_order_20260826-041334.py`
- `scripts/contributed/bo4_source_literals_20260826-030006.py`
- `scripts/contributed/map_prefix_mode_grid_20260826-044806.py`
- `scripts/contributed/separator_variants_20260826-041334.py`
- `scripts/contributed/source_literal_concats_20260826-044806.py`
- `scripts/contributed/token_boundaries_20260826-041334.py`
- `scripts/contributed/v2_typed_borrowed_endings_range_20260825-102343.py`
- `scripts/contributed/v2_typed_source_20260825-101559.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.