### PR TITLE
[BLKOPSCW] findings from Zakkary19, 20260826-080437 (2 names)

### DIFF
--- a/submissions/Zakkary19_BLKOPSCW_20260826-080437/about_20260826-080437.md
+++ b/submissions/Zakkary19_BLKOPSCW_20260826-080437/about_20260826-080437.md
@@ -1,0 +1,38 @@
+# Submission 20260826-080437
+
+- game: **BLKOPSCW**
+- from: Zakkary19
+- names: 2
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- material: 2
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 100 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260826-075837_plan
+- method: all-boundary sound cores x uncarried sound endings
+- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
+- ran for: 3m 17s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- beginnings: 0
+- endings: 28304
+- stems: 2018668
+- ids hunted: 122845
+- candidates tested: 57138397740
+- new: 2
+- sketch beginnings: 
+- sketch stems: 000001ad4b3a16660000055355fb707b0000116c72a86c8800001a7948e2da7b0000261d00af5a5700002b1519e1ded400003cd0bb5e04e900003e662bfcc8e100003f686b513e9300004539e386abfe000047045784f62e000048bb4c35d1c700004ec0ee5f3551000059b99780a20500006296216d57d100006d11a6a6ae7600008ed79cb32e090000965d9177932d000098934c7c630600009da2806c90300000aa984ebb57620000aec8c22d128f0000b327d9e196d40000c2b8a94bc4b40000c43959f1d3170000c6e299e473210000d0b5476b5d4b0000d5f19e8574340000d7354da7c98b0000d97fef7000c50000ef4a2113a6a70000fea310cfca17
+- sketch endings: 0004e83a03144b810007a544f9072879000a2ca527ed58380012ed645c322543001494c09150134100173525c400009e001a6caa73694b19001f772d70565e6b002248b820015177002272a0545b733c002509325fdbb6ab0025413a86e41ba80025afd40afb061400273cc10c9e1af500283dd27c81a359002ac5dc8e45c419002bc3511321326e00303aac00c209b00030bee52f5c9007003175ebb597b6660031a893c7d06dcb0032ff0ae639bb010034eb49902ccad10036551192a3d812003f790b10c162d2003ff36eebaf97e400400a4462ea460300404bcc6f59dc5c004162181e1bfe2b0041c5ade22f69500044cd9b8c115c7f00450baa68a34cdc
+- fingerprint: bccb5381894b0e48
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/Zakkary19_BLKOPSCW_20260826-080437/material_20260826-080437.txt
+++ b/submissions/Zakkary19_BLKOPSCW_20260826-080437/material_20260826-080437.txt
@@ -1,0 +1,2 @@
+660b583b98b1b4f,mc/mtl_p9_rm_drv_tower_radio_decal_dirt_dirty
+4aded35be7389c3d,mc/mtl_veh_t9_mil_ru_tank_sam_missile_decal_text_aa


### PR DESCRIPTION
**BLKOPSCW** — 2 asset names, confirmed against that game's own loaded assets.

- material: 2

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Zakkary19

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260826-075837_plan
- method: all-boundary sound cores x uncarried sound endings
- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
- ran for: 3m 17s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- beginnings: 0
- endings: 28304
- stems: 2018668
- ids hunted: 122845
- candidates tested: 57138397740
- new: 2
- sketch beginnings: 
- sketch stems: 000001ad4b3a16660000055355fb707b0000116c72a86c8800001a7948e2da7b0000261d00af5a5700002b1519e1ded400003cd0bb5e04e900003e662bfcc8e100003f686b513e9300004539e386abfe000047045784f62e000048bb4c35d1c700004ec0ee5f3551000059b99780a20500006296216d57d100006d11a6a6ae7600008ed79cb32e090000965d9177932d000098934c7c630600009da2806c90300000aa984ebb57620000aec8c22d128f0000b327d9e196d40000c2b8a94bc4b40000c43959f1d3170000c6e299e473210000d0b5476b5d4b0000d5f19e8574340000d7354da7c98b0000d97fef7000c50000ef4a2113a6a70000fea310cfca17
- sketch endings: 0004e83a03144b810007a544f9072879000a2ca527ed58380012ed645c322543001494c09150134100173525c400009e001a6caa73694b19001f772d70565e6b002248b820015177002272a0545b733c002509325fdbb6ab0025413a86e41ba80025afd40afb061400273cc10c9e1af500283dd27c81a359002ac5dc8e45c419002bc3511321326e00303aac00c209b00030bee52f5c9007003175ebb597b6660031a893c7d06dcb0032ff0ae639bb010034eb49902ccad10036551192a3d812003f790b10c162d2003ff36eebaf97e400400a4462ea460300404bcc6f59dc5c004162181e1bfe2b0041c5ade22f69500044cd9b8c115c7f00450baa68a34cdc
- fingerprint: bccb5381894b0e48

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/bo4snd_ends_20260826-004415.txt`
- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/numbered_grids_20260821-054219.py`
- `scripts/contributed/overnight_suite_20260826-004415.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.