### PR TITLE
[BLKOPS04] findings from Hexeption, 20260826-080521 (2 names)

### DIFF
--- a/scripts/contributed/precedents_suffix6_20260826-080521.py
+++ b/scripts/contributed/precedents_suffix6_20260826-080521.py
@@ -1,0 +1,67 @@
+"""Offer each six-token suffix the one-token precedents measured before that exact suffix.
+
+Run:
+    python contrib/precedents_suffix6.py | bin\\windows\\confirm_list.exe - ^
+        --label "per-suffix precedents, six-token tails" --script contrib/precedents_suffix6.py
+
+This is a reusable, stricter continuation of ``scripts/precedents.py``.  It reads the current
+published and confirmed corpus and writes candidates to standard output; no working data is
+written.  Six-token tails are deliberately kept separate from the established five-token pass so
+the search reaches a distinct, more specific contextual ground.
+"""
+import os
+import sys
+
+_root = os.path.dirname(os.path.abspath(__file__))
+while _root != os.path.dirname(_root) and not os.path.isfile(
+    os.path.join(_root, "scripts", "snapshot.py")
+):
+    _root = os.path.dirname(_root)
+sys.path.insert(0, os.path.join(_root, "scripts"))
+
+import argparse
+import collections
+import precedents
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--most", type=int, default=precedents.MOST_PRECEDENTS)
+    parser.add_argument("--count", action="store_true")
+    options = parser.parse_args(argv)
+    names = precedents.known_names()
+    before = precedents.measure(names)
+    suffixes = collections.defaultdict(collections.Counter)
+    for name in names:
+        directory, parts = precedents.split(name)
+        if len(parts) < 8:
+            continue
+        suffix = "_" + "_".join(parts[-6:])
+        suffixes[suffix][parts[-7]] += 1
+    offered = {
+        suffix: [token for token, _ in counts.most_common(options.most)]
+        for suffix, counts in suffixes.items()
+        if sum(counts.values()) >= precedents.LEAST_SEEN
+    }
+    candidates = set()
+    for name in names:
+        directory, parts = precedents.split(name)
+        if len(parts) < 8:
+            continue
+        suffix = "_" + "_".join(parts[-6:])
+        for token in offered.get(suffix, ()):
+            if token == parts[-7]:
+                continue
+            candidates.add(directory + "_".join(parts[:-7] + [token] + parts[-6:]))
+    print(f"known names: {len(names):,}", file=sys.stderr)
+    print(f"six-token suffixes with precedents: {len(offered):,}", file=sys.stderr)
+    print(f"unique candidates: {len(candidates):,}", file=sys.stderr)
+    if not options.count:
+        sys.stdout.write("\n".join(candidates))
+        if candidates:
+            sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/submissions/Hexeption_BLKOPS04_20260826-080521/about_20260826-080521.md
+++ b/submissions/Hexeption_BLKOPS04_20260826-080521/about_20260826-080521.md
@@ -1,0 +1,38 @@
+# Submission 20260826-080521
+
+- game: **BLKOPS04**
+- from: Hexeption
+- names: 2
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- xanim: 2
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 100 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260826-075941_plan
+- method: _v2 xanim borrowed endings, ranks 24001-32000
+- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
+- ran for: 2m 46s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- beginnings: 1500
+- endings: 8000
+- stems: 9117
+- ids hunted: 163705
+- candidates tested: 109417675500
+- new: 2
+- sketch beginnings: 000fc8c79c7c49ea0020827dba0df4e6005990dd0d3b363b008239b90999bf180098b615974373250119a347d380e9b2011bc5777ea5360201341ad290b43153018d7a123421d6cd0192cde7dcc31dae01c74a82188c591801da85b090e454150202a1357e8f2a6502371e2055b11fcd027d47769d2e729302b6009a484f7d5e02d24f422726554802e7b6a411789f9b02f484df4f983cc10358bf0fa7f91c6703acf04c20a48f8203d502075e1ab46c03fc72a0f79baa35045b997cbd8f138c048a1e6c3be283410495d72b31863c38050b62da0ae5aa900516d5eb6fe5fccc0523afead2ee113a052e50b0280d6ecf053c59eacd40f39105430a46bf9a5597
+- sketch stems: 000a9af65b41e5a5000b92d3b6ca537a0022fa2cd1f4743c00298120d730b5c80031b5a6fc96b144003651949be6c5e10039878ae0c98d70003acf017d2fca1d0041c1e60b539f7700422a1923c49411004336bbd4dfae520048c22615d27a3f00494f789eec381b004a85482f889bb60051eff89596d29e0053d76675da1c9e005f95058f59a2d40078cc7efc63f24d008e4e20ff7016250092c607e827f92d00974e0004bbc6d0009d7e4fb856bf7900a6aa81fa43536e00abfbbc7cc3759900ae91c761dcd27700bb97275fb4492500bfada269acb13600cae7a76fcb6a5500cd7992e01ca93700d19847ac982de000d3d483d16967b600d6a05609db7a4d
+- sketch endings: 0006c6029f07580100132a1eb6c30d2d0017146ecc62c90f00173525c400009e00228960d5ef3f51002d646afe57541b00388a0374715c0a005beac98544c7ae005efbcf03390c650065c20aff5b66c8006e12c037775805007935a8d711665c0081e2b1a5586b8900841f16b6c126d500891b722cad2bd6009aa8e602437cee009f55ae8b98e4fb00a150557ce5ddef00ab30a31057b25900bb5d69902fd1be00c48259234d978d00c585d54328095800ceef565e78bafb00d0bc292f06800600daebed1bfb2a8800def554eacc2a1a00e4763b1b1d7f8500eb3e4df25ad04000f260efd13ccdeb00f66812db5dfba400fd5092a403ff16010e305c187e0b36
+- fingerprint: b1b4b7e4737bf0ae
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/Hexeption_BLKOPS04_20260826-080521/xanim_20260826-080521.txt
+++ b/submissions/Hexeption_BLKOPS04_20260826-080521/xanim_20260826-080521.txt
@@ -1,0 +1,2 @@
+488974e02c474a7b,pt_dw_swim_fire_leftarm
+62ab93eedebe3246,pt_dw_swim_fire_over_leftarm


### PR DESCRIPTION
**BLKOPS04** — 2 asset names, confirmed against that game's own loaded assets.

- xanim: 2

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Hexeption

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260826-075941_plan
- method: _v2 xanim borrowed endings, ranks 24001-32000
- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
- ran for: 2m 46s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- beginnings: 1500
- endings: 8000
- stems: 9117
- ids hunted: 163705
- candidates tested: 109417675500
- new: 2
- sketch beginnings: 000fc8c79c7c49ea0020827dba0df4e6005990dd0d3b363b008239b90999bf180098b615974373250119a347d380e9b2011bc5777ea5360201341ad290b43153018d7a123421d6cd0192cde7dcc31dae01c74a82188c591801da85b090e454150202a1357e8f2a6502371e2055b11fcd027d47769d2e729302b6009a484f7d5e02d24f422726554802e7b6a411789f9b02f484df4f983cc10358bf0fa7f91c6703acf04c20a48f8203d502075e1ab46c03fc72a0f79baa35045b997cbd8f138c048a1e6c3be283410495d72b31863c38050b62da0ae5aa900516d5eb6fe5fccc0523afead2ee113a052e50b0280d6ecf053c59eacd40f39105430a46bf9a5597
- sketch stems: 000a9af65b41e5a5000b92d3b6ca537a0022fa2cd1f4743c00298120d730b5c80031b5a6fc96b144003651949be6c5e10039878ae0c98d70003acf017d2fca1d0041c1e60b539f7700422a1923c49411004336bbd4dfae520048c22615d27a3f00494f789eec381b004a85482f889bb60051eff89596d29e0053d76675da1c9e005f95058f59a2d40078cc7efc63f24d008e4e20ff7016250092c607e827f92d00974e0004bbc6d0009d7e4fb856bf7900a6aa81fa43536e00abfbbc7cc3759900ae91c761dcd27700bb97275fb4492500bfada269acb13600cae7a76fcb6a5500cd7992e01ca93700d19847ac982de000d3d483d16967b600d6a05609db7a4d
- sketch endings: 0006c6029f07580100132a1eb6c30d2d0017146ecc62c90f00173525c400009e00228960d5ef3f51002d646afe57541b00388a0374715c0a005beac98544c7ae005efbcf03390c650065c20aff5b66c8006e12c037775805007935a8d711665c0081e2b1a5586b8900841f16b6c126d500891b722cad2bd6009aa8e602437cee009f55ae8b98e4fb00a150557ce5ddef00ab30a31057b25900bb5d69902fd1be00c48259234d978d00c585d54328095800ceef565e78bafb00d0bc292f06800600daebed1bfb2a8800def554eacc2a1a00e4763b1b1d7f8500eb3e4df25ad04000f260efd13ccdeb00f66812db5dfba400fd5092a403ff16010e305c187e0b36
- fingerprint: b1b4b7e4737bf0ae

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/adjacent_token_order_20260826-041334.py`
- `scripts/contributed/bo4_source_literals_20260826-030006.py`
- `scripts/contributed/map_prefix_mode_grid_20260826-044806.py`
- `scripts/contributed/precedents_suffix6_20260826-080521.py`
- `scripts/contributed/separator_variants_20260826-041334.py`
- `scripts/contributed/source_literal_concats_20260826-044806.py`
- `scripts/contributed/suffix_block_precedents_20260826-064355.py`
- `scripts/contributed/token_boundaries_20260826-041334.py`
- `scripts/contributed/v2_typed_borrowed_endings_range_20260825-102343.py`
- `scripts/contributed/v2_typed_source_20260825-101559.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.