### PR TITLE
[BLKOPSCW] findings from Zakkary19, 20260826-093803 (2 names)

### DIFF
--- a/submissions/Zakkary19_BLKOPSCW_20260826-093803/about_20260826-093803.md
+++ b/submissions/Zakkary19_BLKOPSCW_20260826-093803/about_20260826-093803.md
@@ -1,0 +1,38 @@
+# Submission 20260826-093803
+
+- game: **BLKOPSCW**
+- from: Zakkary19
+- names: 2
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- material: 2
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 100 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260826-092902_plan
+- method: all-boundary cores x uncarried endings
+- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
+- ran for: 6m 20s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- beginnings: 0
+- endings: 100000
+- stems: 1790004
+- ids hunted: 122845
+- candidates tested: 179002190004
+- new: 2
+- sketch beginnings: 
+- sketch stems: 000006e18d650fb900000ab4ba1aeee400000c977c5d672200000feaf9e727be000012c311da10ff0000169f01f264ce00002b1519e1ded4000037218d8ac72000003b9f496e1f3100004e56e3fbb0ec000054c6c2049ef9000054e2e1aff6700000595d5e43b51e0000612ff46513d0000062e7cbfd19140000673d5ec1845600006c06f143465600006dfd9719897600007cbaa17ccc8d0000953fd0beca160000b9a20339b21f0000bb7c449703510000bdf5ddb3c7270000c951a42bde610000d86305422c730000d86ce7b41ecb0000dff33e0893840000ef4a2113a6a70000f0d2d965b07e0000f0e6510e13400000f8739296b6aa00010c5b5e86db17
+- sketch endings: 0001bf49f7ec48d30001df6ac08d3428000229682628f65c000271aa0414ec0b0002da8ef2e22ceb000368909aaa7dc600067eab9c5d06f9000715995132634d00079b9bd87017440007fa22af3229dc00081b80627cffa80008f05da7a32d8b000931978e22ab230009b3595fe41010000b8b91a2cae7a6000dac17c66fcdb1000e676be6fed101000f2b3bdf945843000f3fed4afaa24f00103ca407b45ca70010dea55748343000115a72530fe295001203b2611bcd5200131eb4e7bcfef500135065d628cdd3001494595def5ffd00149cee732b298b0014cffc55cfa7160014ff7cc20d9bd50016ee0622fb3c6700170d2b19575e04001747673152a206
+- fingerprint: c0d15da03b014d82
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/Zakkary19_BLKOPSCW_20260826-093803/material_20260826-093803.txt
+++ b/submissions/Zakkary19_BLKOPSCW_20260826-093803/material_20260826-093803.txt
@@ -1,0 +1,2 @@
+101b605e29c83e78,mc/mtl_veh_t9_mil_boat_jetski_mpx_mech_attachment_armor_side_d_dead
+66eba75439c1186d,mc/mtl_veh_t9_mil_boat_jetski_mpx_mech_attachment_armor_side_e_dead


### PR DESCRIPTION
**BLKOPSCW** — 2 asset names, confirmed against that game's own loaded assets.

- material: 2

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Zakkary19

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260826-092902_plan
- method: all-boundary cores x uncarried endings
- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
- ran for: 6m 20s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- beginnings: 0
- endings: 100000
- stems: 1790004
- ids hunted: 122845
- candidates tested: 179002190004
- new: 2
- sketch beginnings: 
- sketch stems: 000006e18d650fb900000ab4ba1aeee400000c977c5d672200000feaf9e727be000012c311da10ff0000169f01f264ce00002b1519e1ded4000037218d8ac72000003b9f496e1f3100004e56e3fbb0ec000054c6c2049ef9000054e2e1aff6700000595d5e43b51e0000612ff46513d0000062e7cbfd19140000673d5ec1845600006c06f143465600006dfd9719897600007cbaa17ccc8d0000953fd0beca160000b9a20339b21f0000bb7c449703510000bdf5ddb3c7270000c951a42bde610000d86305422c730000d86ce7b41ecb0000dff33e0893840000ef4a2113a6a70000f0d2d965b07e0000f0e6510e13400000f8739296b6aa00010c5b5e86db17
- sketch endings: 0001bf49f7ec48d30001df6ac08d3428000229682628f65c000271aa0414ec0b0002da8ef2e22ceb000368909aaa7dc600067eab9c5d06f9000715995132634d00079b9bd87017440007fa22af3229dc00081b80627cffa80008f05da7a32d8b000931978e22ab230009b3595fe41010000b8b91a2cae7a6000dac17c66fcdb1000e676be6fed101000f2b3bdf945843000f3fed4afaa24f00103ca407b45ca70010dea55748343000115a72530fe295001203b2611bcd5200131eb4e7bcfef500135065d628cdd3001494595def5ffd00149cee732b298b0014cffc55cfa7160014ff7cc20d9bd50016ee0622fb3c6700170d2b19575e04001747673152a206
- fingerprint: c0d15da03b014d82

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/bo4snd_ends_20260826-004415.txt`
- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/numbered_grids_20260821-054219.py`
- `scripts/contributed/overnight_suite_20260826-004415.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.