### PR TITLE
[BLKOPS04] findings from Hexeption, 20260826-102939 (3 names)

### DIFF
--- a/submissions/Hexeption_BLKOPS04_20260826-102939/about_20260826-102939.md
+++ b/submissions/Hexeption_BLKOPS04_20260826-102939/about_20260826-102939.md
@@ -1,0 +1,53 @@
+# Submission 20260826-102939
+
+- game: **BLKOPS04**
+- from: Hexeption
+- names: 3
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 2
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- image: 2
+- material: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 100 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260826-102345_list
+- method: image siblings of confirmed materials
+- what it does: a candidate list generated outside the search and confirmed here
+- ran for: 6s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- candidates tested: 1893903
+- matched: 4
+- new: 2
+- sketch stems: 000006bc59d8576d000013e9d17db956000016cbd3943da90000323b45a663a9000033b79e0eedd500003be26e53e51800003cc8026e4712000041efc7f1be4a00004854e9ea014100004c0e8c5515bd000052f1f2e348900000531313c9493100005d348940d586000063a33732586900006945e25546130000765607c932be00007efa48f1393700008a1a18991fbf000096e85d9155db0000974c8aeee78a00009d6043da5beb0000a6a51d22c1450000a6cb3612cfd60000afe7af4409e30000bfb517cb1b210000ceda8a5148c30000d040f64095430000d466a19c598f0000db54bb8b768b0000ddf8ca00e0fb00010776a26adf6500010cd4b4c4690c
+- ids hunted: 163666
+- throughput: 0.6M candidates/s
+- fingerprint: fcd60cda18c741af
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.
+
+### run_20260826-102352_list
+- method: materials from image cores
+- what it does: a candidate list generated outside the search and confirmed here
+- ran for: 9s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- candidates tested: 4736760
+- matched: 2
+- new: 1
+- sketch stems: 00000b49cdacf2a40000158d4871a4d800001d2ce810eed600001fc3b65de7ea000023ea2200edc20000245b48853f14000025728e943b5b0000299c09e9a21100002c234c058d5f00002cf784b0845600003086198d162f000030f27796d95b000033921bf5d854000034bcb64c23ae000038ae7c24696900003fb4f1dab64e000046f061291cbc00004b8010f9d0d800004c850c37a28300005833d6ee7cdb00005da5289742b40000621362ce07370000632284f9e92200006659652065910000685279e7811a00006fc0b99231d0000078ae84036a0f000079b9a955a44d00007b8a98503cc500008321177320f10000837c07d21d7b0000869fdcdd71aa
+- ids hunted: 163666
+- throughput: 0.8M candidates/s
+- fingerprint: 67cd9816ffb2626a
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/Hexeption_BLKOPS04_20260826-102939/image_20260826-102939.txt
+++ b/submissions/Hexeption_BLKOPS04_20260826-102939/image_20260826-102939.txt
@@ -1,0 +1,2 @@
+5596433982bccab7,i_attach_t8_loot_ar_doubletap_long_barrel_mk2_n
+5596443982bccc6a,i_attach_t8_loot_ar_doubletap_long_barrel_mk2_m

--- a/submissions/Hexeption_BLKOPS04_20260826-102939/material_20260826-102939.txt
+++ b/submissions/Hexeption_BLKOPS04_20260826-102939/material_20260826-102939.txt
@@ -1,0 +1,1 @@
+3674f366a2da940e,mc/mtl_attach_t8_loot_ar_doubletap_long_barrel_muzzle


### PR DESCRIPTION
**BLKOPS04** — 3 asset names, confirmed against that game's own loaded assets.

- image: 2
- material: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Hexeption

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260826-102345_list
- method: image siblings of confirmed materials
- what it does: a candidate list generated outside the search and confirmed here
- ran for: 6s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- candidates tested: 1893903
- matched: 4
- new: 2
- sketch stems: 000006bc59d8576d000013e9d17db956000016cbd3943da90000323b45a663a9000033b79e0eedd500003be26e53e51800003cc8026e4712000041efc7f1be4a00004854e9ea014100004c0e8c5515bd000052f1f2e348900000531313c9493100005d348940d586000063a33732586900006945e25546130000765607c932be00007efa48f1393700008a1a18991fbf000096e85d9155db0000974c8aeee78a00009d6043da5beb0000a6a51d22c1450000a6cb3612cfd60000afe7af4409e30000bfb517cb1b210000ceda8a5148c30000d040f64095430000d466a19c598f0000db54bb8b768b0000ddf8ca00e0fb00010776a26adf6500010cd4b4c4690c
- ids hunted: 163666
- throughput: 0.6M candidates/s
- fingerprint: fcd60cda18c741af

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

### run_20260826-102352_list
- method: materials from image cores
- what it does: a candidate list generated outside the search and confirmed here
- ran for: 9s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- candidates tested: 4736760
- matched: 2
- new: 1
- sketch stems: 00000b49cdacf2a40000158d4871a4d800001d2ce810eed600001fc3b65de7ea000023ea2200edc20000245b48853f14000025728e943b5b0000299c09e9a21100002c234c058d5f00002cf784b0845600003086198d162f000030f27796d95b000033921bf5d854000034bcb64c23ae000038ae7c24696900003fb4f1dab64e000046f061291cbc00004b8010f9d0d800004c850c37a28300005833d6ee7cdb00005da5289742b40000621362ce07370000632284f9e92200006659652065910000685279e7811a00006fc0b99231d0000078ae84036a0f000079b9a955a44d00007b8a98503cc500008321177320f10000837c07d21d7b0000869fdcdd71aa
- ids hunted: 163666
- throughput: 0.8M candidates/s
- fingerprint: 67cd9816ffb2626a

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/materials_from_images.py`
- `scripts/contributed/adjacent_token_order_20260826-041334.py`
- `scripts/contributed/bo4_source_literals_20260826-030006.py`
- `scripts/contributed/map_prefix_mode_grid_20260826-044806.py`
- `scripts/contributed/precedents_suffix6_20260826-080521.py`
- `scripts/contributed/separator_variants_20260826-041334.py`
- `scripts/contributed/source_literal_concats_20260826-044806.py`
- `scripts/contributed/suffix_block_precedents_20260826-064355.py`
- `scripts/contributed/token_boundaries_20260826-041334.py`
- `scripts/contributed/uncarried_ends_20260826-083728.txt`
- `scripts/contributed/uncarried_ends_20260826-093543.txt`
- `scripts/contributed/uncarried_ends_20260826-085424.txt`
- `scripts/contributed/uncarried_ends_20260826-090330.txt`
- `scripts/contributed/uncarried_ends_20260826-093543.txt`
- `scripts/contributed/v2_typed_borrowed_endings_range_20260825-102343.py`
- `scripts/contributed/v2_typed_source_20260825-101559.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.