### PR TITLE
[BLKOPS04] findings from Hexeption, 20260826-120940 (3 names)

### DIFF
--- a/scripts/contributed/head_axis_tail_grid_20260826-120940.py
+++ b/scripts/contributed/head_axis_tail_grid_20260826-120940.py
@@ -1,0 +1,38 @@
+"""Fill evidence-backed head_axis_tail family grids without requiring shared tails."""
+import collections
+import pathlib
+import sys
+import argparse
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+import snapshot
+
+TABLES = ("fnv1a_xmaterials", "fnv1a_xmaterials_v2", "fnv1a_ximages",
+          "fnv1a_ximages_v2", "fnv1a_xmodels", "fnv1a_xanims", "fnv1a_xanims_v2")
+have = {n.lower() for n in snapshot.table_names(*TABLES)} | {n.lower() for n in snapshot.confirmed_names()}
+groups = collections.defaultdict(list)
+for name in have:
+    if name.count("_") >= 2 and all(c not in name for c in "/.\\"):
+        p = name.split("_", 2)
+        if len(p) == 3 and p[1] and p[2]:
+            groups[p[0]].append((p[1], p[2]))
+ranked = []
+for head, pairs in groups.items():
+    axes = {a for a, _ in pairs}; tails = {t for _, t in pairs}
+    if len(pairs) >= 200 and len(axes) >= 3 and len(tails) >= 20:
+        ranked.append((len(axes) * len(tails), head, axes, tails))
+ranked.sort(reverse=True)
+ap = argparse.ArgumentParser(); ap.add_argument('--size', action='store_true'); ap.add_argument('--top', type=int, default=8); ap.add_argument('--cap', type=int, default=50_000_000); args = ap.parse_args()
+seen = set(); cap = args.cap
+for _, head, axes, tails in ranked[:args.top]:
+    for axis in sorted(axes):
+        for tail in sorted(tails):
+            if len(seen) >= cap: break
+            candidate = f"{head}_{axis}_{tail}"
+            if candidate not in have:
+                seen.add(candidate)
+        if len(seen) >= cap: break
+    if len(seen) >= cap: break
+print(f"{len(ranked)} families, {len(seen)} unseen cells", file=sys.stderr)
+if not args.size:
+    for candidate in sorted(seen): print(candidate)

--- a/submissions/Hexeption_BLKOPS04_20260826-120940/about_20260826-120940.md
+++ b/submissions/Hexeption_BLKOPS04_20260826-120940/about_20260826-120940.md
@@ -1,0 +1,38 @@
+# Submission 20260826-120940
+
+- game: **BLKOPS04**
+- from: Hexeption
+- names: 3
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- xanim: 3
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 100 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260826-120531_plan
+- method: _v2 xanim borrowed endings, ranks 24001-32000
+- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
+- ran for: 2m 38s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- beginnings: 1500
+- endings: 8000
+- stems: 9160
+- ids hunted: 163645
+- candidates tested: 109933740000
+- new: 3
+- sketch beginnings: 000fc8c79c7c49ea0020827dba0df4e6005990dd0d3b363b008239b90999bf180098b615974373250119a347d380e9b2011bc5777ea5360201341ad290b43153018d7a123421d6cd0192cde7dcc31dae01c74a82188c591801da85b090e454150202a1357e8f2a6502371e2055b11fcd025a432f273c86e6027d47769d2e729302b6009a484f7d5e02d24f422726554802e7b6a411789f9b02f484df4f983cc10358bf0fa7f91c6703acf04c20a48f8203d502075e1ab46c03fc72a0f79baa35045b997cbd8f138c048a1e6c3be283410495d72b31863c38050b62da0ae5aa900516d5eb6fe5fccc0523afead2ee113a052e50b0280d6ecf053c59eacd40f391
+- sketch stems: 000a9af65b41e5a5000b92d3b6ca537a0022fa2cd1f4743c00298120d730b5c80031b5a6fc96b144003651949be6c5e10039878ae0c98d70003acf017d2fca1d0041c1e60b539f7700422a1923c49411004336bbd4dfae520048c22615d27a3f00494f789eec381b004a85482f889bb60051eff89596d29e0053d76675da1c9e005f95058f59a2d40078cc7efc63f24d008e4e20ff7016250092c607e827f92d00974e0004bbc6d0009d7e4fb856bf7900a6aa81fa43536e00abfbbc7cc3759900ae91c761dcd27700bb97275fb4492500bfada269acb13600cae7a76fcb6a5500cd7992e01ca93700d19847ac982de000d3d483d16967b600d6a05609db7a4d
+- sketch endings: 0003c818cfdeb8b10006c6029f07580100132a1eb6c30d2d0017c2597271e7d4001c386035eca776002d646afe57541b005efbcf03390c65006078e67261dfa60065c20aff5b66c8006e12c037775805007935a8d711665c007fb9de52765ce000891b722cad2bd6009aa8e602437cee009f55ae8b98e4fb00a150557ce5ddef00c585d54328095800c7d6937ad7308900c86a2ac304fbc300d0bc292f06800600daebed1bfb2a8800def554eacc2a1a00eb3e4df25ad04000ecbe16f76f4b7200f260efd13ccdeb00f66812db5dfba401168e654965b0d9011bc12bf526113501259ce04d604385012da8bb7c8795ec013c18de7a1e43fd014afa68682f22a4
+- fingerprint: 7efe110d81503bdd
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/Hexeption_BLKOPS04_20260826-120940/xanim_20260826-120940.txt
+++ b/submissions/Hexeption_BLKOPS04_20260826-120940/xanim_20260826-120940.txt
@@ -1,0 +1,3 @@
+3fec6e6b86e77a55,pb_tablet_ult_prone_flashed
+58a2bf47ecffff97,pt_ruin_grapple_gun_pullout
+58e9a548e3e60099,pb_tablet_ult_prone_concussed


### PR DESCRIPTION
**BLKOPS04** — 3 asset names, confirmed against that game's own loaded assets.

- xanim: 3

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Hexeption

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260826-120531_plan
- method: _v2 xanim borrowed endings, ranks 24001-32000
- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
- ran for: 2m 38s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- beginnings: 1500
- endings: 8000
- stems: 9160
- ids hunted: 163645
- candidates tested: 109933740000
- new: 3
- sketch beginnings: 000fc8c79c7c49ea0020827dba0df4e6005990dd0d3b363b008239b90999bf180098b615974373250119a347d380e9b2011bc5777ea5360201341ad290b43153018d7a123421d6cd0192cde7dcc31dae01c74a82188c591801da85b090e454150202a1357e8f2a6502371e2055b11fcd025a432f273c86e6027d47769d2e729302b6009a484f7d5e02d24f422726554802e7b6a411789f9b02f484df4f983cc10358bf0fa7f91c6703acf04c20a48f8203d502075e1ab46c03fc72a0f79baa35045b997cbd8f138c048a1e6c3be283410495d72b31863c38050b62da0ae5aa900516d5eb6fe5fccc0523afead2ee113a052e50b0280d6ecf053c59eacd40f391
- sketch stems: 000a9af65b41e5a5000b92d3b6ca537a0022fa2cd1f4743c00298120d730b5c80031b5a6fc96b144003651949be6c5e10039878ae0c98d70003acf017d2fca1d0041c1e60b539f7700422a1923c49411004336bbd4dfae520048c22615d27a3f00494f789eec381b004a85482f889bb60051eff89596d29e0053d76675da1c9e005f95058f59a2d40078cc7efc63f24d008e4e20ff7016250092c607e827f92d00974e0004bbc6d0009d7e4fb856bf7900a6aa81fa43536e00abfbbc7cc3759900ae91c761dcd27700bb97275fb4492500bfada269acb13600cae7a76fcb6a5500cd7992e01ca93700d19847ac982de000d3d483d16967b600d6a05609db7a4d
- sketch endings: 0003c818cfdeb8b10006c6029f07580100132a1eb6c30d2d0017c2597271e7d4001c386035eca776002d646afe57541b005efbcf03390c65006078e67261dfa60065c20aff5b66c8006e12c037775805007935a8d711665c007fb9de52765ce000891b722cad2bd6009aa8e602437cee009f55ae8b98e4fb00a150557ce5ddef00c585d54328095800c7d6937ad7308900c86a2ac304fbc300d0bc292f06800600daebed1bfb2a8800def554eacc2a1a00eb3e4df25ad04000ecbe16f76f4b7200f260efd13ccdeb00f66812db5dfba401168e654965b0d9011bc12bf526113501259ce04d604385012da8bb7c8795ec013c18de7a1e43fd014afa68682f22a4
- fingerprint: 7efe110d81503bdd

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/adjacent_token_order_20260826-041334.py`
- `scripts/contributed/blkops04_sound_asset_dirs_20260826-104215.txt`
- `scripts/contributed/blkops04_sound_asset_ends_20260826-104215.txt`
- `scripts/contributed/blkops04_sound_asset_stems_20260826-104215.txt`
- `scripts/contributed/bo4_source_literals_20260826-030006.py`
- `scripts/contributed/head_axis_tail_grid_20260826-120940.py`
- `scripts/contributed/map_prefix_mode_grid_20260826-044806.py`
- `scripts/contributed/precedents_suffix6_20260826-080521.py`
- `scripts/contributed/separator_variants_20260826-041334.py`
- `scripts/contributed/source_literal_concats_20260826-044806.py`
- `scripts/contributed/suffix_block_precedents_20260826-064355.py`
- `scripts/contributed/token_boundaries_20260826-041334.py`
- `scripts/contributed/uncarried_ends_20260826-083728.txt`
- `scripts/contributed/uncarried_ends_20260826-093543.txt`
- `scripts/contributed/uncarried_ends_20260826-085424.txt`
- `scripts/contributed/uncarried_ends_20260826-090330.txt`
- `scripts/contributed/uncarried_ends_20260826-093543.txt`
- `scripts/contributed/v2_typed_borrowed_endings_range_20260825-102343.py`
- `scripts/contributed/v2_typed_source_20260825-101559.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.