### PR TITLE
[BLKOPS04] findings from Hexeption, 20260826-223823 (1 names)

### DIFF
--- a/scripts/contributed/bo2_sab_to_bo4_asset_20260826-223823.py
+++ b/scripts/contributed/bo2_sab_to_bo4_asset_20260826-223823.py
@@ -1,0 +1,19 @@
+"""Transfer BO2 SAB cores into BO4's literal-backslash sound_asset grammar."""
+import pathlib, re
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+TAILS = ("ln100.pc.snd", "ll100.pc.snd", "sn100.pc.snd", "sl100.pc.snd", "pn100.pc.snd", "pl100.pc.snd")
+LANG = {"en","ru","fr","de","it","es","pt","pl","ja","ko","zh","cz","ar"}
+def main():
+    seen = set()
+    for line in (ROOT / "borrowed" / "bo2_sab.txt").read_text(encoding="utf-8", errors="replace").splitlines():
+        n = line.strip().lower().replace("/", "\\")
+        core = n.split(".", 1)[0]
+        if not core: continue
+        parts = core.split("\\")
+        if parts and parts[0] in LANG: parts = parts[1:]
+        core = "\\".join(parts)
+        if core: seen.add(core)
+    for core in sorted(seen):
+        for tail in TAILS: print(core + "." + tail)
+    print(f"{len(seen)} BO2 cores, {len(seen)*len(TAILS)} candidates", file=__import__('sys').stderr)
+if __name__ == "__main__": main()

--- a/scripts/contributed/bo4_sound_asset_char_subs_20260826-223823.py
+++ b/scripts/contributed/bo4_sound_asset_char_subs_20260826-223823.py
@@ -1,0 +1,53 @@
+"""Interior character substitutions on confirmed BO4 sound_asset names only.
+
+Keeps the literal backslash path and dotted encoding tail intact; intended for
+confirm_list --game BLKOPS04 --no-fold.
+"""
+import glob, os, sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+import snapshot
+
+def main():
+    snap = next(snapshot.read(p) for p in snapshot.snapshots()
+                if "blkops04" in os.path.basename(p).lower())
+    wanted = {aid for aid, pool in snap.records if snap.pool_name(pool) == "sound_asset"}
+    names = []
+    for path in glob.glob("cod-name-db/csv/*xsounds*.csv"):
+        for line in open(path, encoding="utf-8", errors="replace"):
+            _, _, name = line.partition(",")
+            name = name.strip()
+            if name and snapshot.fnv1a_nofold(name) & snapshot.ID_MASK in wanted:
+                names.append(name)
+    for path in glob.glob("findings/blkops04/sound_asset.txt"):
+        for line in open(path, encoding="utf-8", errors="replace"):
+            comma = line.find(",")
+            if comma >= 0:
+                names.append(line[comma + 1:].rstrip("\r\n"))
+    names = sorted(set(names))
+    counts = {}
+    for name in names:
+        for c in name:
+            counts[c] = counts.get(c, 0) + 1
+    total = sum(counts.values()) or 1
+    alphabet = sorted(c for c, n in counts.items()
+                      if n / total >= .0002 and c not in "\\/*.")
+    seen = set()
+    for name in names:
+        cut = max(name.rfind("/"), name.rfind("\\")) + 1
+        head, base = name[:cut], name[cut:]
+        dot = base.find(".")
+        if dot <= 0:
+            continue
+        core, tail = base[:dot], base[dot:]
+        for i, old in enumerate(core):
+            for c in alphabet:
+                if c == old:
+                    continue
+                candidate = head + core[:i] + c + core[i + 1:] + tail
+                if candidate not in seen:
+                    seen.add(candidate)
+                    print(candidate)
+    print(f"{len(names)} seeds, {len(seen)} candidates", file=sys.stderr)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/contributed/bo4_sound_asset_digit_insertions_20260826-223823.py
+++ b/scripts/contributed/bo4_sound_asset_digit_insertions_20260826-223823.py
@@ -1,0 +1,47 @@
+"""Generate BO4 sound_asset names formed by inserting one measured digit in a known SAB basename.
+
+The dotted encoding tail is preserved; BO4 sound paths remain backslash-spelled and are filtered
+against the BO4 sound_asset pool before edits.  This is a bounded character-length seam distinct
+from tail replacement and directory/basename recombination.
+"""
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+import snapshot
+
+
+def main():
+    snap = snapshot.read(str(ROOT / "snapshots" / "blkops04.ids"))
+    wanted = {asset for asset, pool in snap.records if snap.pool_name(pool) == "sound_asset"}
+    names = set()
+    for name in snapshot.confirmed_names("sound_asset"):
+        if snapshot.fnv1a_nofold(name) in wanted:
+            names.add(name.strip().lower())
+    for name in snapshot.table_names("fnv1a_xsounds"):
+        if snapshot.fnv1a_nofold(name) in wanted:
+            names.add(name.strip().lower())
+
+    seen = set()
+    count = 0
+    for name in sorted(names):
+        dot = name.find(".")
+        if dot <= 0:
+            continue
+        base, tail = name[:dot], name[dot:]
+        # Preserve the directory and the SAB dotted tail; only edit the basename.
+        cut = max(base.rfind("\\"), base.rfind("/")) + 1
+        prefix, stem = base[:cut], base[cut:]
+        for pos in range(len(stem) + 1):
+            for digit in "0123456789":
+                candidate = prefix + stem[:pos] + digit + stem[pos:] + tail
+                if candidate not in seen:
+                    seen.add(candidate)
+                    count += 1
+                    print(candidate)
+    print(f"{len(names)} BO4 sound_asset seeds, {count} candidates", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/submissions/Hexeption_BLKOPS04_20260826-223823/about_20260826-223823.md
+++ b/submissions/Hexeption_BLKOPS04_20260826-223823/about_20260826-223823.md
@@ -1,0 +1,21 @@
+# Submission 20260826-223823
+
+- game: **BLKOPS04**
+- from: Hexeption
+- names: 1
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: not recorded (run predates this field)
+- confirmed on: not recorded (run predates this field)
+- sound_alias: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 9 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260826-223810_recovered
+- method: not recorded (an older or interrupted run)

--- a/submissions/Hexeption_BLKOPS04_20260826-223823/sound_alias_20260826-223823.txt
+++ b/submissions/Hexeption_BLKOPS04_20260826-223823/sound_alias_20260826-223823.txt
@@ -1,0 +1,1 @@
+f5ac7636d0b5dc6,zmb_pu_sweety


### PR DESCRIPTION
**BLKOPS04** — 1 asset names, confirmed against that game's own loaded assets.

- sound_alias: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Hexeption

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260826-223810_recovered
- method: not recorded (an older or interrupted run)


## Tooling this run leaves behind

- `scripts/contributed/adjacent_token_order_20260826-041334.py`
- `scripts/contributed/agent_uncarried_begins_20260826-220242.txt`
- `scripts/contributed/blkops04_sound_asset_dirs_20260826-201044.txt`
- `scripts/contributed/blkops04_sound_asset_ends_20260826-201044.txt`
- `scripts/contributed/blkops04_sound_asset_stems_20260826-201044.txt`
- `scripts/contributed/bo2_sab_to_bo4_asset_20260826-223823.py`
- `scripts/contributed/bo4_anim_token_substitutions_20260826-210155.py`
- `scripts/contributed/bo4_bik_execution_numeric_20260826-215537.py`
- `scripts/contributed/bo4_cross_title_begins_20260826-210155.txt`
- `scripts/contributed/bo4_measured_heads5_20260826-215537.py`
- `scripts/contributed/bo4_sound_asset_base_tail3_20260826-201044.py`
- `scripts/contributed/bo4_sound_asset_base_tail3.stems_20260826-201044.txt`
- `scripts/contributed/bo4_sound_asset_char_subs_20260826-223823.py`
- `scripts/contributed/bo4_sound_asset_digit_insertions_20260826-223823.py`
- `scripts/contributed/bo4_source_literals_20260826-030006.py`
- `scripts/contributed/bo4_uncarried_begins_cross_title_20260826-210155.py`
- `scripts/contributed/bo4snd_ends_20260826-202909.txt`
- `scripts/contributed/cw_double_deletion_20260826-210155.py`
- `scripts/contributed/head_axis_tail_grid_20260826-120940.py`
- `scripts/contributed/map_prefix_mode_grid_20260826-044806.py`
- `scripts/contributed/precedents_suffix6_20260826-080521.py`
- `scripts/contributed/separator_variants_20260826-041334.py`
- `scripts/contributed/source_literal_concats_20260826-044806.py`
- `scripts/contributed/suffix_block_precedents_20260826-064355.py`
- `scripts/contributed/token_boundaries_20260826-041334.py`
- `scripts/contributed/uncarried_ends_20260826-083728.txt`
- `scripts/contributed/uncarried_ends_20260826-093543.txt`
- `scripts/contributed/uncarried_ends_20260826-085424.txt`
- `scripts/contributed/uncarried_ends_20260826-090330.txt`
- `scripts/contributed/uncarried_ends_20260826-093543.txt`
- `scripts/contributed/v2_typed_borrowed_endings_range_20260825-102343.py`
- `scripts/contributed/v2_typed_source_20260825-101559.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.