### PR TITLE
[BLKOPS04] findings from Hexeption, 20260826-225347 (1 names)

### DIFF
--- a/scripts/contributed/bo3_sab_direct_to_bo4_asset_20260826-225347.py
+++ b/scripts/contributed/bo3_sab_direct_to_bo4_asset_20260826-225347.py
@@ -1,0 +1,17 @@
+"""Direct BO3 SAB path cores respelled with BO4's literal-backslash tails."""
+import pathlib, sys
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+TAILS = ("ln100.pc.snd", "ll100.pc.snd", "sn100.pc.snd", "sl100.pc.snd", "pn100.pc.snd", "pl100.pc.snd")
+LANG = {"en","ru","fr","de","it","es","pt","pl","ja","ko","zh","cz","ar"}
+def main():
+    seen = set()
+    for line in (ROOT / "cod-name-db" / "csv" / "bo3_sab.csv").read_text(encoding="utf-8", errors="replace").splitlines():
+        _, sep, n = line.partition(",")
+        if not sep: continue
+        parts = n.strip().lower().replace("/", "\\").split(".", 1)[0].split("\\")
+        if parts and parts[0] in LANG: parts = parts[1:]
+        if parts: seen.add("\\".join(parts))
+    for core in sorted(seen):
+        for tail in TAILS: print(core + "." + tail)
+    print(f"{len(seen)} BO3 cores, {len(seen)*len(TAILS)} candidates", file=sys.stderr)
+if __name__ == "__main__": main()

--- a/scripts/contributed/cw_sound_asset_char_subs_20260826-225347.py
+++ b/scripts/contributed/cw_sound_asset_char_subs_20260826-225347.py
@@ -1,0 +1,34 @@
+"""Interior character substitutions on confirmed CW sound_asset names only."""
+import glob, os, sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+import snapshot
+def main():
+    snap = next(snapshot.read(p) for p in snapshot.snapshots() if "blkopscw" in os.path.basename(p).lower())
+    wanted = {aid for aid, pool in snap.records if snap.pool_name(pool) == "sound_asset"}
+    names = []
+    for path in glob.glob("cod-name-db/csv/*xsounds*.csv"):
+        for line in open(path, encoding="utf-8", errors="replace"):
+            _, _, name = line.partition(","); name = name.strip()
+            if name and snapshot.fnv1a(name) & snapshot.ID_MASK in wanted: names.append(name)
+    for path in glob.glob("findings/blkopscw/sound_asset.txt"):
+        for line in open(path, encoding="utf-8", errors="replace"):
+            comma = line.find(",")
+            if comma >= 0: names.append(line[comma + 1:].rstrip("\r\n"))
+    names = sorted(set(names)); counts = {}
+    for n in names:
+        for c in n: counts[c] = counts.get(c, 0) + 1
+    total = sum(counts.values()) or 1
+    alphabet = sorted(c for c, n in counts.items() if n / total >= .0002 and c not in "\\/*.")
+    seen = set()
+    for n in names:
+        cut = max(n.rfind("/"), n.rfind("\\")) + 1; head, base = n[:cut], n[cut:]
+        dot = base.find(".")
+        if dot <= 0: continue
+        core, tail = base[:dot], base[dot:]
+        for i, old in enumerate(core):
+            for c in alphabet:
+                if c != old:
+                    seen.add(head + core[:i] + c + core[i + 1:] + tail)
+    for c in sorted(seen): print(c)
+    print(f"{len(names)} seeds, {len(seen)} candidates", file=sys.stderr)
+if __name__ == "__main__": main()

--- a/submissions/Hexeption_BLKOPS04_20260826-225347/about_20260826-225347.md
+++ b/submissions/Hexeption_BLKOPS04_20260826-225347/about_20260826-225347.md
@@ -1,0 +1,21 @@
+# Submission 20260826-225347
+
+- game: **BLKOPS04**
+- from: Hexeption
+- names: 1
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: not recorded (run predates this field)
+- confirmed on: not recorded (run predates this field)
+- sound_alias: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 10 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260826-225334_recovered
+- method: not recorded (an older or interrupted run)

--- a/submissions/Hexeption_BLKOPS04_20260826-225347/sound_alias_20260826-225347.txt
+++ b/submissions/Hexeption_BLKOPS04_20260826-225347/sound_alias_20260826-225347.txt
@@ -1,0 +1,1 @@
+3879189c855ae28,vox_tvoi_tutor_noma_slide_13_nag


### PR DESCRIPTION
**BLKOPS04** — 1 asset names, confirmed against that game's own loaded assets.

- sound_alias: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Hexeption

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260826-225334_recovered
- method: not recorded (an older or interrupted run)


## Tooling this run leaves behind

- `scripts/contributed/adjacent_token_order_20260826-041334.py`
- `scripts/contributed/agent_uncarried_begins_20260826-220242.txt`
- `scripts/contributed/blkops04_sound_asset_dirs_20260826-201044.txt`
- `scripts/contributed/blkops04_sound_asset_ends_20260826-201044.txt`
- `scripts/contributed/blkops04_sound_asset_stems_20260826-201044.txt`
- `scripts/contributed/bo2_sab_to_bo4_asset_20260826-223823.py`
- `scripts/contributed/bo3_sab_direct_to_bo4_asset_20260826-225347.py`
- `scripts/contributed/bo4_anim_token_substitutions_20260826-210155.py`
- `scripts/contributed/bo4_bik_execution_numeric_20260826-215537.py`
- `scripts/contributed/bo4_cross_title_begins_20260826-210155.txt`
- `scripts/contributed/bo4_measured_heads5_20260826-215537.py`
- `scripts/contributed/bo4_sound_asset_base_tail3_20260826-201044.py`
- `scripts/contributed/bo4_sound_asset_base_tail3.stems_20260826-201044.txt`
- `scripts/contributed/bo4_sound_asset_char_subs_20260826-223823.py`
- `scripts/contributed/bo4_sound_asset_digit_insertions_20260826-223823.py`
- `scripts/contributed/bo4_source_literals_20260826-030006.py`
- `scripts/contributed/bo4_uncarried_begins_cross_title_20260826-210155.py`
- `scripts/contributed/bo4snd_ends_20260826-202909.txt`
- `scripts/contributed/cw_double_deletion_20260826-210155.py`
- `scripts/contributed/cw_sound_asset_char_subs_20260826-225347.py`
- `scripts/contributed/head_axis_tail_grid_20260826-120940.py`
- `scripts/contributed/map_prefix_mode_grid_20260826-044806.py`
- `scripts/contributed/precedents_suffix6_20260826-080521.py`
- `scripts/contributed/separator_variants_20260826-041334.py`
- `scripts/contributed/source_literal_concats_20260826-044806.py`
- `scripts/contributed/suffix_block_precedents_20260826-064355.py`
- `scripts/contributed/token_boundaries_20260826-041334.py`
- `scripts/contributed/uncarried_ends_20260826-083728.txt`
- `scripts/contributed/uncarried_ends_20260826-093543.txt`
- `scripts/contributed/uncarried_ends_20260826-085424.txt`
- `scripts/contributed/uncarried_ends_20260826-090330.txt`
- `scripts/contributed/uncarried_ends_20260826-093543.txt`
- `scripts/contributed/v2_typed_borrowed_endings_range_20260825-102343.py`
- `scripts/contributed/v2_typed_source_20260825-101559.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.