### PR TITLE
[BLKOPS04] findings from Hexeption, 20260827-011119 (3 names)

### DIFF
--- a/scripts/contributed/bo4_heads_slash_bounded_20260827-011119.py
+++ b/scripts/contributed/bo4_heads_slash_bounded_20260827-011119.py
@@ -1,0 +1,16 @@
+"""Bounded complement of the five-character head alphabet for BO4.
+
+The existing heads-slash plan targets fronts containing a directory separator,
+which ordinary tail alphabets cannot spell.  This deliberately samples a small,
+stable prefix of that distinct space rather than rerunning the full plan.
+"""
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+begins = (ROOT / "plans" / "codex_heads5_slash_20260825.begins.txt").read_text(encoding="utf-8").splitlines()
+stems = (ROOT / "plans" / "codex_heads5_slash_20260825.stems.txt").read_text(encoding="utf-8").splitlines()
+# 1,000 slash-bearing fronts x 5,000 known headless bodies = 5M candidates.
+for begin in begins[:1000]:
+    for stem in stems[:5000]:
+        if begin and stem:
+            print(begin + stem)

--- a/scripts/contributed/bo4_precedents_suffix6_nonsound_20260827-011119.py
+++ b/scripts/contributed/bo4_precedents_suffix6_nonsound_20260827-011119.py
@@ -1,0 +1,19 @@
+"""Six-token contextual precedent swaps over BO4 non-sound asset names only."""
+import sys
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+import snapshot
+import precedents_suffix6
+
+def known_names():
+    tables = ("fnv1a_xmodels", "fnv1a_xmaterials", "fnv1a_ximages", "fnv1a_xanims")
+    values = set()
+    for table in tables:
+        values.update(n.strip().lower().replace("\\", "/") for n in snapshot.table_names(table) if n.strip())
+    for kind in ("model", "material", "image", "anim"):
+        values.update(n.strip().lower().replace("\\", "/") for n in snapshot.confirmed_names(kind=kind) if n.strip())
+    return values
+
+precedents_suffix6.precedents.known_names = known_names
+raise SystemExit(precedents_suffix6.main(sys.argv[1:]))

--- a/scripts/contributed/bo4_repad_nonsound_20260827-011119.py
+++ b/scripts/contributed/bo4_repad_nonsound_20260827-011119.py
@@ -1,0 +1,30 @@
+"""BO4 non-sound numeric repadding: change one numeric run's zero padding."""
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+import snapshot
+
+TABLES = ("fnv1a_xmodels", "fnv1a_xmaterials", "fnv1a_ximages", "fnv1a_xanims")
+RUN = re.compile(r"(?<![0-9])([0-9]+)(?![0-9])")
+known = {n.strip().lower().replace("\\", "/") for n in snapshot.table_names(*TABLES) if n.strip()}
+for kind in ("model", "material", "image", "anim"):
+    known.update(n.strip().lower().replace("\\", "/") for n in snapshot.confirmed_names(kind=kind) if n.strip())
+seen = set()
+for name in known:
+    for match in RUN.finditer(name):
+        digits = match.group(1)
+        value = digits.lstrip("0") or "0"
+        if len(value) > 4:
+            continue
+        for width in (1, 2, 3, 4):
+            padded = value.zfill(width)
+            if padded == digits:
+                continue
+            candidate = name[:match.start()] + padded + name[match.end():]
+            if candidate not in known and candidate not in seen:
+                seen.add(candidate)
+                print(candidate)
+print(f"{len(seen):,} candidates", file=sys.stderr)

--- a/scripts/contributed/reverse_basename_chars_20260827-011119.py
+++ b/scripts/contributed/reverse_basename_chars_20260827-011119.py
@@ -1,0 +1,14 @@
+"""Reverse the characters of each known non-sound basename, preserving its directory."""
+import os,sys
+sys.path.insert(0,os.path.join(os.path.dirname(__file__),"..","scripts")); import snapshot
+TABLES=("fnv1a_xmaterials","fnv1a_ximages","fnv1a_xmodels","fnv1a_xanims")
+def main():
+ names=set(snapshot.table_names(*TABLES)); names.update(snapshot.confirmed_names())
+ out=set()
+ for n in names:
+  n=n.strip().lower().replace("\\","/"); d,b=n.rsplit("/",1) if "/" in n else ("",n)
+  if "." in b or len(b)<4: continue
+  out.add((d+"/" if d else "")+b[::-1])
+ for n in sorted(out): print(n)
+ print(f"{len(names)} seeds, {len(out)} candidates",file=sys.stderr)
+if __name__=="__main__": main()

--- a/scripts/contributed/reverse_tokens_20260827-011119.py
+++ b/scripts/contributed/reverse_tokens_20260827-011119.py
@@ -1,0 +1,14 @@
+"""Reverse the complete underscore-token order of known non-sound asset names."""
+import os, sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts")); import snapshot
+TABLES=("fnv1a_xmaterials","fnv1a_ximages","fnv1a_xmodels","fnv1a_xanims")
+def main():
+    names=set(snapshot.table_names(*TABLES)); names.update(snapshot.confirmed_names())
+    out=set()
+    for n in names:
+        n=n.strip().lower().replace("\\","/"); d,b=n.rsplit("/",1) if "/" in n else ("",n)
+        if "." in b or b.count("_")<2: continue
+        r="_".join(reversed(b.split("_"))); out.add((d+"/" if d else "")+r)
+    for n in sorted(out): print(n)
+    print(f"{len(names)} seeds, {len(out)} candidates",file=sys.stderr)
+if __name__=="__main__": main()

--- a/scripts/contributed/rotate_tokens_20260827-011119.py
+++ b/scripts/contributed/rotate_tokens_20260827-011119.py
@@ -1,0 +1,14 @@
+"""Rotate all underscore-separated tokens left by one on known non-sound names."""
+import os,sys
+sys.path.insert(0,os.path.join(os.path.dirname(__file__),"..","scripts")); import snapshot
+TABLES=("fnv1a_xmaterials","fnv1a_ximages","fnv1a_xmodels","fnv1a_xanims")
+def main():
+ names=set(snapshot.table_names(*TABLES)); names.update(snapshot.confirmed_names())
+ out=set()
+ for n in names:
+  n=n.strip().lower().replace("\\","/"); d,b=n.rsplit("/",1) if "/" in n else ("",n)
+  if "." in b or b.count("_")<2: continue
+  p=b.split("_"); r="_".join(p[1:]+p[:1]); out.add((d+"/" if d else "")+r)
+ for n in sorted(out): print(n)
+ print(f"{len(names)} seeds, {len(out)} candidates",file=sys.stderr)
+if __name__=="__main__": main()

--- a/scripts/contributed/sort_basename_chars_20260827-011119.py
+++ b/scripts/contributed/sort_basename_chars_20260827-011119.py
@@ -1,0 +1,13 @@
+"""Alphabetically sort each known non-sound basename's characters."""
+import os,sys
+sys.path.insert(0,os.path.join(os.path.dirname(__file__),"..","scripts")); import snapshot
+TABLES=("fnv1a_xmaterials","fnv1a_ximages","fnv1a_xmodels","fnv1a_xanims")
+def main():
+ names=set(snapshot.table_names(*TABLES)); names.update(snapshot.confirmed_names()); out=set()
+ for n in names:
+  n=n.strip().lower().replace("\\","/"); d,b=n.rsplit("/",1) if "/" in n else ("",n)
+  if "." in b or len(b)<4: continue
+  out.add((d+"/" if d else "")+"".join(sorted(b)))
+ for n in sorted(out): print(n)
+ print(f"{len(names)} seeds, {len(out)} candidates",file=sys.stderr)
+if __name__=="__main__": main()

--- a/scripts/contributed/swap_basename_halves_20260827-011119.py
+++ b/scripts/contributed/swap_basename_halves_20260827-011119.py
@@ -1,0 +1,13 @@
+"""Swap the two halves of each known non-sound basename."""
+import os,sys
+sys.path.insert(0,os.path.join(os.path.dirname(__file__),"..","scripts")); import snapshot
+TABLES=("fnv1a_xmaterials","fnv1a_ximages","fnv1a_xmodels","fnv1a_xanims")
+def main():
+ names=set(snapshot.table_names(*TABLES)); names.update(snapshot.confirmed_names()); out=set()
+ for n in names:
+  n=n.strip().lower().replace("\\","/"); d,b=n.rsplit("/",1) if "/" in n else ("",n)
+  if "." in b or len(b)<6: continue
+  k=len(b)//2; out.add((d+"/" if d else "")+b[k:]+b[:k])
+ for n in sorted(out): print(n)
+ print(f"{len(names)} seeds, {len(out)} candidates",file=sys.stderr)
+if __name__=="__main__": main()

--- a/scripts/contributed/swap_outer_tokens_20260827-011119.py
+++ b/scripts/contributed/swap_outer_tokens_20260827-011119.py
@@ -1,0 +1,15 @@
+"""Swap the first and last underscore tokens of known non-sound asset names."""
+import os,sys
+sys.path.insert(0,os.path.join(os.path.dirname(__file__),"..","scripts")); import snapshot
+TABLES=("fnv1a_xmaterials","fnv1a_ximages","fnv1a_xmodels","fnv1a_xanims")
+def main():
+ names=set(snapshot.table_names(*TABLES)); names.update(snapshot.confirmed_names())
+ out=set()
+ for n in names:
+  n=n.strip().lower().replace("\\","/"); d,b=n.rsplit("/",1) if "/" in n else ("",n)
+  if "." in b or b.count("_")<2: continue
+  p=b.split("_"); p[0],p[-1]=p[-1],p[0]
+  out.add((d+"/" if d else "")+"_".join(p))
+ for n in sorted(out): print(n)
+ print(f"{len(names)} seeds, {len(out)} candidates",file=sys.stderr)
+if __name__=="__main__": main()

--- a/submissions/Hexeption_BLKOPS04_20260827-011119/about_20260827-011119.md
+++ b/submissions/Hexeption_BLKOPS04_20260827-011119/about_20260827-011119.md
@@ -1,0 +1,36 @@
+# Submission 20260827-011119
+
+- game: **BLKOPS04**
+- from: Hexeption
+- names: 3
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- xmodel: 2
+- xanim: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 28 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260827-010857_list
+- method: BO4 bounded family column cross product
+- what it does: Cross at most two small axes within key-4 same-family asset names
+- ran for: 1m 42s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- candidates tested: 10956657
+- matched: 11
+- new: 3
+- sketch stems: 0000007011c7586500000089edc28b72000003c2c40ee5d200000a9028e0790e00000b046be1e32c00001cba375be43f0000249b4dab525c0000251a40979c9f000028f9a6a9edab000029bff364304f00002a71cf56235e00002de050ec84af00002e291330785a00002f03636000f5000031d364a1c2c8000039a30aaa257a00003bdfcb0d7d990000400b8b16151e00004188b1387337000042065795c5680000421e1856df36000043d8782201d700004d7f5e5e568d00004e2f12a07179000050a5c63ed7f70000526ae99ca605000053c8c196ed700000541f548afaf3000055e988e1ad3d0000609ebc0a191e000063d1ceb5a6c8000074f5e9b82d2a
+- ids hunted: 160206
+- throughput: 0.1M candidates/s
+- fingerprint: 9647f9a538479a9d
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/Hexeption_BLKOPS04_20260827-011119/xanim_20260827-011119.txt
+++ b/submissions/Hexeption_BLKOPS04_20260827-011119/xanim_20260827-011119.txt
@@ -1,0 +1,1 @@
+1ca0f305e59e7e6f,p8_fxanim_mp_icebreaker_usa_station_array_s5_anim

--- a/submissions/Hexeption_BLKOPS04_20260827-011119/xmodel_20260827-011119.txt
+++ b/submissions/Hexeption_BLKOPS04_20260827-011119/xmodel_20260827-011119.txt
@@ -1,0 +1,2 @@
+2eb4916f1e8d3d9d,p8_fxanim_gp_foliage_distictis_flowers_ledge_128_long_ylw_smod
+6932ad3e9d048b3f,c_t8_mp_swatbuddy_female_head2_tan


### PR DESCRIPTION
**BLKOPS04** — 3 asset names, confirmed against that game's own loaded assets.

- xmodel: 2
- xanim: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Hexeption

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260827-010857_list
- method: BO4 bounded family column cross product
- what it does: Cross at most two small axes within key-4 same-family asset names
- ran for: 1m 42s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- candidates tested: 10956657
- matched: 11
- new: 3
- sketch stems: 0000007011c7586500000089edc28b72000003c2c40ee5d200000a9028e0790e00000b046be1e32c00001cba375be43f0000249b4dab525c0000251a40979c9f000028f9a6a9edab000029bff364304f00002a71cf56235e00002de050ec84af00002e291330785a00002f03636000f5000031d364a1c2c8000039a30aaa257a00003bdfcb0d7d990000400b8b16151e00004188b1387337000042065795c5680000421e1856df36000043d8782201d700004d7f5e5e568d00004e2f12a07179000050a5c63ed7f70000526ae99ca605000053c8c196ed700000541f548afaf3000055e988e1ad3d0000609ebc0a191e000063d1ceb5a6c8000074f5e9b82d2a
- ids hunted: 160206
- throughput: 0.1M candidates/s
- fingerprint: 9647f9a538479a9d

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/templates_20260819-220821.py`
- `scripts/contributed/adjacent_token_order_20260826-041334.py`
- `scripts/contributed/agent_uncarried_begins_20260826-220242.txt`
- `scripts/contributed/blkops04_sound_asset_dirs_20260826-201044.txt`
- `scripts/contributed/blkops04_sound_asset_ends_20260826-201044.txt`
- `scripts/contributed/blkops04_sound_asset_stems_20260826-201044.txt`
- `scripts/contributed/bo2_sab_to_bo4_asset_20260826-223823.py`
- `scripts/contributed/bo3_sab_direct_to_bo4_asset_20260826-225347.py`
- `scripts/contributed/bo4_anim_token_substitutions_20260826-210155.py`
- `scripts/contributed/bo4_bik_execution_numeric_20260826-215537.py`
- `scripts/contributed/bo4_cross_title_begins_20260826-210155.txt`
- `scripts/contributed/bo4_heads_slash_bounded_20260827-011119.py`
- `scripts/contributed/bo4_measured_heads5_20260826-215537.py`
- `scripts/contributed/bo4_precedents_suffix6_nonsound_20260827-011119.py`
- `scripts/contributed/bo4_repad_nonsound_20260827-011119.py`
- `scripts/contributed/bo4_sound_asset_base_tail3_20260826-201044.py`
- `scripts/contributed/bo4_sound_asset_base_tail3.stems_20260826-201044.txt`
- `scripts/contributed/bo4_sound_asset_char_subs_20260826-223823.py`
- `scripts/contributed/bo4_sound_asset_digit_insertions_20260826-223823.py`
- `scripts/contributed/bo4_source_literals_20260826-030006.py`
- `scripts/contributed/bo4_uncarried_begins_cross_title_20260826-210155.py`
- `scripts/contributed/bo4snd_ends_20260826-202909.txt`
- `scripts/contributed/cw_double_deletion_20260826-210155.py`
- `scripts/contributed/cw_sound_asset_char_subs_20260826-225347.py`
- `scripts/contributed/head_axis_tail_grid_20260826-120940.py`
- `scripts/contributed/map_prefix_mode_grid_20260826-044806.py`
- `scripts/contributed/precedents_suffix6_20260826-080521.py`
- `scripts/contributed/reverse_basename_chars_20260827-011119.py`
- `scripts/contributed/reverse_tokens_20260827-011119.py`
- `scripts/contributed/rotate_tokens_20260827-011119.py`
- `scripts/contributed/separator_variants_20260826-041334.py`
- `scripts/contributed/sort_basename_chars_20260827-011119.py`
- `scripts/contributed/source_literal_concats_20260826-044806.py`
- `scripts/contributed/suffix_block_precedents_20260826-064355.py`
- `scripts/contributed/swap_basename_halves_20260827-011119.py`
- `scripts/contributed/swap_outer_tokens_20260827-011119.py`
- `scripts/contributed/token_boundaries_20260826-041334.py`
- `scripts/contributed/uncarried_ends_20260826-231255.txt`
- `scripts/contributed/uncarried_ends_20260826-093543.txt`
- `scripts/contributed/uncarried_ends_20260826-085424.txt`
- `scripts/contributed/uncarried_ends_20260826-090330.txt`
- `scripts/contributed/uncarried_ends_20260826-093543.txt`
- `scripts/contributed/v2_typed_borrowed_endings_range_20260825-102343.py`
- `scripts/contributed/v2_typed_source_20260825-101559.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.