### PR TITLE
[BLKOPS04] findings from Hexeption, 20260827-013046 (1 names)

### DIFF
--- a/scripts/contributed/bo4_reverse_all_tokens_20260827-013046.py
+++ b/scripts/contributed/bo4_reverse_all_tokens_20260827-013046.py
@@ -1,0 +1,20 @@
+"""Reverse every underscore token in each known BO4 non-sound basename."""
+import sys
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+import snapshot
+tables = ("fnv1a_xmodels", "fnv1a_xmaterials", "fnv1a_ximages", "fnv1a_xanims")
+known = {n.strip().lower().replace("\\", "/") for n in snapshot.table_names(*tables) if n.strip()}
+for kind in ("model", "material", "image", "anim"):
+    known.update(n.strip().lower().replace("\\", "/") for n in snapshot.confirmed_names(kind=kind) if n.strip())
+out = set()
+for name in known:
+    directory, _, base = name.rpartition("/")
+    parts = base.split("_")
+    if len(parts) < 3 or "." in base:
+        continue
+    out.add((directory + "/" if directory else "") + "_".join(reversed(parts)))
+out.difference_update(known)
+print(f"{len(known):,} seeds, {len(out):,} candidates", file=sys.stderr)
+for candidate in sorted(out): print(candidate)

--- a/scripts/contributed/bo4_reverse_interior_tokens_20260827-013046.py
+++ b/scripts/contributed/bo4_reverse_interior_tokens_20260827-013046.py
@@ -1,0 +1,22 @@
+"""BO4 non-sound: reverse the interior underscore-token sequence."""
+import sys
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+import snapshot
+tables = ("fnv1a_xmodels", "fnv1a_xmaterials", "fnv1a_ximages", "fnv1a_xanims")
+known = {n.strip().lower().replace("\\", "/") for n in snapshot.table_names(*tables) if n.strip()}
+for kind in ("model", "material", "image", "anim"):
+    known.update(n.strip().lower().replace("\\", "/") for n in snapshot.confirmed_names(kind=kind) if n.strip())
+out = set()
+for name in known:
+    directory, _, base = name.rpartition("/")
+    parts = base.split("_")
+    if len(parts) < 4 or "." in base:
+        continue
+    candidate = "_".join([parts[0], *reversed(parts[1:-1]), parts[-1]])
+    out.add((directory + "/" if directory else "") + candidate)
+out.difference_update(known)
+print(f"{len(known):,} seeds, {len(out):,} candidates", file=sys.stderr)
+for candidate in sorted(out):
+    print(candidate)

--- a/scripts/contributed/bo4_rotate_first_three_20260827-013046.py
+++ b/scripts/contributed/bo4_rotate_first_three_20260827-013046.py
@@ -1,0 +1,21 @@
+"""Rotate the first three underscore tokens left in BO4 non-sound basenames."""
+import sys
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+import snapshot
+tables = ("fnv1a_xmodels", "fnv1a_xmaterials", "fnv1a_ximages", "fnv1a_xanims")
+known = {n.strip().lower().replace("\\", "/") for n in snapshot.table_names(*tables) if n.strip()}
+for kind in ("model", "material", "image", "anim"):
+    known.update(n.strip().lower().replace("\\", "/") for n in snapshot.confirmed_names(kind=kind) if n.strip())
+out = set()
+for name in known:
+    directory, _, base = name.rpartition("/")
+    parts = base.split("_")
+    if len(parts) < 4 or "." in base:
+        continue
+    candidate = "_".join(parts[1:3] + parts[:1] + parts[3:])
+    out.add((directory + "/" if directory else "") + candidate)
+out.difference_update(known)
+print(f"{len(known):,} seeds, {len(out):,} candidates", file=sys.stderr)
+for candidate in sorted(out): print(candidate)

--- a/scripts/contributed/bo4_rotate_first_token_20260827-013046.py
+++ b/scripts/contributed/bo4_rotate_first_token_20260827-013046.py
@@ -1,0 +1,21 @@
+"""Move the first underscore token of each known BO4 non-sound basename to the end."""
+import sys
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+import snapshot
+tables = ("fnv1a_xmodels", "fnv1a_xmaterials", "fnv1a_ximages", "fnv1a_xanims")
+known = {n.strip().lower().replace("\\", "/") for n in snapshot.table_names(*tables) if n.strip()}
+for kind in ("model", "material", "image", "anim"):
+    known.update(n.strip().lower().replace("\\", "/") for n in snapshot.confirmed_names(kind=kind) if n.strip())
+out = set()
+for name in known:
+    directory, _, base = name.rpartition("/")
+    parts = base.split("_")
+    if len(parts) < 3 or "." in base:
+        continue
+    out.add((directory + "/" if directory else "") + "_".join(parts[1:] + parts[:1]))
+out.difference_update(known)
+print(f"{len(known):,} seeds, {len(out):,} candidates", file=sys.stderr)
+for candidate in sorted(out):
+    print(candidate)

--- a/scripts/contributed/bo4_rotate_last_three_20260827-013046.py
+++ b/scripts/contributed/bo4_rotate_last_three_20260827-013046.py
@@ -1,0 +1,21 @@
+"""Rotate the final three underscore tokens right in BO4 non-sound basenames."""
+import sys
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+import snapshot
+tables = ("fnv1a_xmodels", "fnv1a_xmaterials", "fnv1a_ximages", "fnv1a_xanims")
+known = {n.strip().lower().replace("\\", "/") for n in snapshot.table_names(*tables) if n.strip()}
+for kind in ("model", "material", "image", "anim"):
+    known.update(n.strip().lower().replace("\\", "/") for n in snapshot.confirmed_names(kind=kind) if n.strip())
+out = set()
+for name in known:
+    directory, _, base = name.rpartition("/")
+    parts = base.split("_")
+    if len(parts) < 4 or "." in base:
+        continue
+    candidate = "_".join(parts[:-3] + parts[-1:] + parts[-3:-1])
+    out.add((directory + "/" if directory else "") + candidate)
+out.difference_update(known)
+print(f"{len(known):,} seeds, {len(out):,} candidates", file=sys.stderr)
+for candidate in sorted(out): print(candidate)

--- a/scripts/contributed/bo4_rotate_last_token_20260827-013046.py
+++ b/scripts/contributed/bo4_rotate_last_token_20260827-013046.py
@@ -1,0 +1,21 @@
+"""Move the final underscore token to the front of BO4 non-sound basenames."""
+import sys
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+import snapshot
+tables = ("fnv1a_xmodels", "fnv1a_xmaterials", "fnv1a_ximages", "fnv1a_xanims")
+known = {n.strip().lower().replace("\\", "/") for n in snapshot.table_names(*tables) if n.strip()}
+for kind in ("model", "material", "image", "anim"):
+    known.update(n.strip().lower().replace("\\", "/") for n in snapshot.confirmed_names(kind=kind) if n.strip())
+out = set()
+for name in known:
+    directory, _, base = name.rpartition("/")
+    parts = base.split("_")
+    if len(parts) < 3 or "." in base:
+        continue
+    out.add((directory + "/" if directory else "") + "_".join(parts[-1:] + parts[:-1]))
+out.difference_update(known)
+print(f"{len(known):,} seeds, {len(out):,} candidates", file=sys.stderr)
+for candidate in sorted(out):
+    print(candidate)

--- a/scripts/contributed/bo4_swap_second_penultimate_20260827-013046.py
+++ b/scripts/contributed/bo4_swap_second_penultimate_20260827-013046.py
@@ -1,0 +1,21 @@
+"""Swap second and penultimate underscore tokens in BO4 non-sound basenames."""
+import sys
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+import snapshot
+tables = ("fnv1a_xmodels", "fnv1a_xmaterials", "fnv1a_ximages", "fnv1a_xanims")
+known = {n.strip().lower().replace("\\", "/") for n in snapshot.table_names(*tables) if n.strip()}
+for kind in ("model", "material", "image", "anim"):
+    known.update(n.strip().lower().replace("\\", "/") for n in snapshot.confirmed_names(kind=kind) if n.strip())
+out = set()
+for name in known:
+    directory, _, base = name.rpartition("/")
+    parts = base.split("_")
+    if len(parts) < 4 or "." in base:
+        continue
+    parts[1], parts[-2] = parts[-2], parts[1]
+    out.add((directory + "/" if directory else "") + "_".join(parts))
+out.difference_update(known)
+print(f"{len(known):,} seeds, {len(out):,} candidates", file=sys.stderr)
+for candidate in sorted(out): print(candidate)

--- a/scripts/contributed/duplicate_basename_20260827-013046.py
+++ b/scripts/contributed/duplicate_basename_20260827-013046.py
@@ -1,0 +1,13 @@
+"""Duplicate each known non-sound basename with an underscore separator."""
+import os,sys
+sys.path.insert(0,os.path.join(os.path.dirname(__file__),"..","scripts")); import snapshot
+TABLES=("fnv1a_xmaterials","fnv1a_ximages","fnv1a_xmodels","fnv1a_xanims")
+def main():
+ names=set(snapshot.table_names(*TABLES)); names.update(snapshot.confirmed_names()); out=set()
+ for n in names:
+  n=n.strip().lower().replace("\\","/"); d,b=n.rsplit("/",1) if "/" in n else ("",n)
+  if "." in b or len(b)<4: continue
+  out.add((d+"/" if d else "")+b+"_"+b)
+ for n in sorted(out): print(n)
+ print(f"{len(names)} seeds, {len(out)} candidates",file=sys.stderr)
+if __name__=="__main__": main()

--- a/scripts/contributed/even_odd_basename_20260827-013046.py
+++ b/scripts/contributed/even_odd_basename_20260827-013046.py
@@ -1,0 +1,13 @@
+"""Reorder basename characters as even positions reversed, then odd positions reversed."""
+import os,sys
+sys.path.insert(0,os.path.join(os.path.dirname(__file__),"..","scripts")); import snapshot
+TABLES=("fnv1a_xmaterials","fnv1a_ximages","fnv1a_xmodels","fnv1a_xanims")
+def main():
+ names=set(snapshot.table_names(*TABLES)); names.update(snapshot.confirmed_names()); out=set()
+ for n in names:
+  n=n.strip().lower().replace("\\","/"); d,b=n.rsplit("/",1) if "/" in n else ("",n)
+  if "." in b or len(b)<4: continue
+  out.add((d+"/" if d else "")+b[::2][::-1]+b[1::2][::-1])
+ for n in sorted(out): print(n)
+ print(f"{len(names)} seeds, {len(out)} candidates",file=sys.stderr)
+if __name__=="__main__": main()

--- a/scripts/contributed/odd_even_basename_20260827-013046.py
+++ b/scripts/contributed/odd_even_basename_20260827-013046.py
@@ -1,0 +1,13 @@
+"""Reorder basename characters as odd positions followed by even positions."""
+import os,sys
+sys.path.insert(0,os.path.join(os.path.dirname(__file__),"..","scripts")); import snapshot
+TABLES=("fnv1a_xmaterials","fnv1a_ximages","fnv1a_xmodels","fnv1a_xanims")
+def main():
+ names=set(snapshot.table_names(*TABLES)); names.update(snapshot.confirmed_names()); out=set()
+ for n in names:
+  n=n.strip().lower().replace("\\","/"); d,b=n.rsplit("/",1) if "/" in n else ("",n)
+  if "." in b or len(b)<4: continue
+  out.add((d+"/" if d else "")+b[::2]+b[1::2])
+ for n in sorted(out): print(n)
+ print(f"{len(names)} seeds, {len(out)} candidates",file=sys.stderr)
+if __name__=="__main__": main()

--- a/scripts/contributed/prepend_duplicate_basename_20260827-013046.py
+++ b/scripts/contributed/prepend_duplicate_basename_20260827-013046.py
@@ -1,0 +1,13 @@
+"""Prefix each known non-sound basename with an underscore and itself."""
+import os,sys
+sys.path.insert(0,os.path.join(os.path.dirname(__file__),"..","scripts")); import snapshot
+TABLES=("fnv1a_xmaterials","fnv1a_ximages","fnv1a_xmodels","fnv1a_xanims")
+def main():
+ names=set(snapshot.table_names(*TABLES)); names.update(snapshot.confirmed_names()); out=set()
+ for n in names:
+  n=n.strip().lower().replace("\\","/"); d,b=n.rsplit("/",1) if "/" in n else ("",n)
+  if "." in b or len(b)<4: continue
+  out.add((d+"/" if d else "")+b+"_"+b[::-1])
+ for n in sorted(out): print(n)
+ print(f"{len(names)} seeds, {len(out)} candidates",file=sys.stderr)
+if __name__=="__main__": main()

--- a/scripts/contributed/rotate_basename_char_left_20260827-013046.py
+++ b/scripts/contributed/rotate_basename_char_left_20260827-013046.py
@@ -1,0 +1,13 @@
+"""Rotate each known non-sound basename one character to the left."""
+import os,sys
+sys.path.insert(0,os.path.join(os.path.dirname(__file__),"..","scripts")); import snapshot
+TABLES=("fnv1a_xmaterials","fnv1a_ximages","fnv1a_xmodels","fnv1a_xanims")
+def main():
+ names=set(snapshot.table_names(*TABLES)); names.update(snapshot.confirmed_names()); out=set()
+ for n in names:
+  n=n.strip().lower().replace("\\","/"); d,b=n.rsplit("/",1) if "/" in n else ("",n)
+  if "." in b or len(b)<4: continue
+  out.add((d+"/" if d else "")+b[1:]+b[0])
+ for n in sorted(out): print(n)
+ print(f"{len(names)} seeds, {len(out)} candidates",file=sys.stderr)
+if __name__=="__main__": main()

--- a/scripts/contributed/rotate_basename_char_right_20260827-013046.py
+++ b/scripts/contributed/rotate_basename_char_right_20260827-013046.py
@@ -1,0 +1,13 @@
+"""Rotate each known non-sound basename one character to the right."""
+import os,sys
+sys.path.insert(0,os.path.join(os.path.dirname(__file__),"..","scripts")); import snapshot
+TABLES=("fnv1a_xmaterials","fnv1a_ximages","fnv1a_xmodels","fnv1a_xanims")
+def main():
+ names=set(snapshot.table_names(*TABLES)); names.update(snapshot.confirmed_names()); out=set()
+ for n in names:
+  n=n.strip().lower().replace("\\","/"); d,b=n.rsplit("/",1) if "/" in n else ("",n)
+  if "." in b or len(b)<4: continue
+  out.add((d+"/" if d else "")+b[-1]+b[:-1])
+ for n in sorted(out): print(n)
+ print(f"{len(names)} seeds, {len(out)} candidates",file=sys.stderr)
+if __name__=="__main__": main()

--- a/scripts/contributed/rotate_path_directories_20260827-013046.py
+++ b/scripts/contributed/rotate_path_directories_20260827-013046.py
@@ -1,0 +1,13 @@
+"""Move the first path directory to the end on known non-sound asset paths."""
+import os,sys
+sys.path.insert(0,os.path.join(os.path.dirname(__file__),"..","scripts")); import snapshot
+TABLES=("fnv1a_xmaterials","fnv1a_ximages","fnv1a_xmodels","fnv1a_xanims")
+def main():
+ names=set(snapshot.table_names(*TABLES)); names.update(snapshot.confirmed_names()); out=set()
+ for n in names:
+  n=n.strip().lower().replace("\\","/"); p=n.split("/")
+  if len(p)<3 or any("." in x for x in p): continue
+  out.add("/".join(p[1:]+p[:1]))
+ for n in sorted(out): print(n)
+ print(f"{len(names)} seeds, {len(out)} candidates",file=sys.stderr)
+if __name__=="__main__": main()

--- a/scripts/contributed/sort_basename_tokens_20260827-013046.py
+++ b/scripts/contributed/sort_basename_tokens_20260827-013046.py
@@ -1,0 +1,13 @@
+"""Alphabetically sort underscore-separated basename tokens of known non-sound names."""
+import os,sys
+sys.path.insert(0,os.path.join(os.path.dirname(__file__),"..","scripts")); import snapshot
+TABLES=("fnv1a_xmaterials","fnv1a_ximages","fnv1a_xmodels","fnv1a_xanims")
+def main():
+ names=set(snapshot.table_names(*TABLES)); names.update(snapshot.confirmed_names()); out=set()
+ for n in names:
+  n=n.strip().lower().replace("\\","/"); d,b=n.rsplit("/",1) if "/" in n else ("",n)
+  if "." in b or b.count("_")<2: continue
+  out.add((d+"/" if d else "")+"_".join(sorted(b.split("_"))))
+ for n in sorted(out): print(n)
+ print(f"{len(names)} seeds, {len(out)} candidates",file=sys.stderr)
+if __name__=="__main__": main()

--- a/scripts/contributed/strip_asset_directories_20260827-013046.py
+++ b/scripts/contributed/strip_asset_directories_20260827-013046.py
@@ -1,0 +1,12 @@
+"""Offer the bare basename of each known non-sound path as a candidate."""
+import os,sys
+sys.path.insert(0,os.path.join(os.path.dirname(__file__),"..","scripts")); import snapshot
+TABLES=("fnv1a_xmaterials","fnv1a_ximages","fnv1a_xmodels","fnv1a_xanims")
+def main():
+ names=set(snapshot.table_names(*TABLES)); names.update(snapshot.confirmed_names()); out=set()
+ for n in names:
+  n=n.strip().lower().replace("\\","/")
+  if "/" in n and "." not in n: out.add(n.rsplit("/",1)[1])
+ for n in sorted(out): print(n)
+ print(f"{len(names)} seeds, {len(out)} candidates",file=sys.stderr)
+if __name__=="__main__": main()

--- a/scripts/contributed/swap_path_directories_20260827-013046.py
+++ b/scripts/contributed/swap_path_directories_20260827-013046.py
@@ -1,0 +1,13 @@
+"""Swap the first two directory components of known non-sound asset paths."""
+import os,sys
+sys.path.insert(0,os.path.join(os.path.dirname(__file__),"..","scripts")); import snapshot
+TABLES=("fnv1a_xmaterials","fnv1a_ximages","fnv1a_xmodels","fnv1a_xanims")
+def main():
+ names=set(snapshot.table_names(*TABLES)); names.update(snapshot.confirmed_names()); out=set()
+ for n in names:
+  n=n.strip().lower().replace("\\","/"); p=n.split("/")
+  if len(p)<3 or any("." in x for x in p): continue
+  p[0],p[1]=p[1],p[0]; out.add("/".join(p))
+ for n in sorted(out): print(n)
+ print(f"{len(names)} seeds, {len(out)} candidates",file=sys.stderr)
+if __name__=="__main__": main()

--- a/submissions/Hexeption_BLKOPS04_20260827-013046/about_20260827-013046.md
+++ b/submissions/Hexeption_BLKOPS04_20260827-013046/about_20260827-013046.md
@@ -1,0 +1,35 @@
+# Submission 20260827-013046
+
+- game: **BLKOPS04**
+- from: Hexeption
+- names: 1
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- material: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 32 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260827-013008_list
+- method: BO4 last-three token rotation
+- what it does: Rotate final three basename tokens right in known non-sound assets
+- ran for: 7s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- candidates tested: 873488
+- matched: 1
+- new: 1
+- sketch stems: 00000cb89c884eb00000293a7d32b7b500005e4b26f4f28400006257ce52602a000074f9dd466aac00009c937f5d03b70000aad21a2d3fd90000af2376c686d10000b1d78e6f58960000b8beb44d318b0000d44a0ef6e7fe0000e734ddae39eb0000ea331857d7f20000ea50749d6b2c0000ef35b73aedb10001052f00fefe7c000132009062c1540001a73635fc82d60001b5873e6354210001bb85f9acaa5e0001be3c47a5be760001c6623e58dcd40001d63cfebccfc40001f29f67b33fa90002220f2f5a8ddf0002221f3e1e48fc0002288859d7806a00023cd1b01a352600023d1f9787ba4300024f819aded8de00025d06b6e712a80002670f9969d2a6
+- ids hunted: 160200
+- throughput: 0.3M candidates/s
+- fingerprint: 6451ed2766dcd5df
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/Hexeption_BLKOPS04_20260827-013046/material_20260827-013046.txt
+++ b/submissions/Hexeption_BLKOPS04_20260827-013046/material_20260827-013046.txt
@@ -1,0 +1,1 @@
+147fccf5cc16e3e2,mc/mtl_c_t8_mob_zmb_eyes


### PR DESCRIPTION
**BLKOPS04** — 1 asset names, confirmed against that game's own loaded assets.

- material: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Hexeption

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260827-013008_list
- method: BO4 last-three token rotation
- what it does: Rotate final three basename tokens right in known non-sound assets
- ran for: 7s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- candidates tested: 873488
- matched: 1
- new: 1
- sketch stems: 00000cb89c884eb00000293a7d32b7b500005e4b26f4f28400006257ce52602a000074f9dd466aac00009c937f5d03b70000aad21a2d3fd90000af2376c686d10000b1d78e6f58960000b8beb44d318b0000d44a0ef6e7fe0000e734ddae39eb0000ea331857d7f20000ea50749d6b2c0000ef35b73aedb10001052f00fefe7c000132009062c1540001a73635fc82d60001b5873e6354210001bb85f9acaa5e0001be3c47a5be760001c6623e58dcd40001d63cfebccfc40001f29f67b33fa90002220f2f5a8ddf0002221f3e1e48fc0002288859d7806a00023cd1b01a352600023d1f9787ba4300024f819aded8de00025d06b6e712a80002670f9969d2a6
- ids hunted: 160200
- throughput: 0.3M candidates/s
- fingerprint: 6451ed2766dcd5df

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/adjacent_token_order_20260826-041334.py`
- `scripts/contributed/agent_uncarried_begins_20260826-220242.txt`
- `scripts/contributed/blkops04_sound_asset_dirs_20260826-201044.txt`
- `scripts/contributed/blkops04_sound_asset_ends_20260826-201044.txt`
- `scripts/contributed/blkops04_sound_asset_stems_20260826-201044.txt`
- `scripts/contributed/bo2_sab_to_bo4_asset_20260826-223823.py`
- `scripts/contributed/bo3_sab_direct_to_bo4_asset_20260826-225347.py`
- `scripts/contributed/bo4_anim_token_substitutions_20260826-210155.py`
- `scripts/contributed/bo4_bik_execution_numeric_20260826-215537.py`
- `scripts/contributed/bo4_cross_title_begins_20260826-210155.txt`
- `scripts/contributed/bo4_heads_slash_bounded_20260827-011119.py`
- `scripts/contributed/bo4_measured_heads5_20260826-215537.py`
- `scripts/contributed/bo4_precedents_suffix6_nonsound_20260827-011119.py`
- `scripts/contributed/bo4_repad_nonsound_20260827-011119.py`
- `scripts/contributed/bo4_reverse_all_tokens_20260827-013046.py`
- `scripts/contributed/bo4_reverse_interior_tokens_20260827-013046.py`
- `scripts/contributed/bo4_rotate_first_three_20260827-013046.py`
- `scripts/contributed/bo4_rotate_first_token_20260827-013046.py`
- `scripts/contributed/bo4_rotate_last_three_20260827-013046.py`
- `scripts/contributed/bo4_rotate_last_token_20260827-013046.py`
- `scripts/contributed/bo4_sound_asset_base_tail3_20260826-201044.py`
- `scripts/contributed/bo4_sound_asset_base_tail3.stems_20260826-201044.txt`
- `scripts/contributed/bo4_sound_asset_char_subs_20260826-223823.py`
- `scripts/contributed/bo4_sound_asset_digit_insertions_20260826-223823.py`
- `scripts/contributed/bo4_source_literals_20260826-030006.py`
- `scripts/contributed/bo4_swap_second_penultimate_20260827-013046.py`
- `scripts/contributed/bo4_uncarried_begins_cross_title_20260826-210155.py`
- `scripts/contributed/bo4snd_ends_20260826-202909.txt`
- `scripts/contributed/cw_double_deletion_20260826-210155.py`
- `scripts/contributed/cw_sound_asset_char_subs_20260826-225347.py`
- `scripts/contributed/duplicate_basename_20260827-013046.py`
- `scripts/contributed/even_odd_basename_20260827-013046.py`
- `scripts/contributed/head_axis_tail_grid_20260826-120940.py`
- `scripts/contributed/interleave_basename_halves_20260827-011549.py`
- `scripts/contributed/map_prefix_mode_grid_20260826-044806.py`
- `scripts/contributed/odd_even_basename_20260827-013046.py`
- `scripts/contributed/precedents_suffix6_20260826-080521.py`
- `scripts/contributed/prepend_duplicate_basename_20260827-013046.py`
- `scripts/contributed/reverse_basename_chars_20260827-011119.py`
- `scripts/contributed/reverse_tokens_20260827-011119.py`
- `scripts/contributed/rotate_basename_char_left_20260827-013046.py`
- `scripts/contributed/rotate_basename_char_right_20260827-013046.py`
- `scripts/contributed/rotate_path_directories_20260827-013046.py`
- `scripts/contributed/rotate_tokens_20260827-011119.py`
- `scripts/contributed/separator_variants_20260826-041334.py`
- `scripts/contributed/sort_basename_chars_20260827-011119.py`
- `scripts/contributed/sort_basename_tokens_20260827-013046.py`
- `scripts/contributed/source_literal_concats_20260826-044806.py`
- `scripts/contributed/strip_asset_directories_20260827-013046.py`
- `scripts/contributed/suffix_block_precedents_20260826-064355.py`
- `scripts/contributed/swap_basename_halves_20260827-011119.py`
- `scripts/contributed/swap_outer_tokens_20260827-011119.py`
- `scripts/contributed/swap_path_directories_20260827-013046.py`
- `scripts/contributed/token_boundaries_20260826-041334.py`
- `scripts/contributed/uncarried_ends_20260826-231255.txt`
- `scripts/contributed/uncarried_ends_20260826-093543.txt`
- `scripts/contributed/uncarried_ends_20260826-085424.txt`
- `scripts/contributed/uncarried_ends_20260826-090330.txt`
- `scripts/contributed/uncarried_ends_20260826-093543.txt`
- `scripts/contributed/v2_typed_borrowed_endings_range_20260825-102343.py`
- `scripts/contributed/v2_typed_source_20260825-101559.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.