### PR TITLE
[BLKOPS04] findings from Zakkary19, 20260827-062338 (2 names)

### DIFF
--- a/submissions/Zakkary19_BLKOPS04_20260827-062338/about_20260827-062338.md
+++ b/submissions/Zakkary19_BLKOPS04_20260827-062338/about_20260827-062338.md
@@ -1,0 +1,38 @@
+# Submission 20260827-062338
+
+- game: **BLKOPS04**
+- from: Zakkary19
+- names: 2
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- material: 2
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 84 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260827-061324_plan
+- method: all-boundary cores x uncarried endings
+- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
+- ran for: 7m 43s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- beginnings: 0
+- endings: 100000
+- stems: 1796130
+- ids hunted: 159808
+- candidates tested: 179614796130
+- new: 2
+- sketch beginnings: 
+- sketch stems: 000006e18d650fb900000ab4ba1aeee400000c977c5d672200000feaf9e727be000012c311da10ff0000169f01f264ce00002b1519e1ded400002ee0bf50cc96000037218d8ac72000003b9f496e1f3100004e56e3fbb0ec000054c6c2049ef9000054e2e1aff6700000595d5e43b51e0000612ff46513d0000062e7cbfd19140000673d5ec1845600006c06f143465600006dfd9719897600007cbaa17ccc8d0000953fd0beca160000b9a20339b21f0000bb7c449703510000bdf5ddb3c7270000c951a42bde610000d86305422c730000d86ce7b41ecb0000dff33e0893840000ef4a2113a6a70000f0d2d965b07e0000f0e6510e13400000f8739296b6aa
+- sketch endings: 000013d434b4724f000065b3318082ca00006877dd21ae220000b498aeee251c0000b53a60e804620000e8e367dc36f300023a9f2674c4f00002582f51cdb7ee00025a3472daa8da00025c7284e1dcc50002a11084202a1a0002aaaa48e6effc0003936247ef7843000403a6158d4bfd00040f702af23dc100042854a62cea060004be5a5d6abaa700051eff04547b710005ada07146a30a0006f6f9886165690007343925c5ecff0007df8e8462b9b80008112cf7b5145a00090b4e2a677ea200094624d116e9e000099f192f039c30000aa7bc54de0394000c47a603dd2fe6000e54f0b29746e6000e99400ae1d49d000f0edb89597c18000f1027621b11ed
+- fingerprint: 9dbd6f90da3d0593
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/Zakkary19_BLKOPS04_20260827-062338/material_20260827-062338.txt
+++ b/submissions/Zakkary19_BLKOPS04_20260827-062338/material_20260827-062338.txt
@@ -1,0 +1,2 @@
+2723d9e93175a04b,mc/mtl_c_t8_mp_spe_seraph_cw1_forearm_armor_exo1_cst
+75540af04cd1c560,mc/mtl_c_t8_mp_spe_seraph_cw2_forearm_armor_exo1_cst


### PR DESCRIPTION
**BLKOPS04** — 2 asset names, confirmed against that game's own loaded assets.

- material: 2

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Zakkary19

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260827-061324_plan
- method: all-boundary cores x uncarried endings
- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
- ran for: 7m 43s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- beginnings: 0
- endings: 100000
- stems: 1796130
- ids hunted: 159808
- candidates tested: 179614796130
- new: 2
- sketch beginnings: 
- sketch stems: 000006e18d650fb900000ab4ba1aeee400000c977c5d672200000feaf9e727be000012c311da10ff0000169f01f264ce00002b1519e1ded400002ee0bf50cc96000037218d8ac72000003b9f496e1f3100004e56e3fbb0ec000054c6c2049ef9000054e2e1aff6700000595d5e43b51e0000612ff46513d0000062e7cbfd19140000673d5ec1845600006c06f143465600006dfd9719897600007cbaa17ccc8d0000953fd0beca160000b9a20339b21f0000bb7c449703510000bdf5ddb3c7270000c951a42bde610000d86305422c730000d86ce7b41ecb0000dff33e0893840000ef4a2113a6a70000f0d2d965b07e0000f0e6510e13400000f8739296b6aa
- sketch endings: 000013d434b4724f000065b3318082ca00006877dd21ae220000b498aeee251c0000b53a60e804620000e8e367dc36f300023a9f2674c4f00002582f51cdb7ee00025a3472daa8da00025c7284e1dcc50002a11084202a1a0002aaaa48e6effc0003936247ef7843000403a6158d4bfd00040f702af23dc100042854a62cea060004be5a5d6abaa700051eff04547b710005ada07146a30a0006f6f9886165690007343925c5ecff0007df8e8462b9b80008112cf7b5145a00090b4e2a677ea200094624d116e9e000099f192f039c30000aa7bc54de0394000c47a603dd2fe6000e54f0b29746e6000e99400ae1d49d000f0edb89597c18000f1027621b11ed
- fingerprint: 9dbd6f90da3d0593

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/bo4snd_ends_20260826-004415.txt`
- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/numbered_grids_20260821-054219.py`
- `scripts/contributed/overnight_suite_20260827-004818.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.