### PR TITLE
[BLKOPS04] findings from Zakkary19, 20260827-064522 (1 names)

### DIFF
--- a/submissions/Zakkary19_BLKOPS04_20260827-064522/about_20260827-064522.md
+++ b/submissions/Zakkary19_BLKOPS04_20260827-064522/about_20260827-064522.md
@@ -1,0 +1,38 @@
+# Submission 20260827-064522
+
+- game: **BLKOPS04**
+- from: Zakkary19
+- names: 1
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- material: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 89 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260827-063329_plan
+- method: all-boundary cores x uncarried endings
+- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
+- ran for: 9m 18s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- beginnings: 0
+- endings: 100000
+- stems: 1796132
+- ids hunted: 159808
+- candidates tested: 179614996132
+- new: 1
+- sketch beginnings: 
+- sketch stems: 000006e18d650fb900000ab4ba1aeee400000c977c5d672200000feaf9e727be000012c311da10ff0000169f01f264ce00002b1519e1ded400002ee0bf50cc96000037218d8ac72000003b9f496e1f3100004e56e3fbb0ec000054c6c2049ef9000054e2e1aff6700000595d5e43b51e0000612ff46513d0000062e7cbfd19140000673d5ec1845600006c06f143465600006dfd9719897600007cbaa17ccc8d0000953fd0beca160000b9a20339b21f0000bb7c449703510000bdf5ddb3c7270000c951a42bde610000d86305422c730000d86ce7b41ecb0000dff33e0893840000ef4a2113a6a70000f0d2d965b07e0000f0e6510e13400000f8739296b6aa
+- sketch endings: 00009d1c61c251e300009f0c4c83480500017217509b55f50001b4dd72acd1050001c12df56c976600045c1367de2d76000494e09392a8ba0005fc359dfe48d80007d020b1aadee00007ebdee4342b29000869271a4714cb000872a76958d2e10008d27d1ea81564000a26aa4929c79c000a386057bf50ef000a40e5b489b763000a46404dbbc13f000bbfb1098be4ab000e936d1430bb76000f3c26611669560010d236676abe5b0010edf816682b0100111bd139da50ff0011a3cd783860190011fb447bd20ff300126f0d1c4b4fd20012f03820724db60013177929c37c7600138edae33d989f00142c93a0d81ca8001610c70a9e83930016235cd8606636
+- fingerprint: 76ea9984b3601db6
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/Zakkary19_BLKOPS04_20260827-064522/material_20260827-064522.txt
+++ b/submissions/Zakkary19_BLKOPS04_20260827-064522/material_20260827-064522.txt
@@ -1,0 +1,1 @@
+5f33e9be9807cf39,mc/mtl_veh_t7_mphd_gaz_tigr_dead_body_main_back_surface


### PR DESCRIPTION
**BLKOPS04** — 1 asset names, confirmed against that game's own loaded assets.

- material: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Zakkary19

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260827-063329_plan
- method: all-boundary cores x uncarried endings
- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
- ran for: 9m 18s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- beginnings: 0
- endings: 100000
- stems: 1796132
- ids hunted: 159808
- candidates tested: 179614996132
- new: 1
- sketch beginnings: 
- sketch stems: 000006e18d650fb900000ab4ba1aeee400000c977c5d672200000feaf9e727be000012c311da10ff0000169f01f264ce00002b1519e1ded400002ee0bf50cc96000037218d8ac72000003b9f496e1f3100004e56e3fbb0ec000054c6c2049ef9000054e2e1aff6700000595d5e43b51e0000612ff46513d0000062e7cbfd19140000673d5ec1845600006c06f143465600006dfd9719897600007cbaa17ccc8d0000953fd0beca160000b9a20339b21f0000bb7c449703510000bdf5ddb3c7270000c951a42bde610000d86305422c730000d86ce7b41ecb0000dff33e0893840000ef4a2113a6a70000f0d2d965b07e0000f0e6510e13400000f8739296b6aa
- sketch endings: 00009d1c61c251e300009f0c4c83480500017217509b55f50001b4dd72acd1050001c12df56c976600045c1367de2d76000494e09392a8ba0005fc359dfe48d80007d020b1aadee00007ebdee4342b29000869271a4714cb000872a76958d2e10008d27d1ea81564000a26aa4929c79c000a386057bf50ef000a40e5b489b763000a46404dbbc13f000bbfb1098be4ab000e936d1430bb76000f3c26611669560010d236676abe5b0010edf816682b0100111bd139da50ff0011a3cd783860190011fb447bd20ff300126f0d1c4b4fd20012f03820724db60013177929c37c7600138edae33d989f00142c93a0d81ca8001610c70a9e83930016235cd8606636
- fingerprint: 76ea9984b3601db6

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/bo4snd_ends_20260826-004415.txt`
- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/numbered_grids_20260821-054219.py`
- `scripts/contributed/overnight_suite_20260827-004818.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.