### PR TITLE
[BLKOPSCW] findings from Zakkary19, 20260827-071904 (1 names)

### DIFF
--- a/submissions/Zakkary19_BLKOPSCW_20260827-071904/about_20260827-071904.md
+++ b/submissions/Zakkary19_BLKOPSCW_20260827-071904/about_20260827-071904.md
@@ -1,0 +1,38 @@
+# Submission 20260827-071904
+
+- game: **BLKOPSCW**
+- from: Zakkary19
+- names: 1
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 1
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- sound_alias: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 95 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260827-070834_plan
+- method: all-boundary cores x uncarried endings
+- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
+- ran for: 7m 51s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- beginnings: 0
+- endings: 100000
+- stems: 1796138
+- ids hunted: 120392
+- candidates tested: 179615596138
+- new: 2
+- sketch beginnings: 
+- sketch stems: 000006e18d650fb900000ab4ba1aeee400000c977c5d672200000feaf9e727be000012c311da10ff0000169f01f264ce00002b1519e1ded400002ee0bf50cc96000037218d8ac72000003b9f496e1f3100004e56e3fbb0ec000054c6c2049ef9000054e2e1aff6700000595d5e43b51e0000612ff46513d0000062e7cbfd19140000673d5ec1845600006c06f143465600006dfd9719897600007cbaa17ccc8d0000953fd0beca160000b9a20339b21f0000bb7c449703510000bdf5ddb3c7270000c951a42bde610000d86305422c730000d86ce7b41ecb0000dff33e0893840000ef4a2113a6a70000f0d2d965b07e0000f0e6510e13400000f8739296b6aa
+- sketch endings: 0000529b80a633f200009f9cc2c74c800000c758cb1bbbed0001114048013a85000174872b31752b00030cb6303ee1e800041521e7ba1afd000537a26427bb76000549dfe34f77e000058cb7b8c069a400070f3e249ec3bc0008935e985c4a7800092439ad056efa000a2ca527ed5838000b2cdb3ba9c339000b58dadd3e7cc0000b5e4acc8c2519000b7d5ee4e019ac000c1017f7a1dc1f000d8903c8652263000e48a36411f7dd000f1a6038c3a7b2000fc7cc329960cf00118263fe009bc400124ad6d6445ea800129b7cc2462c2f0012ed645c32254300137f0079c504890013a3a0559d57a10013f476e90243eb001496bc304b53590015b37d56374d55
+- fingerprint: bc0b8d383322c9d7
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/Zakkary19_BLKOPSCW_20260827-071904/sound_alias_20260827-071904.txt
+++ b/submissions/Zakkary19_BLKOPSCW_20260827-071904/sound_alias_20260827-071904.txt
@@ -1,0 +1,1 @@
+639a4b315f988e7b,mpl_d_hard_exp_lfe


### PR DESCRIPTION
**BLKOPSCW** — 1 asset names, confirmed against that game's own loaded assets.

- sound_alias: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 1
- submitted by: @Zakkary19

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260827-070834_plan
- method: all-boundary cores x uncarried endings
- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
- ran for: 7m 51s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- beginnings: 0
- endings: 100000
- stems: 1796138
- ids hunted: 120392
- candidates tested: 179615596138
- new: 2
- sketch beginnings: 
- sketch stems: 000006e18d650fb900000ab4ba1aeee400000c977c5d672200000feaf9e727be000012c311da10ff0000169f01f264ce00002b1519e1ded400002ee0bf50cc96000037218d8ac72000003b9f496e1f3100004e56e3fbb0ec000054c6c2049ef9000054e2e1aff6700000595d5e43b51e0000612ff46513d0000062e7cbfd19140000673d5ec1845600006c06f143465600006dfd9719897600007cbaa17ccc8d0000953fd0beca160000b9a20339b21f0000bb7c449703510000bdf5ddb3c7270000c951a42bde610000d86305422c730000d86ce7b41ecb0000dff33e0893840000ef4a2113a6a70000f0d2d965b07e0000f0e6510e13400000f8739296b6aa
- sketch endings: 0000529b80a633f200009f9cc2c74c800000c758cb1bbbed0001114048013a85000174872b31752b00030cb6303ee1e800041521e7ba1afd000537a26427bb76000549dfe34f77e000058cb7b8c069a400070f3e249ec3bc0008935e985c4a7800092439ad056efa000a2ca527ed5838000b2cdb3ba9c339000b58dadd3e7cc0000b5e4acc8c2519000b7d5ee4e019ac000c1017f7a1dc1f000d8903c8652263000e48a36411f7dd000f1a6038c3a7b2000fc7cc329960cf00118263fe009bc400124ad6d6445ea800129b7cc2462c2f0012ed645c32254300137f0079c504890013a3a0559d57a10013f476e90243eb001496bc304b53590015b37d56374d55
- fingerprint: bc0b8d383322c9d7

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/bo4snd_ends_20260826-004415.txt`
- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/numbered_grids_20260821-054219.py`
- `scripts/contributed/overnight_suite_20260827-004818.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.