### PR TITLE
[BLKOPS04] findings from Zakkary19, 20260827-131148 (2 names)

### DIFF
--- a/submissions/Zakkary19_BLKOPS04_20260827-131148/about_20260827-131148.md
+++ b/submissions/Zakkary19_BLKOPS04_20260827-131148/about_20260827-131148.md
@@ -1,0 +1,38 @@
+# Submission 20260827-131148
+
+- game: **BLKOPS04**
+- from: Zakkary19
+- names: 2
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- material: 2
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 100 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260827-125603_plan
+- method: heads of length 4, slash-bearing beginnings
+- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
+- ran for: 13m 00s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- beginnings: 210975
+- endings: 0
+- stems: 959598
+- ids hunted: 159892
+- candidates tested: 202451188050
+- new: 2
+- sketch beginnings: 000052f04f787f6c000071ddcea07f740000dbd115144c7300012052edaed9c6000205254dda6a7500021c13a2b501ea000269470f01d53c0002f2cc2ee7e5a20003892b9a2db8090003dbf6c9c12e7d000470fff4d0378d00053bdaeef4631e00059b8a69e0efb900059cabde55c57d000662342f00d3de0006672a079b95330007201d28b1f2b300075eaf54e1b9c7000809558ce233b4000862644a8740560008e1b9c525be590008fd89a99b0edb0009581eed90c0a500098037fce79bee0009be415518a33f000a065e72f90f1d000a16b4ccf2b5f5000a308e463b8563000a332bacaddb35000a691c907f8f34000abfc0a01850bf000af2a29512871e
+- sketch stems: 00001170a7975394000034820ba7f3b300003bca2633974300003d3da9321622000068d9b38163fa00006dcf4221638900008c08503e49e00000941c1685e3310000972b73462b3900009b41f982af0700009fcc25d0b3730000bb71ca5b19fe0000c24e1e1e81a80000ceb9ddd8fa990000cf8b3cd864c80000e81896ebcb0c0000f37143bc414e0000fc8420074d7800010a8d9b997c8700012076eaae941c00013804f35f601100014ef4c9ba30fe00015b1e44c80ccd00018d9a5959b9910001b8ca657de26d0001ba33713614bc0001ca7f95ffc9a50001d59b073fe81a0001d7bbd3e78db10001f471377477a30001fcbb7b1a450c000228aef7453638
+- sketch endings: 
+- fingerprint: cf9339ee2905fb10
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/Zakkary19_BLKOPS04_20260827-131148/material_20260827-131148.txt
+++ b/submissions/Zakkary19_BLKOPS04_20260827-131148/material_20260827-131148.txt
@@ -1,0 +1,2 @@
+21cf0cb5a6ab7f24,wc/mtl_p8_sta_metal_window_frame_black
+41f5d182a44e44c4,wc/mtl_p8_nt4_firewood_wood_paint_red_decal


### PR DESCRIPTION
**BLKOPS04** — 2 asset names, confirmed against that game's own loaded assets.

- material: 2

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Zakkary19

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260827-125603_plan
- method: heads of length 4, slash-bearing beginnings
- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
- ran for: 13m 00s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- beginnings: 210975
- endings: 0
- stems: 959598
- ids hunted: 159892
- candidates tested: 202451188050
- new: 2
- sketch beginnings: 000052f04f787f6c000071ddcea07f740000dbd115144c7300012052edaed9c6000205254dda6a7500021c13a2b501ea000269470f01d53c0002f2cc2ee7e5a20003892b9a2db8090003dbf6c9c12e7d000470fff4d0378d00053bdaeef4631e00059b8a69e0efb900059cabde55c57d000662342f00d3de0006672a079b95330007201d28b1f2b300075eaf54e1b9c7000809558ce233b4000862644a8740560008e1b9c525be590008fd89a99b0edb0009581eed90c0a500098037fce79bee0009be415518a33f000a065e72f90f1d000a16b4ccf2b5f5000a308e463b8563000a332bacaddb35000a691c907f8f34000abfc0a01850bf000af2a29512871e
- sketch stems: 00001170a7975394000034820ba7f3b300003bca2633974300003d3da9321622000068d9b38163fa00006dcf4221638900008c08503e49e00000941c1685e3310000972b73462b3900009b41f982af0700009fcc25d0b3730000bb71ca5b19fe0000c24e1e1e81a80000ceb9ddd8fa990000cf8b3cd864c80000e81896ebcb0c0000f37143bc414e0000fc8420074d7800010a8d9b997c8700012076eaae941c00013804f35f601100014ef4c9ba30fe00015b1e44c80ccd00018d9a5959b9910001b8ca657de26d0001ba33713614bc0001ca7f95ffc9a50001d59b073fe81a0001d7bbd3e78db10001f471377477a30001fcbb7b1a450c000228aef7453638
- sketch endings: 
- fingerprint: cf9339ee2905fb10

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/bo4snd_ends_20260826-004415.txt`
- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/numbered_grids_20260821-054219.py`
- `scripts/contributed/overnight_suite_20260827-004818.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.