### PR TITLE
[BLKOPS04] findings from Zakkary19, 20260830-075328 (3 names)

### DIFF
--- a/submissions/Zakkary19_BLKOPS04_20260830-075328/about_20260830-075328.md
+++ b/submissions/Zakkary19_BLKOPS04_20260830-075328/about_20260830-075328.md
@@ -1,0 +1,100 @@
+# Submission 20260830-075328
+
+- game: **BLKOPS04**
+- from: Zakkary19
+- names: 3
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 5
+- runs included: 4
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- image: 1
+- material: 1
+- xmodel: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 63 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260830-061849_plan
+- method: all-boundary sound cores x uncarried sound endings
+- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
+- ran for: 3m 22s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- beginnings: 0
+- endings: 28638
+- stems: 2033324
+- ids hunted: 157613
+- candidates tested: 58232366036
+- new: 2
+- sketch beginnings: 
+- sketch stems: 000001ad4b3a16660000055355fb707b0000116c72a86c8800001a7948e2da7b0000261d00af5a5700002b1519e1ded400002ee0bf50cc9600003cd0bb5e04e900003e662bfcc8e100003f686b513e9300004539e386abfe000047045784f62e000048bb4c35d1c700004ec0ee5f3551000059b99780a20500006296216d57d100006d11a6a6ae7600008ed79cb32e090000965d9177932d000098934c7c630600009da2806c90300000aa984ebb57620000aec8c22d128f0000b327d9e196d40000c2b8a94bc4b40000c43959f1d3170000c6e299e473210000d0b5476b5d4b0000d5f19e8574340000d7354da7c98b0000d97fef7000c50000ef4a2113a6a7
+- sketch endings: 0004e83a03144b810007a544f9072879000a2ca527ed58380012ed645c322543001494c09150134100173525c400009e001a6caa73694b19001f772d70565e6b002248b820015177002272a0545b733c002509325fdbb6ab0025413a86e41ba80025afd40afb061400273cc10c9e1af500283dd27c81a359002ac5dc8e45c419002bc3511321326e00303aac00c209b00030bee52f5c9007003175ebb597b6660031a893c7d06dcb0032ff0ae639bb010034eb49902ccad10036551192a3d812003f790b10c162d2003ff36eebaf97e400400a4462ea460300404bcc6f59dc5c004162181e1bfe2b0041c5ade22f69500044cd9b8c115c7f00450baa68a34cdc
+- fingerprint: 10be643b8ffba232
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.
+
+### run_20260830-063047_plan
+- method: all-boundary sound cores x uncarried sound endings
+- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
+- ran for: 8m 23s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- beginnings: 0
+- endings: 60000
+- stems: 2033326
+- ids hunted: 157613
+- candidates tested: 122001593326
+- new: 1
+- sketch beginnings: 
+- sketch stems: 000001ad4b3a16660000055355fb707b0000116c72a86c8800001a7948e2da7b0000261d00af5a5700002b1519e1ded400002ee0bf50cc9600003cd0bb5e04e900003e662bfcc8e100003f686b513e9300004539e386abfe000047045784f62e000048bb4c35d1c700004ec0ee5f3551000059b99780a20500006296216d57d100006d11a6a6ae7600008ed79cb32e090000965d9177932d000098934c7c630600009da2806c90300000aa984ebb57620000aec8c22d128f0000b327d9e196d40000c2b8a94bc4b40000c43959f1d3170000c6e299e473210000d0b5476b5d4b0000d5f19e8574340000d7354da7c98b0000d97fef7000c50000ef4a2113a6a7
+- sketch endings: 00000e56e68ff2ad000013d434b4724f000014e89d24eb3500004eb4142e348d00027e48b87969d800029060f893dbf40002aaaa48e6effc0002b61bdcaac24d0003477c27e27f880003bf92fab8232e00054cc2ce114373000577b6fd5507c50007ffd3755fdb0800098027a9b89c27000b62aa1032da53000c30d0c85c778f000e404bcace059e000e6b3edc6a009e000e99746e60cb0c00109399f33296ac0010c554ec023cce0011e0e1254b8e0f00123d8bc476597b0015499b4ffc16260015b64fa28285170015bdb968ec426a0015db035e3f69710016a41b0a1bc857001a1a50ea361e72001bf211155214cd001c6c657bb374e3001d53ce06e42bf4
+- fingerprint: d387c97fd033b048
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.
+
+### run_20260830-070047_plan
+- method: all-boundary cores x uncarried endings
+- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
+- ran for: 8m 05s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- beginnings: 0
+- endings: 100000
+- stems: 1802198
+- ids hunted: 157613
+- candidates tested: 180221602198
+- new: 2
+- sketch beginnings: 
+- sketch stems: 000006e18d650fb900000ab4ba1aeee400000c977c5d672200000feaf9e727be000012c311da10ff0000169f01f264ce00002b1519e1ded400002ee0bf50cc96000037218d8ac72000003b9f496e1f3100004e56e3fbb0ec000054c6c2049ef9000054e2e1aff6700000595d5e43b51e0000612ff46513d0000062e7cbfd19140000673d5ec1845600006c06f143465600006dfd9719897600007cbaa17ccc8d0000953fd0beca160000b9a20339b21f0000bb7c449703510000bdf5ddb3c7270000c951a42bde610000d86305422c730000d86ce7b41ecb0000dff33e0893840000ef4a2113a6a70000f0d2d965b07e0000f0e6510e13400000f8739296b6aa
+- sketch endings: 000013d434b4724f000065b3318082ca00006877dd21ae220000b498aeee251c0000b53a60e8046200023a9f2674c4f00002582f51cdb7ee00025a3472daa8da00025c7284e1dcc50002a11084202a1a0002aaaa48e6effc0003936247ef7843000403a6158d4bfd00040f702af23dc100042854a62cea060004be5a5d6abaa700051eff04547b710005ada07146a30a0006f6f9886165690007343925c5ecff0007df8e8462b9b80008112cf7b5145a00090b4e2a677ea200094624d116e9e000099f192f039c30000aa7bc54de0394000c47a603dd2fe6000e54f0b29746e6000e99400ae1d49d000f0edb89597c18000f1027621b11ed000fb1a1a08e5fd6
+- fingerprint: f353c00d2addabf3
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.
+
+### run_20260830-071725_plan
+- method: all-boundary cores x uncarried endings
+- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
+- ran for: 8m 16s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- beginnings: 0
+- endings: 100000
+- stems: 1802202
+- ids hunted: 157613
+- candidates tested: 180222002202
+- new: 3
+- sketch beginnings: 
+- sketch stems: 000006e18d650fb900000ab4ba1aeee400000c977c5d672200000feaf9e727be000012c311da10ff0000169f01f264ce00002b1519e1ded400002ee0bf50cc96000037218d8ac72000003b9f496e1f3100004e56e3fbb0ec000054c6c2049ef9000054e2e1aff6700000595d5e43b51e0000612ff46513d0000062e7cbfd19140000673d5ec1845600006c06f143465600006dfd9719897600007cbaa17ccc8d0000953fd0beca160000b9a20339b21f0000bb7c449703510000bdf5ddb3c7270000c951a42bde610000d86305422c730000d86ce7b41ecb0000dff33e0893840000ef4a2113a6a70000f0d2d965b07e0000f0e6510e13400000f8739296b6aa
+- sketch endings: 0000529b80a633f200009f9cc2c74c800000c758cb1bbbed0001114048013a85000174872b31752b00030cb6303ee1e800041521e7ba1afd000537a26427bb76000549dfe34f77e000058cb7b8c069a400070f3e249ec3bc0008935e985c4a7800092439ad056efa000a2ca527ed5838000b2cdb3ba9c339000b58dadd3e7cc0000b5e4acc8c2519000b7d5ee4e019ac000c1017f7a1dc1f000d8903c8652263000e48a36411f7dd000f1a6038c3a7b2000fc7cc329960cf00118263fe009bc400124ad6d6445ea800129b7cc2462c2f0012ed645c32254300137f0079c504890013a3a0559d57a10013f476e90243eb001496bc304b53590015b37d56374d55
+- fingerprint: fa7d4c0e8f9c82c4
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/Zakkary19_BLKOPS04_20260830-075328/image_20260830-075328.txt
+++ b/submissions/Zakkary19_BLKOPS04_20260830-075328/image_20260830-075328.txt
@@ -1,0 +1,1 @@
+41604ae1c0c3be0c,i_mtl_preview_fx_quality

--- a/submissions/Zakkary19_BLKOPS04_20260830-075328/material_20260830-075328.txt
+++ b/submissions/Zakkary19_BLKOPS04_20260830-075328/material_20260830-075328.txt
@@ -1,0 +1,1 @@
+2fb9418ec869ca7d,mc/mtl_p8_zm_man_trap_electric_cap_vent_little

--- a/submissions/Zakkary19_BLKOPS04_20260830-075328/xmodel_20260830-075328.txt
+++ b/submissions/Zakkary19_BLKOPS04_20260830-075328/xmodel_20260830-075328.txt
@@ -1,0 +1,1 @@
+d83bdef59c7b27e,p8_kit_spa_gen_01_roof_tiles_01_end_right_bottom_red_clay_dirty_0_01


### PR DESCRIPTION
**BLKOPS04** — 3 asset names, confirmed against that game's own loaded assets.

- image: 1
- material: 1
- xmodel: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 5
- submitted by: @Zakkary19

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260830-061849_plan
- method: all-boundary sound cores x uncarried sound endings
- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
- ran for: 3m 22s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- beginnings: 0
- endings: 28638
- stems: 2033324
- ids hunted: 157613
- candidates tested: 58232366036
- new: 2
- sketch beginnings: 
- sketch stems: 000001ad4b3a16660000055355fb707b0000116c72a86c8800001a7948e2da7b0000261d00af5a5700002b1519e1ded400002ee0bf50cc9600003cd0bb5e04e900003e662bfcc8e100003f686b513e9300004539e386abfe000047045784f62e000048bb4c35d1c700004ec0ee5f3551000059b99780a20500006296216d57d100006d11a6a6ae7600008ed79cb32e090000965d9177932d000098934c7c630600009da2806c90300000aa984ebb57620000aec8c22d128f0000b327d9e196d40000c2b8a94bc4b40000c43959f1d3170000c6e299e473210000d0b5476b5d4b0000d5f19e8574340000d7354da7c98b0000d97fef7000c50000ef4a2113a6a7
- sketch endings: 0004e83a03144b810007a544f9072879000a2ca527ed58380012ed645c322543001494c09150134100173525c400009e001a6caa73694b19001f772d70565e6b002248b820015177002272a0545b733c002509325fdbb6ab0025413a86e41ba80025afd40afb061400273cc10c9e1af500283dd27c81a359002ac5dc8e45c419002bc3511321326e00303aac00c209b00030bee52f5c9007003175ebb597b6660031a893c7d06dcb0032ff0ae639bb010034eb49902ccad10036551192a3d812003f790b10c162d2003ff36eebaf97e400400a4462ea460300404bcc6f59dc5c004162181e1bfe2b0041c5ade22f69500044cd9b8c115c7f00450baa68a34cdc
- fingerprint: 10be643b8ffba232

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

### run_20260830-063047_plan
- method: all-boundary sound cores x uncarried sound endings
- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
- ran for: 8m 23s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- beginnings: 0
- endings: 60000
- stems: 2033326
- ids hunted: 157613
- candidates tested: 122001593326
- new: 1
- sketch beginnings: 
- sketch stems: 000001ad4b3a16660000055355fb707b0000116c72a86c8800001a7948e2da7b0000261d00af5a5700002b1519e1ded400002ee0bf50cc9600003cd0bb5e04e900003e662bfcc8e100003f686b513e9300004539e386abfe000047045784f62e000048bb4c35d1c700004ec0ee5f3551000059b99780a20500006296216d57d100006d11a6a6ae7600008ed79cb32e090000965d9177932d000098934c7c630600009da2806c90300000aa984ebb57620000aec8c22d128f0000b327d9e196d40000c2b8a94bc4b40000c43959f1d3170000c6e299e473210000d0b5476b5d4b0000d5f19e8574340000d7354da7c98b0000d97fef7000c50000ef4a2113a6a7
- sketch endings: 00000e56e68ff2ad000013d434b4724f000014e89d24eb3500004eb4142e348d00027e48b87969d800029060f893dbf40002aaaa48e6effc0002b61bdcaac24d0003477c27e27f880003bf92fab8232e00054cc2ce114373000577b6fd5507c50007ffd3755fdb0800098027a9b89c27000b62aa1032da53000c30d0c85c778f000e404bcace059e000e6b3edc6a009e000e99746e60cb0c00109399f33296ac0010c554ec023cce0011e0e1254b8e0f00123d8bc476597b0015499b4ffc16260015b64fa28285170015bdb968ec426a0015db035e3f69710016a41b0a1bc857001a1a50ea361e72001bf211155214cd001c6c657bb374e3001d53ce06e42bf4
- fingerprint: d387c97fd033b048

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

### run_20260830-070047_plan
- method: all-boundary cores x uncarried endings
- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
- ran for: 8m 05s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- beginnings: 0
- endings: 100000
- stems: 1802198
- ids hunted: 157613
- candidates tested: 180221602198
- new: 2
- sketch beginnings: 
- sketch stems: 000006e18d650fb900000ab4ba1aeee400000c977c5d672200000feaf9e727be000012c311da10ff0000169f01f264ce00002b1519e1ded400002ee0bf50cc96000037218d8ac72000003b9f496e1f3100004e56e3fbb0ec000054c6c2049ef9000054e2e1aff6700000595d5e43b51e0000612ff46513d0000062e7cbfd19140000673d5ec1845600006c06f143465600006dfd9719897600007cbaa17ccc8d0000953fd0beca160000b9a20339b21f0000bb7c449703510000bdf5ddb3c7270000c951a42bde610000d86305422c730000d86ce7b41ecb0000dff33e0893840000ef4a2113a6a70000f0d2d965b07e0000f0e6510e13400000f8739296b6aa
- sketch endings: 000013d434b4724f000065b3318082ca00006877dd21ae220000b498aeee251c0000b53a60e8046200023a9f2674c4f00002582f51cdb7ee00025a3472daa8da00025c7284e1dcc50002a11084202a1a0002aaaa48e6effc0003936247ef7843000403a6158d4bfd00040f702af23dc100042854a62cea060004be5a5d6abaa700051eff04547b710005ada07146a30a0006f6f9886165690007343925c5ecff0007df8e8462b9b80008112cf7b5145a00090b4e2a677ea200094624d116e9e000099f192f039c30000aa7bc54de0394000c47a603dd2fe6000e54f0b29746e6000e99400ae1d49d000f0edb89597c18000f1027621b11ed000fb1a1a08e5fd6
- fingerprint: f353c00d2addabf3

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

### run_20260830-071725_plan
- method: all-boundary cores x uncarried endings
- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
- ran for: 8m 16s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- beginnings: 0
- endings: 100000
- stems: 1802202
- ids hunted: 157613
- candidates tested: 180222002202
- new: 3
- sketch beginnings: 
- sketch stems: 000006e18d650fb900000ab4ba1aeee400000c977c5d672200000feaf9e727be000012c311da10ff0000169f01f264ce00002b1519e1ded400002ee0bf50cc96000037218d8ac72000003b9f496e1f3100004e56e3fbb0ec000054c6c2049ef9000054e2e1aff6700000595d5e43b51e0000612ff46513d0000062e7cbfd19140000673d5ec1845600006c06f143465600006dfd9719897600007cbaa17ccc8d0000953fd0beca160000b9a20339b21f0000bb7c449703510000bdf5ddb3c7270000c951a42bde610000d86305422c730000d86ce7b41ecb0000dff33e0893840000ef4a2113a6a70000f0d2d965b07e0000f0e6510e13400000f8739296b6aa
- sketch endings: 0000529b80a633f200009f9cc2c74c800000c758cb1bbbed0001114048013a85000174872b31752b00030cb6303ee1e800041521e7ba1afd000537a26427bb76000549dfe34f77e000058cb7b8c069a400070f3e249ec3bc0008935e985c4a7800092439ad056efa000a2ca527ed5838000b2cdb3ba9c339000b58dadd3e7cc0000b5e4acc8c2519000b7d5ee4e019ac000c1017f7a1dc1f000d8903c8652263000e48a36411f7dd000f1a6038c3a7b2000fc7cc329960cf00118263fe009bc400124ad6d6445ea800129b7cc2462c2f0012ed645c32254300137f0079c504890013a3a0559d57a10013f476e90243eb001496bc304b53590015b37d56374d55
- fingerprint: fa7d4c0e8f9c82c4

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/bo4snd_ends_20260830-055842.txt`
- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/numbered_grids_20260821-054219.py`
- `scripts/contributed/overnight_suite_20260830-055842.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.