### PR TITLE
[BLKOPS04] findings from Zakkary19, 20260831-130455 (5 names)

### DIFF
--- a/submissions/Zakkary19_BLKOPS04_20260831-130455/about_20260831-130455.md
+++ b/submissions/Zakkary19_BLKOPS04_20260831-130455/about_20260831-130455.md
@@ -1,0 +1,39 @@
+# Submission 20260831-130455
+
+- game: **BLKOPS04**
+- from: Zakkary19
+- names: 5
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- material: 3
+- xmodel: 2
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 0 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260831-130334_plan
+- method: all-boundary cores x uncarried endings
+- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
+- ran for: 18s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- beginnings: 0
+- endings: 100000
+- stems: 76496
+- ids hunted: 153948
+- candidates tested: 7649676496
+- new: 5
+- sketch beginnings: 
+- sketch stems: 00002b1519e1ded400002ee0bf50cc960001aef44909c8860001c4288d1f83f80003b69caf19a9720004a5cf1343b386000624bd7bcc757200063685031d44230006518ce0f1ed4d00068f4e032473900006b5e60602d68c0007d55dbb0777ea000c7c620254ad84000d4e4e5c704308000e8b0363827d88000f1597bb35c60d000f41c7b161d2b1001049eb6ca5009300108dc43f3f7d7100110279a47aed8c00110f76cb990dc100131ee02c31e698001416b90333d31100145d41c6155d7d0014b07560ee3bd2001501337ddd67d100152fa9c4c4534c00164f8aa3d6a8a10018203c5faa4eef0019925b8a34db71001a3f8df536b4e2001a5d530127f60d
+- sketch endings: 0001bf49f7ec48d30001df6ac08d3428000229682628f65c000271aa0414ec0b0002da8ef2e22ceb000368909aaa7dc600067eab9c5d06f9000715995132634d00079b9bd87017440007fa22af3229dc00081b80627cffa80008f05da7a32d8b000931978e22ab230009b3595fe41010000b8b91a2cae7a6000dac17c66fcdb1000e676be6fed101000f2b3bdf945843000f3fed4afaa24f00103ca407b45ca70010dea55748343000115a72530fe295001203b2611bcd5200131eb4e7bcfef500135065d628cdd3001494595def5ffd00149cee732b298b0014cffc55cfa7160014ff7cc20d9bd50016ee0622fb3c6700170d2b19575e04001747673152a206
+- fingerprint: 17f49bd79efb1405
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/Zakkary19_BLKOPS04_20260831-130455/material_20260831-130455.txt
+++ b/submissions/Zakkary19_BLKOPS04_20260831-130455/material_20260831-130455.txt
@@ -1,0 +1,3 @@
+5a46924191a8802d,mc/mtl_veh_t8_civ_truck_mini_tag_trash_attach_body_int_dirty
+738c1b1cf840774d,mc/mtl_veh_t8_civ_car_racer_body_01_mirror
+7e33fec6f734e820,mc/mtl_veh_t8_civ_car_racer_body_03_light

--- a/submissions/Zakkary19_BLKOPS04_20260831-130455/xmodel_20260831-130455.txt
+++ b/submissions/Zakkary19_BLKOPS04_20260831-130455/xmodel_20260831-130455.txt
@@ -1,0 +1,2 @@
+d5b2b479fd7b75,c_t8_zmb_ora_zombie_electric_s_llegoff
+2b9d294653359a0f,c_t8_zmb_ora_zombie_electric_s_rlegoff


### PR DESCRIPTION
**BLKOPS04** — 5 asset names, confirmed against that game's own loaded assets.

- material: 3
- xmodel: 2

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Zakkary19

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260831-130334_plan
- method: all-boundary cores x uncarried endings
- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
- ran for: 18s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- beginnings: 0
- endings: 100000
- stems: 76496
- ids hunted: 153948
- candidates tested: 7649676496
- new: 5
- sketch beginnings: 
- sketch stems: 00002b1519e1ded400002ee0bf50cc960001aef44909c8860001c4288d1f83f80003b69caf19a9720004a5cf1343b386000624bd7bcc757200063685031d44230006518ce0f1ed4d00068f4e032473900006b5e60602d68c0007d55dbb0777ea000c7c620254ad84000d4e4e5c704308000e8b0363827d88000f1597bb35c60d000f41c7b161d2b1001049eb6ca5009300108dc43f3f7d7100110279a47aed8c00110f76cb990dc100131ee02c31e698001416b90333d31100145d41c6155d7d0014b07560ee3bd2001501337ddd67d100152fa9c4c4534c00164f8aa3d6a8a10018203c5faa4eef0019925b8a34db71001a3f8df536b4e2001a5d530127f60d
- sketch endings: 0001bf49f7ec48d30001df6ac08d3428000229682628f65c000271aa0414ec0b0002da8ef2e22ceb000368909aaa7dc600067eab9c5d06f9000715995132634d00079b9bd87017440007fa22af3229dc00081b80627cffa80008f05da7a32d8b000931978e22ab230009b3595fe41010000b8b91a2cae7a6000dac17c66fcdb1000e676be6fed101000f2b3bdf945843000f3fed4afaa24f00103ca407b45ca70010dea55748343000115a72530fe295001203b2611bcd5200131eb4e7bcfef500135065d628cdd3001494595def5ffd00149cee732b298b0014cffc55cfa7160014ff7cc20d9bd50016ee0622fb3c6700170d2b19575e04001747673152a206
- fingerprint: 17f49bd79efb1405

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/bo4snd_ends_20260830-055842.txt`
- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/numbered_grids_20260821-054219.py`
- `scripts/contributed/overnight_suite_20260831-054937.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.