### PR TITLE
[BLKOPSCW] findings from Zakkary19, 20260831-152225 (2 names)

### DIFF
--- a/submissions/Zakkary19_BLKOPSCW_20260831-152225/about_20260831-152225.md
+++ b/submissions/Zakkary19_BLKOPSCW_20260831-152225/about_20260831-152225.md
@@ -1,0 +1,38 @@
+# Submission 20260831-152225
+
+- game: **BLKOPSCW**
+- from: Zakkary19
+- names: 2
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- material: 2
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 18 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260831-152059_plan
+- method: all-boundary cores x uncarried endings
+- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
+- ran for: 13s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- beginnings: 0
+- endings: 100000
+- stems: 36945
+- ids hunted: 113016
+- candidates tested: 3694536945
+- new: 2
+- sketch beginnings: 
+- sketch stems: 00002b1519e1ded40001c4288d1f83f80003b69caf19a9720004a5cf1343b38600063685031d4423000f1597bb35c60d00108dc43f3f7d7100110f76cb990dc1001416b90333d31100145d41c6155d7d001501337ddd67d100152fa9c4c4534c00182aeae1fa77ef001a7e7a6d4976d3001ca7f05f38a262001da2dcd16eff55001e2c9de2cd1f4100208856d44379ec00210f78b01caf8a002373e6758040af00237f2be3916d920023ddcd130b37900024c8f466d89d420026007fd114d562002b0e53920affb1002d8c57bb566ead002ee3cf10634b04002ef5baab179fae002f2af27b7e511e002ff87367bbe25e00342faec94b823400346d52c9523064
+- sketch endings: 000013d434b4724f000065b3318082ca00006877dd21ae220000b498aeee251c0000b53a60e8046200023a9f2674c4f00002582f51cdb7ee00025a3472daa8da00025c7284e1dcc500029060f893dbf40002a11084202a1a0002aaaa48e6effc0003936247ef78430003bf92fab8232e00042854a62cea060004be5a5d6abaa700051eff04547b71000577b6fd5507c50005ada07146a30a0006f6f9886165690007df8e8462b9b80008112cf7b5145a00090b4e2a677ea200094624d116e9e000099f192f039c30000aa7bc54de0394000e54f0b29746e6000e99400ae1d49d000f0edb89597c18000f1027621b11ed000fb1a1a08e5fd600100b24e767e250
+- fingerprint: 520827a105b0bfc3
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/Zakkary19_BLKOPSCW_20260831-152225/material_20260831-152225.txt
+++ b/submissions/Zakkary19_BLKOPSCW_20260831-152225/material_20260831-152225.txt
@@ -1,0 +1,2 @@
+59d3154090a111fc,ei/gfx9_muzzle_gas_brake_pap_atlas_1p_hdrg
+7951f49e59a27b48,mc/mtl_p9_rus_cccp_monument_tile_4x4_01_glossy_red


### PR DESCRIPTION
**BLKOPSCW** — 2 asset names, confirmed against that game's own loaded assets.

- material: 2

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Zakkary19

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260831-152059_plan
- method: all-boundary cores x uncarried endings
- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
- ran for: 13s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- beginnings: 0
- endings: 100000
- stems: 36945
- ids hunted: 113016
- candidates tested: 3694536945
- new: 2
- sketch beginnings: 
- sketch stems: 00002b1519e1ded40001c4288d1f83f80003b69caf19a9720004a5cf1343b38600063685031d4423000f1597bb35c60d00108dc43f3f7d7100110f76cb990dc1001416b90333d31100145d41c6155d7d001501337ddd67d100152fa9c4c4534c00182aeae1fa77ef001a7e7a6d4976d3001ca7f05f38a262001da2dcd16eff55001e2c9de2cd1f4100208856d44379ec00210f78b01caf8a002373e6758040af00237f2be3916d920023ddcd130b37900024c8f466d89d420026007fd114d562002b0e53920affb1002d8c57bb566ead002ee3cf10634b04002ef5baab179fae002f2af27b7e511e002ff87367bbe25e00342faec94b823400346d52c9523064
- sketch endings: 000013d434b4724f000065b3318082ca00006877dd21ae220000b498aeee251c0000b53a60e8046200023a9f2674c4f00002582f51cdb7ee00025a3472daa8da00025c7284e1dcc500029060f893dbf40002a11084202a1a0002aaaa48e6effc0003936247ef78430003bf92fab8232e00042854a62cea060004be5a5d6abaa700051eff04547b71000577b6fd5507c50005ada07146a30a0006f6f9886165690007df8e8462b9b80008112cf7b5145a00090b4e2a677ea200094624d116e9e000099f192f039c30000aa7bc54de0394000e54f0b29746e6000e99400ae1d49d000f0edb89597c18000f1027621b11ed000fb1a1a08e5fd600100b24e767e250
- fingerprint: 520827a105b0bfc3

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/bo4snd_cores_20260831-143621.txt`
- `scripts/contributed/bo4snd_ends_20260831-143621.txt`
- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/numbered_grids_20260821-054219.py`
- `scripts/contributed/overnight_suite_20260831-054937.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.