### PR TITLE
[BLKOPS04] findings from Tnt540, 20260831-191005 (9 names)

### DIFF
--- a/submissions/Tnt540_BLKOPS04_20260831-191005/about_20260831-191005.md
+++ b/submissions/Tnt540_BLKOPS04_20260831-191005/about_20260831-191005.md
@@ -1,0 +1,39 @@
+# Submission 20260831-191005
+
+- game: **BLKOPS04**
+- from: Tnt540
+- names: 9
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- sound_alias: 5
+- image: 4
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 35 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260831-190201_plan
+- method: uncarried beginnings
+- what it does: the 209 leading segments no cut of which `data/prefixes.txt` carries, against cores from the published names that use them and from everything this machine has confirmed
+- ran for: 6m 59s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- beginnings: 209
+- endings: 4629
+- stems: 232565
+- ids hunted: 151329
+- candidates tested: 225046173550
+- new: 9
+- sketch beginnings: 0084b979595f86df00ac8133506d429c01f06f475d5e01cd022e34e844929260023406f88536a8de06b447482b9b5c4c077e5a5892a3a5550a8a3ee3821a9c200c6e148aebdba61010305f4ce6a3acb710ae443e5c2e4f6910ba4644e2f2362210e46cfccf95307513a71ef39f0565921468bd47616673c616f376f22c888dd617afaf989a8f88dd1b422267e8c11d6a1e6081a8b7d556401ea834b7fb05f7bb1f40f1f82eb3403420bb4254738dbfd521226e9452a89e1b213e56e5c91f648922bd22fb1e9545d022e531950cd2622d25c4f76680830c91271d6215fefd4657272dc5fde967f77f277359869d28d63c285a54c5d573e3892aa7475e81592478
+- sketch stems: 000063a33732586900006dcf4221638900009d6043da5beb000237540b6e3f930002911d10cffd910002d170e3084a65000310ff73e68ee600035a6d588aa75600035ede9efa5e900003f6860e09096b00041a795924b8050004580ec440bc3700045dbd500476f70004b220cea1973b0004ba2cf231767300053721e203b70500055b459ce7f696000572dad17c593a0005bfae70539563000691ed8bf2501b00069d83370d16da0007062ac4634403000787492ee03c490007b8194b955b970008672ecbe2454e000881f91cb06af30008a20e2daf750d0008a618331e0baa0008fbb8f33ee9d600093b33cbd771cf000981d1120ea1a2000989a03fbea75e
+- sketch endings: 00013f24e9c02312000e99746e60cb0c0021ad1c1ec69307006ef56eb12e99de0079e3b242d77715009072d9a0fdb056009a7b66951c5917009c15ec9396ebe7009f2d1508ebb20700c54a81d77e708d00c85aaad3ac2ef900e6571a83b53ecb00f216ca5435be4a00f6ff637612aa210104a330f10582350109de0acab502c20113f5c1bdd185dd01209e6672fa09ae0122426a4c250c7901257c80cacd49bb0140a72543eec36d014e5a7b64d98c35017b5fae025c739d017b69b311ad8d88017e3e9d07ed17e00186a019561fbcde0190916401b2b4ca019605d7d622c68601b2b53ee592a84b01b309ae5eed3d5801b396974159901701cbfe144208d0a3
+- fingerprint: f2c75c55adc08c35
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/Tnt540_BLKOPS04_20260831-191005/image_20260831-191005.txt
+++ b/submissions/Tnt540_BLKOPS04_20260831-191005/image_20260831-191005.txt
@@ -1,0 +1,4 @@
+13a21c8002f33466,hud_mp_notification_war_bronze
+1acbdc051d85f4a8,hud_mp_notification_war_gold
+564025c11036a6ef,hud_mp_notification_war_silver
+6f5612b213bf366c,hud_mp_notification_war_iron

--- a/submissions/Tnt540_BLKOPS04_20260831-191005/sound_alias_20260831-191005.txt
+++ b/submissions/Tnt540_BLKOPS04_20260831-191005/sound_alias_20260831-191005.txt
@@ -1,0 +1,5 @@
+205cc527b5726b4d,zmb_challenges_tribute_ignite_lp
+5390d89dc611da6c,zmb_challenges_brazier_ignite_complete
+5a4997dc84f6d680,zmb_planet_fall_lp
+60759f1c75049cd4,zmb_avogadro_radial_attack_start
+7007602a9c1e2b84,zmb_planet_fall_impact_splash


### PR DESCRIPTION
**BLKOPS04** — 9 asset names, confirmed against that game's own loaded assets.

- sound_alias: 5
- image: 4

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Tnt540

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260831-190201_plan
- method: uncarried beginnings
- what it does: the 209 leading segments no cut of which `data/prefixes.txt` carries, against cores from the published names that use them and from everything this machine has confirmed
- ran for: 6m 59s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- beginnings: 209
- endings: 4629
- stems: 232565
- ids hunted: 151329
- candidates tested: 225046173550
- new: 9
- sketch beginnings: 0084b979595f86df00ac8133506d429c01f06f475d5e01cd022e34e844929260023406f88536a8de06b447482b9b5c4c077e5a5892a3a5550a8a3ee3821a9c200c6e148aebdba61010305f4ce6a3acb710ae443e5c2e4f6910ba4644e2f2362210e46cfccf95307513a71ef39f0565921468bd47616673c616f376f22c888dd617afaf989a8f88dd1b422267e8c11d6a1e6081a8b7d556401ea834b7fb05f7bb1f40f1f82eb3403420bb4254738dbfd521226e9452a89e1b213e56e5c91f648922bd22fb1e9545d022e531950cd2622d25c4f76680830c91271d6215fefd4657272dc5fde967f77f277359869d28d63c285a54c5d573e3892aa7475e81592478
- sketch stems: 000063a33732586900006dcf4221638900009d6043da5beb000237540b6e3f930002911d10cffd910002d170e3084a65000310ff73e68ee600035a6d588aa75600035ede9efa5e900003f6860e09096b00041a795924b8050004580ec440bc3700045dbd500476f70004b220cea1973b0004ba2cf231767300053721e203b70500055b459ce7f696000572dad17c593a0005bfae70539563000691ed8bf2501b00069d83370d16da0007062ac4634403000787492ee03c490007b8194b955b970008672ecbe2454e000881f91cb06af30008a20e2daf750d0008a618331e0baa0008fbb8f33ee9d600093b33cbd771cf000981d1120ea1a2000989a03fbea75e
- sketch endings: 00013f24e9c02312000e99746e60cb0c0021ad1c1ec69307006ef56eb12e99de0079e3b242d77715009072d9a0fdb056009a7b66951c5917009c15ec9396ebe7009f2d1508ebb20700c54a81d77e708d00c85aaad3ac2ef900e6571a83b53ecb00f216ca5435be4a00f6ff637612aa210104a330f10582350109de0acab502c20113f5c1bdd185dd01209e6672fa09ae0122426a4c250c7901257c80cacd49bb0140a72543eec36d014e5a7b64d98c35017b5fae025c739d017b69b311ad8d88017e3e9d07ed17e00186a019561fbcde0190916401b2b4ca019605d7d622c68601b2b53ee592a84b01b309ae5eed3d5801b396974159901701cbfe144208d0a3
- fingerprint: f2c75c55adc08c35

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.
