### PR TITLE
[BLKOPSCW] findings from Zakkary19, 20260901-013349 (2 names)

### DIFF
--- a/submissions/Zakkary19_BLKOPSCW_20260901-013349/about_20260901-013349.md
+++ b/submissions/Zakkary19_BLKOPSCW_20260901-013349/about_20260901-013349.md
@@ -1,0 +1,55 @@
+# Submission 20260901-013349
+
+- game: **BLKOPSCW**
+- from: Zakkary19
+- names: 2
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 5
+- runs included: 2
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- image: 2
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 60 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260901-012312_plan
+- method: all-boundary sound cores x uncarried sound endings
+- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
+- ran for: 7m 48s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- beginnings: 0
+- endings: 60000
+- stems: 2042235
+- ids hunted: 112332
+- candidates tested: 122536142235
+- new: 6
+- sketch beginnings: 
+- sketch stems: 000001ad4b3a16660000055355fb707b0000116c72a86c8800001a7948e2da7b0000261d00af5a5700002b1519e1ded400002ee0bf50cc9600003cd0bb5e04e900003e662bfcc8e100003f686b513e9300004539e386abfe000047045784f62e000048bb4c35d1c700004ec0ee5f3551000059b99780a20500006296216d57d100006d11a6a6ae7600008ed79cb32e090000965d9177932d000098934c7c630600009da2806c90300000aa984ebb57620000aec8c22d128f0000b327d9e196d40000c2b8a94bc4b40000c43959f1d3170000c6e299e473210000d0b5476b5d4b0000d5f19e8574340000d7354da7c98b0000d97fef7000c50000ef4a2113a6a7
+- sketch endings: 00000e56e68ff2ad000013d434b4724f000014e89d24eb3500004eb4142e348d00027e48b87969d800029060f893dbf40002aaaa48e6effc0002b61bdcaac24d0003477c27e27f880003bf92fab8232e000577b6fd5507c50007ffd3755fdb08000b62aa1032da53000c30d0c85c778f000e404bcace059e000e6b3edc6a009e000e99746e60cb0c00109399f33296ac0010c554ec023cce00123d8bc476597b0015499b4ffc16260015b64fa28285170015bdb968ec426a0015db035e3f69710016a41b0a1bc857001a1a50ea361e72001bf211155214cd001c6c657bb374e3001d53ce06e42bf4001e15386defee24001f2ab779e4fe26001f2bc862c9e8d9
+- fingerprint: 772c1a4abd727d87
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.
+
+### run_20260901-013109_list
+- method: image channel completion
+- what it does: a candidate list generated outside the search and confirmed here
+- ran for: 5s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- candidates tested: 2565441
+- matched: 9
+- new: 1
+- sketch stems: 0000102ecfb034d9000013b6a770442600001f5059d15ed3000021d60eb05f1c000030905a70ba1d000033f4eab885460000390928de220c00003add22b66a6600003b9f496e1f310000411ce82002be0000456f94434834000052eddb08e5db0000598d8b071f4b00005cb01562dc1300005d0ed36c5a0300006086707e6ebf0000629afd919599000064c4056c6a8f000067df0de6d53e000072645533decb000082fc0f538339000096e8c6f1189300009af668f959470000a50ef8438ecf0000a522c73772950000ab17d8ced7790000ac84041e550c0000ad7fa18f50200000b30a86ccc3480000b83334faa2bb0000c0b765c8bdfa0000c63116955f85
+- ids hunted: 112332
+- throughput: 0.9M candidates/s
+- fingerprint: 9da4d110c5f43200
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/Zakkary19_BLKOPSCW_20260901-013349/image_20260901-013349.txt
+++ b/submissions/Zakkary19_BLKOPSCW_20260901-013349/image_20260901-013349.txt
@@ -1,0 +1,2 @@
+7d1860292ee0283,i_mtl_veh_t8_civ_van_sprinter_console_dead_multi_m
+485b0a5d9d9e7a30,i_mtl_veh_t8_civ_van_sprinter_face_decal_hole_r


### PR DESCRIPTION
**BLKOPSCW** — 2 asset names, confirmed against that game's own loaded assets.

- image: 2

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 5
- submitted by: @Zakkary19

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260901-012312_plan
- method: all-boundary sound cores x uncarried sound endings
- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
- ran for: 7m 48s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- beginnings: 0
- endings: 60000
- stems: 2042235
- ids hunted: 112332
- candidates tested: 122536142235
- new: 6
- sketch beginnings: 
- sketch stems: 000001ad4b3a16660000055355fb707b0000116c72a86c8800001a7948e2da7b0000261d00af5a5700002b1519e1ded400002ee0bf50cc9600003cd0bb5e04e900003e662bfcc8e100003f686b513e9300004539e386abfe000047045784f62e000048bb4c35d1c700004ec0ee5f3551000059b99780a20500006296216d57d100006d11a6a6ae7600008ed79cb32e090000965d9177932d000098934c7c630600009da2806c90300000aa984ebb57620000aec8c22d128f0000b327d9e196d40000c2b8a94bc4b40000c43959f1d3170000c6e299e473210000d0b5476b5d4b0000d5f19e8574340000d7354da7c98b0000d97fef7000c50000ef4a2113a6a7
- sketch endings: 00000e56e68ff2ad000013d434b4724f000014e89d24eb3500004eb4142e348d00027e48b87969d800029060f893dbf40002aaaa48e6effc0002b61bdcaac24d0003477c27e27f880003bf92fab8232e000577b6fd5507c50007ffd3755fdb08000b62aa1032da53000c30d0c85c778f000e404bcace059e000e6b3edc6a009e000e99746e60cb0c00109399f33296ac0010c554ec023cce00123d8bc476597b0015499b4ffc16260015b64fa28285170015bdb968ec426a0015db035e3f69710016a41b0a1bc857001a1a50ea361e72001bf211155214cd001c6c657bb374e3001d53ce06e42bf4001e15386defee24001f2ab779e4fe26001f2bc862c9e8d9
- fingerprint: 772c1a4abd727d87

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

### run_20260901-013109_list
- method: image channel completion
- what it does: a candidate list generated outside the search and confirmed here
- ran for: 5s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- candidates tested: 2565441
- matched: 9
- new: 1
- sketch stems: 0000102ecfb034d9000013b6a770442600001f5059d15ed3000021d60eb05f1c000030905a70ba1d000033f4eab885460000390928de220c00003add22b66a6600003b9f496e1f310000411ce82002be0000456f94434834000052eddb08e5db0000598d8b071f4b00005cb01562dc1300005d0ed36c5a0300006086707e6ebf0000629afd919599000064c4056c6a8f000067df0de6d53e000072645533decb000082fc0f538339000096e8c6f1189300009af668f959470000a50ef8438ecf0000a522c73772950000ab17d8ced7790000ac84041e550c0000ad7fa18f50200000b30a86ccc3480000b83334faa2bb0000c0b765c8bdfa0000c63116955f85
- ids hunted: 112332
- throughput: 0.9M candidates/s
- fingerprint: 9da4d110c5f43200

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/image_channels.py`
- `scripts/contributed/bo4snd_cores_20260901-010534.txt`
- `scripts/contributed/bo4snd_ends_20260901-010534.txt`
- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/numbered_grids_20260821-054219.py`
- `scripts/contributed/overnight_suite_20260901-010534.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.