### PR TITLE
[BLKOPS04] findings from Tnt540, 20260902-060300 (7 names)

### DIFF
--- a/submissions/Tnt540_BLKOPS04_20260902-060300/about_20260902-060300.md
+++ b/submissions/Tnt540_BLKOPS04_20260902-060300/about_20260902-060300.md
@@ -1,0 +1,39 @@
+# Submission 20260902-060300
+
+- game: **BLKOPS04**
+- from: Tnt540
+- names: 7
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- material: 5
+- image: 2
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 100 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260902-055522_plan
+- method: confirmed-only all-boundary sound cores x uncarried 5-segment sound endings, BLKOPS04
+- what it does: confirmed-only (both games) all-boundary sound cores x the 300,000 commonest 5-segment sound endings data/sound.suffixes.txt cannot express
+- ran for: 6m 06s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- beginnings: 0
+- endings: 300000
+- stems: 148139
+- ids hunted: 150260
+- candidates tested: 44441848139
+- new: 7
+- sketch beginnings: 
+- sketch stems: 00002ee0bf50cc960000ef4a2113a6a7000196f66cc5bd0a0001aef44909c8860001c4288d1f83f80001d42da712184b00033cf2e70d986600033f547a90eb950003df052c8c65a400041bbbb5029bd70004411f5ae467110004f9caa2916c42000624bd7bcc757200063685031d44230006518ce0f1ed4d00068f4e032473900006b5e60602d68c0007d55dbb0777ea00088364222cf1cd0009595233ae099b0009fc4ea542379a000a6d6d22ada5ec000b32b8830e99c2000c7c620254ad84000c9eb9db01a880000caad68ac532c4000d02e08a26b568000d2a274f32763e000d4e4e5c704308000d61c9459c520c000d843abd748604000d9cf054b1db20
+- sketch endings: 00001dcb652f4a1300003db45136c7b500004ca0c832267700009dfedd6101880000a380317afda40000af8168aabcaa0000f4aca1cb8a0e00016ba40e85f83b0001f0701c199f290002084ed63f14c3000249a6e222f30500024bf7509b0d110002757178b266ca00029a92e8d933b80002c73c8431647b000468630b9f8be4000479d15d65cd390004b9d81d88e9230004c4eab80930220004ca174a05ce1200051d84510d3e23000537248e8b0e7e0005a7a2893c9e590006428996a5f54100066d63918a021900070c2a5985292600072404ba0633b400072a35d0d84eb50007742af3ac7cab0007d33fcc28ee480007e85491dd1de80007ea4ea2983990
+- fingerprint: 22691bffe056540d
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/Tnt540_BLKOPS04_20260902-060300/image_20260902-060300.txt
+++ b/submissions/Tnt540_BLKOPS04_20260902-060300/image_20260902-060300.txt
@@ -1,0 +1,2 @@
+174560b08b9c34ae,i_c_t8_mp_spe_buffer_body1_sleeves_snake_com_yellow_cst_c
+3e555773179aceb6,i_c_t8_mp_spe_buffer_body1_boots_snake_com_yellow_cst_c

--- a/submissions/Tnt540_BLKOPS04_20260902-060300/material_20260902-060300.txt
+++ b/submissions/Tnt540_BLKOPS04_20260902-060300/material_20260902-060300.txt
@@ -1,0 +1,5 @@
+21cfd4f4b4489e06,mc/p8_mtl_zm_off_narrative_cipher_04
+21cfd5f4b4489fb9,mc/p8_mtl_zm_off_narrative_cipher_05
+21cfd6f4b448a16c,mc/p8_mtl_zm_off_narrative_cipher_02
+21cfd7f4b448a31f,mc/p8_mtl_zm_off_narrative_cipher_03
+21cfd9f4b448a685,mc/p8_mtl_zm_off_narrative_cipher_01


### PR DESCRIPTION
**BLKOPS04** — 7 asset names, confirmed against that game's own loaded assets.

- material: 5
- image: 2

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Tnt540

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260902-055522_plan
- method: confirmed-only all-boundary sound cores x uncarried 5-segment sound endings, BLKOPS04
- what it does: confirmed-only (both games) all-boundary sound cores x the 300,000 commonest 5-segment sound endings data/sound.suffixes.txt cannot express
- ran for: 6m 06s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- beginnings: 0
- endings: 300000
- stems: 148139
- ids hunted: 150260
- candidates tested: 44441848139
- new: 7
- sketch beginnings: 
- sketch stems: 00002ee0bf50cc960000ef4a2113a6a7000196f66cc5bd0a0001aef44909c8860001c4288d1f83f80001d42da712184b00033cf2e70d986600033f547a90eb950003df052c8c65a400041bbbb5029bd70004411f5ae467110004f9caa2916c42000624bd7bcc757200063685031d44230006518ce0f1ed4d00068f4e032473900006b5e60602d68c0007d55dbb0777ea00088364222cf1cd0009595233ae099b0009fc4ea542379a000a6d6d22ada5ec000b32b8830e99c2000c7c620254ad84000c9eb9db01a880000caad68ac532c4000d02e08a26b568000d2a274f32763e000d4e4e5c704308000d61c9459c520c000d843abd748604000d9cf054b1db20
- sketch endings: 00001dcb652f4a1300003db45136c7b500004ca0c832267700009dfedd6101880000a380317afda40000af8168aabcaa0000f4aca1cb8a0e00016ba40e85f83b0001f0701c199f290002084ed63f14c3000249a6e222f30500024bf7509b0d110002757178b266ca00029a92e8d933b80002c73c8431647b000468630b9f8be4000479d15d65cd390004b9d81d88e9230004c4eab80930220004ca174a05ce1200051d84510d3e23000537248e8b0e7e0005a7a2893c9e590006428996a5f54100066d63918a021900070c2a5985292600072404ba0633b400072a35d0d84eb50007742af3ac7cab0007d33fcc28ee480007e85491dd1de80007ea4ea2983990
- fingerprint: 22691bffe056540d

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/uncarried_begins_20260823-023757.txt`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.