### PR TITLE
[BLKOPS04] findings from Tnt540, 20260902-060523 (4 names)

### DIFF
--- a/submissions/Tnt540_BLKOPS04_20260902-060523/about_20260902-060523.md
+++ b/submissions/Tnt540_BLKOPS04_20260902-060523/about_20260902-060523.md
@@ -1,0 +1,39 @@
+# Submission 20260902-060523
+
+- game: **BLKOPS04**
+- from: Tnt540
+- names: 4
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- material: 3
+- xmodel: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 100 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260902-060330_plan
+- method: confirmed-only all-boundary sound cores x uncarried 1-segment sound endings, BLKOPS04
+- what it does: confirmed-only (both games) all-boundary sound cores x the commonest 1-segment sound endings data/sound.suffixes.txt cannot express
+- ran for: 21s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- beginnings: 0
+- endings: 29030
+- stems: 148151
+- ids hunted: 150260
+- candidates tested: 4300971681
+- new: 4
+- sketch beginnings: 
+- sketch stems: 00002ee0bf50cc960000ef4a2113a6a7000196f66cc5bd0a0001aef44909c8860001c4288d1f83f80001d42da712184b00033cf2e70d986600033f547a90eb950003df052c8c65a400041bbbb5029bd70004411f5ae467110004f9caa2916c42000624bd7bcc757200063685031d44230006518ce0f1ed4d00068f4e032473900006b5e60602d68c0007d55dbb0777ea00088364222cf1cd0009595233ae099b0009fc4ea542379a000a6d6d22ada5ec000b32b8830e99c2000c7c620254ad84000c9eb9db01a880000caad68ac532c4000d02e08a26b568000d2a274f32763e000d4e4e5c704308000d61c9459c520c000d843abd748604000d9cf054b1db20
+- sketch endings: 0004e83a03144b810007a544f9072879000a2ca527ed58380012ed645c322543001494c09150134100173525c400009e001a6caa73694b19001f772d70565e6b002248b820015177002272a0545b733c002509325fdbb6ab0025413a86e41ba80025afd40afb061400273cc10c9e1af500283dd27c81a359002ac5dc8e45c419002bc3511321326e00303aac00c209b00030bee52f5c9007003175ebb597b6660031a893c7d06dcb0032ff0ae639bb010034eb49902ccad10036551192a3d812003f790b10c162d2003ff36eebaf97e400400a4462ea460300404bcc6f59dc5c004162181e1bfe2b0041c5ade22f69500044cd9b8c115c7f00450baa68a34cdc
+- fingerprint: 69016b28519446e5
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/Tnt540_BLKOPS04_20260902-060523/material_20260902-060523.txt
+++ b/submissions/Tnt540_BLKOPS04_20260902-060523/material_20260902-060523.txt
@@ -1,0 +1,3 @@
+edc1d33af9b7120,mc/mtl_p8_zm_man_bedroom_fireplace_detail06
+edc2033af9b7639,mc/mtl_p8_zm_man_bedroom_fireplace_detail05
+edc2133af9b77ec,mc/mtl_p8_zm_man_bedroom_fireplace_detail02

--- a/submissions/Tnt540_BLKOPS04_20260902-060523/xmodel_20260902-060523.txt
+++ b/submissions/Tnt540_BLKOPS04_20260902-060523/xmodel_20260902-060523.txt
@@ -1,0 +1,1 @@
+2c0078538e398b4f,p8_zm_zod_artifact_combined_fire_all


### PR DESCRIPTION
**BLKOPS04** — 4 asset names, confirmed against that game's own loaded assets.

- material: 3
- xmodel: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Tnt540

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260902-060330_plan
- method: confirmed-only all-boundary sound cores x uncarried 1-segment sound endings, BLKOPS04
- what it does: confirmed-only (both games) all-boundary sound cores x the commonest 1-segment sound endings data/sound.suffixes.txt cannot express
- ran for: 21s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- beginnings: 0
- endings: 29030
- stems: 148151
- ids hunted: 150260
- candidates tested: 4300971681
- new: 4
- sketch beginnings: 
- sketch stems: 00002ee0bf50cc960000ef4a2113a6a7000196f66cc5bd0a0001aef44909c8860001c4288d1f83f80001d42da712184b00033cf2e70d986600033f547a90eb950003df052c8c65a400041bbbb5029bd70004411f5ae467110004f9caa2916c42000624bd7bcc757200063685031d44230006518ce0f1ed4d00068f4e032473900006b5e60602d68c0007d55dbb0777ea00088364222cf1cd0009595233ae099b0009fc4ea542379a000a6d6d22ada5ec000b32b8830e99c2000c7c620254ad84000c9eb9db01a880000caad68ac532c4000d02e08a26b568000d2a274f32763e000d4e4e5c704308000d61c9459c520c000d843abd748604000d9cf054b1db20
- sketch endings: 0004e83a03144b810007a544f9072879000a2ca527ed58380012ed645c322543001494c09150134100173525c400009e001a6caa73694b19001f772d70565e6b002248b820015177002272a0545b733c002509325fdbb6ab0025413a86e41ba80025afd40afb061400273cc10c9e1af500283dd27c81a359002ac5dc8e45c419002bc3511321326e00303aac00c209b00030bee52f5c9007003175ebb597b6660031a893c7d06dcb0032ff0ae639bb010034eb49902ccad10036551192a3d812003f790b10c162d2003ff36eebaf97e400400a4462ea460300404bcc6f59dc5c004162181e1bfe2b0041c5ade22f69500044cd9b8c115c7f00450baa68a34cdc
- fingerprint: 69016b28519446e5

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/uncarried_begins_20260823-023757.txt`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.