### PR TITLE
[BLKOPS04] findings from Tnt540, 20260902-062338 (4 names)

### DIFF
--- a/submissions/Tnt540_BLKOPS04_20260902-062338/about_20260902-062338.md
+++ b/submissions/Tnt540_BLKOPS04_20260902-062338/about_20260902-062338.md
@@ -1,0 +1,39 @@
+# Submission 20260902-062338
+
+- game: **BLKOPS04**
+- from: Tnt540
+- names: 4
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- image: 2
+- material: 2
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 100 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260902-062011_plan
+- method: BLKOPS04-scoped all-boundary cores (published+confirmed) x uncarried 1-segment endings
+- what it does: all_names/blkops04 published cores plus confirmed names x the commonest 1-segment endings data/suffixes.txt cannot express
+- ran for: 1m 55s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- beginnings: 0
+- endings: 180148
+- stems: 168331
+- ids hunted: 150260
+- candidates tested: 30324661319
+- new: 4
+- sketch beginnings: 
+- sketch stems: 00002b1519e1ded400002ee0bf50cc960000ef4a2113a6a7000196f66cc5bd0a0001aef44909c8860001c4288d1f83f80001d42da712184b00033cf2e70d986600033f547a90eb950003b69caf19a9720003df052c8c65a400041bbbb5029bd70004411f5ae467110004a5cf1343b3860004f9caa2916c42000624bd7bcc757200063685031d44230006518ce0f1ed4d00068f4e032473900006b5e60602d68c0007d55dbb0777ea0009fc4ea542379a000a6d6d22ada5ec000b32b8830e99c2000c7c620254ad84000c9eb9db01a880000caad68ac532c4000d02e08a26b568000d2a274f32763e000d4e4e5c704308000d843abd748604000d9cf054b1db20
+- sketch endings: 0000529b80a633f20000653fb01d71df00009f9cc2c74c800000c758cb1bbbed0001114048013a85000174872b31752b0002100a835abd8f00030cb6303ee1e80003fde7d0ecb68d00041432dcd8d12c00041521e7ba1afd000530342c02de4c000537a26427bb76000549dfe34f77e000058cb7b8c069a400058e9966e8101500069fed89eb0bed00070f3e249ec3bc00075e31a25ea54d00087ec47ccb9e640008935e985c4a7800092439ad056efa0009d0d49232d16c000a2ca527ed5838000a7fffa0a20349000af8f086fd4adc000b2cdb3ba9c339000b58dadd3e7cc0000b5e4acc8c2519000b7d5ee4e019ac000c0ad73ce194bc000c1017f7a1dc1f
+- fingerprint: 3aea4228e079e1d3
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/Tnt540_BLKOPS04_20260902-062338/image_20260902-062338.txt
+++ b/submissions/Tnt540_BLKOPS04_20260902-062338/image_20260902-062338.txt
@@ -1,0 +1,2 @@
+bf81085f8ce51b5,i_mtl_preview_verticalsync
+53743e0d9262852a,ui_icon_crm_motd_hd_cwl_nologo

--- a/submissions/Tnt540_BLKOPS04_20260902-062338/material_20260902-062338.txt
+++ b/submissions/Tnt540_BLKOPS04_20260902-062338/material_20260902-062338.txt
@@ -1,0 +1,2 @@
+edc1f33af9b7486,mc/mtl_p8_zm_man_bedroom_fireplace_detail04
+edc2233af9b799f,mc/mtl_p8_zm_man_bedroom_fireplace_detail03


### PR DESCRIPTION
**BLKOPS04** — 4 asset names, confirmed against that game's own loaded assets.

- image: 2
- material: 2

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Tnt540

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260902-062011_plan
- method: BLKOPS04-scoped all-boundary cores (published+confirmed) x uncarried 1-segment endings
- what it does: all_names/blkops04 published cores plus confirmed names x the commonest 1-segment endings data/suffixes.txt cannot express
- ran for: 1m 55s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- beginnings: 0
- endings: 180148
- stems: 168331
- ids hunted: 150260
- candidates tested: 30324661319
- new: 4
- sketch beginnings: 
- sketch stems: 00002b1519e1ded400002ee0bf50cc960000ef4a2113a6a7000196f66cc5bd0a0001aef44909c8860001c4288d1f83f80001d42da712184b00033cf2e70d986600033f547a90eb950003b69caf19a9720003df052c8c65a400041bbbb5029bd70004411f5ae467110004a5cf1343b3860004f9caa2916c42000624bd7bcc757200063685031d44230006518ce0f1ed4d00068f4e032473900006b5e60602d68c0007d55dbb0777ea0009fc4ea542379a000a6d6d22ada5ec000b32b8830e99c2000c7c620254ad84000c9eb9db01a880000caad68ac532c4000d02e08a26b568000d2a274f32763e000d4e4e5c704308000d843abd748604000d9cf054b1db20
- sketch endings: 0000529b80a633f20000653fb01d71df00009f9cc2c74c800000c758cb1bbbed0001114048013a85000174872b31752b0002100a835abd8f00030cb6303ee1e80003fde7d0ecb68d00041432dcd8d12c00041521e7ba1afd000530342c02de4c000537a26427bb76000549dfe34f77e000058cb7b8c069a400058e9966e8101500069fed89eb0bed00070f3e249ec3bc00075e31a25ea54d00087ec47ccb9e640008935e985c4a7800092439ad056efa0009d0d49232d16c000a2ca527ed5838000a7fffa0a20349000af8f086fd4adc000b2cdb3ba9c339000b58dadd3e7cc0000b5e4acc8c2519000b7d5ee4e019ac000c0ad73ce194bc000c1017f7a1dc1f
- fingerprint: 3aea4228e079e1d3

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/uncarried_begins_20260823-023757.txt`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.