### PR TITLE
[BLKOPS04] findings from Tnt540, 20260902-093210 (3 names)

### DIFF
--- a/submissions/Tnt540_BLKOPS04_20260902-093210/about_20260902-093210.md
+++ b/submissions/Tnt540_BLKOPS04_20260902-093210/about_20260902-093210.md
@@ -1,0 +1,38 @@
+# Submission 20260902-093210
+
+- game: **BLKOPS04**
+- from: Tnt540
+- names: 3
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- material: 3
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 100 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260902-092755_plan
+- method: BLKOPS04-scoped all-boundary cores (published+confirmed) x uncarried 3-segment endings, top 300000
+- what it does: all_names/blkops04 published cores plus confirmed names x the 300,000 commonest 3-segment endings data/suffixes.txt cannot express
+- ran for: 2m 43s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- beginnings: 0
+- endings: 300000
+- stems: 168751
+- ids hunted: 150248
+- candidates tested: 50625468751
+- new: 3
+- sketch beginnings: 
+- sketch stems: 00002b1519e1ded400002ee0bf50cc960000ef4a2113a6a7000196f66cc5bd0a0001aef44909c8860001c4288d1f83f80001d42da712184b00033cf2e70d986600033f547a90eb950003b69caf19a9720003df052c8c65a400041bbbb5029bd70004411f5ae467110004a5cf1343b3860004f9caa2916c42000624bd7bcc757200063685031d44230006518ce0f1ed4d00068f4e032473900006b5e60602d68c0007d55dbb0777ea0009fc4ea542379a000a6d6d22ada5ec000b32b8830e99c2000c7c620254ad84000c9eb9db01a880000caad68ac532c4000d02e08a26b568000d2a274f32763e000d4e4e5c704308000d843abd748604000d9cf054b1db20
+- sketch endings: 000013d434b4724f000065b3318082ca00006877dd21ae220000b498aeee251c0000b53a60e804620000db140e937ae40000e8e367dc36f300010286148b3ff50001520aecf3e64e0001a5f651ab5ff60001b8f4934616560001e9049dbcf46f00023a9f2674c4f00002433227c03c1e00024d3a6e58a1ca000252e1d7ad5fb10002582f51cdb7ee00025a3472daa8da00025c7284e1dcc500029060f893dbf40002a11084202a1a0002aaaa48e6effc0002b01a9a788b18000317e9619eb83c000371851baa5c15000377e89a7736e00003936247ef78430003afe23ce0560d0003bf92fab8232e0003f18f3a976213000403a6158d4bfd00040f702af23dc1
+- fingerprint: aac4edb32f933d92
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/Tnt540_BLKOPS04_20260902-093210/material_20260902-093210.txt
+++ b/submissions/Tnt540_BLKOPS04_20260902-093210/material_20260902-093210.txt
@@ -1,0 +1,3 @@
+4b1e5040b4dacb2,mc/mtl_veh_t8_mil_heli_light_body_front_pnt_body_drk_blk
+164c31643557fdd7,mc/mtl_veh_t8_decal_bolt_01_normal_ao
+72092c680e7ba098,mc/mtl_c_t8_mp_spe_buffer_body1_pants2_snake_com_aqua_cst


### PR DESCRIPTION
**BLKOPS04** — 3 asset names, confirmed against that game's own loaded assets.

- material: 3

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Tnt540

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260902-092755_plan
- method: BLKOPS04-scoped all-boundary cores (published+confirmed) x uncarried 3-segment endings, top 300000
- what it does: all_names/blkops04 published cores plus confirmed names x the 300,000 commonest 3-segment endings data/suffixes.txt cannot express
- ran for: 2m 43s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- beginnings: 0
- endings: 300000
- stems: 168751
- ids hunted: 150248
- candidates tested: 50625468751
- new: 3
- sketch beginnings: 
- sketch stems: 00002b1519e1ded400002ee0bf50cc960000ef4a2113a6a7000196f66cc5bd0a0001aef44909c8860001c4288d1f83f80001d42da712184b00033cf2e70d986600033f547a90eb950003b69caf19a9720003df052c8c65a400041bbbb5029bd70004411f5ae467110004a5cf1343b3860004f9caa2916c42000624bd7bcc757200063685031d44230006518ce0f1ed4d00068f4e032473900006b5e60602d68c0007d55dbb0777ea0009fc4ea542379a000a6d6d22ada5ec000b32b8830e99c2000c7c620254ad84000c9eb9db01a880000caad68ac532c4000d02e08a26b568000d2a274f32763e000d4e4e5c704308000d843abd748604000d9cf054b1db20
- sketch endings: 000013d434b4724f000065b3318082ca00006877dd21ae220000b498aeee251c0000b53a60e804620000db140e937ae40000e8e367dc36f300010286148b3ff50001520aecf3e64e0001a5f651ab5ff60001b8f4934616560001e9049dbcf46f00023a9f2674c4f00002433227c03c1e00024d3a6e58a1ca000252e1d7ad5fb10002582f51cdb7ee00025a3472daa8da00025c7284e1dcc500029060f893dbf40002a11084202a1a0002aaaa48e6effc0002b01a9a788b18000317e9619eb83c000371851baa5c15000377e89a7736e00003936247ef78430003afe23ce0560d0003bf92fab8232e0003f18f3a976213000403a6158d4bfd00040f702af23dc1
- fingerprint: aac4edb32f933d92

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/uncarried_begins_20260823-023757.txt`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.