### PR TITLE
[BLKOPS04] findings from Tnt540, 20260902-104252 (1 names)

### DIFF
--- a/submissions/Tnt540_BLKOPS04_20260902-104252/about_20260902-104252.md
+++ b/submissions/Tnt540_BLKOPS04_20260902-104252/about_20260902-104252.md
@@ -1,0 +1,35 @@
+# Submission 20260902-104252
+
+- game: **BLKOPS04**
+- from: Tnt540
+- names: 1
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- image: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 100 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260902-103925_list
+- method: image siblings of confirmed materials
+- what it does: a candidate list generated outside the search and confirmed here
+- ran for: 5s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- candidates tested: 2303529
+- matched: 13
+- new: 1
+- sketch stems: 000006bc59d8576d000013e9d17db956000016cbd3943da90000323b45a663a9000033b79e0eedd500003be26e53e51800003cc8026e4712000041efc7f1be4a00004854e9ea014100004c0e8c5515bd000052f1f2e348900000531313c9493100005d348940d586000063a337325869000064ed3f5f23b300006945e25546130000765607c932be000076ca20d6f67c00007efa48f13937000082e4cc85109d00008a1a18991fbf000096e85d9155db0000974c8aeee78a00009d6043da5beb0000a6a51d22c1450000a6cb3612cfd60000a929655c7ee60000afe7af4409e30000bfb517cb1b210000ca6f3ab4d99e0000ceda8a5148c30000d040f6409543
+- ids hunted: 150080
+- throughput: 0.8M candidates/s
+- fingerprint: c8c1092e9bdd2337
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/Tnt540_BLKOPS04_20260902-104252/image_20260902-104252.txt
+++ b/submissions/Tnt540_BLKOPS04_20260902-104252/image_20260902-104252.txt
@@ -1,0 +1,1 @@
+5ce2024fba2427b8,i_c_t8_mp_spe_buffer_body1_front_pouch_snake_com_yellow_cst_c


### PR DESCRIPTION
**BLKOPS04** — 1 asset names, confirmed against that game's own loaded assets.

- image: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Tnt540

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260902-103925_list
- method: image siblings of confirmed materials
- what it does: a candidate list generated outside the search and confirmed here
- ran for: 5s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- candidates tested: 2303529
- matched: 13
- new: 1
- sketch stems: 000006bc59d8576d000013e9d17db956000016cbd3943da90000323b45a663a9000033b79e0eedd500003be26e53e51800003cc8026e4712000041efc7f1be4a00004854e9ea014100004c0e8c5515bd000052f1f2e348900000531313c9493100005d348940d586000063a337325869000064ed3f5f23b300006945e25546130000765607c932be000076ca20d6f67c00007efa48f13937000082e4cc85109d00008a1a18991fbf000096e85d9155db0000974c8aeee78a00009d6043da5beb0000a6a51d22c1450000a6cb3612cfd60000a929655c7ee60000afe7af4409e30000bfb517cb1b210000ca6f3ab4d99e0000ceda8a5148c30000d040f6409543
- ids hunted: 150080
- throughput: 0.8M candidates/s
- fingerprint: c8c1092e9bdd2337

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/uncarried_begins_20260823-023757.txt`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.