### PR TITLE
[BLKOPSCW] findings from Zakkary19, 20260902-110124 (2 names)

### DIFF
--- a/submissions/Zakkary19_BLKOPSCW_20260902-110124/about_20260902-110124.md
+++ b/submissions/Zakkary19_BLKOPSCW_20260902-110124/about_20260902-110124.md
@@ -1,0 +1,38 @@
+# Submission 20260902-110124
+
+- game: **BLKOPSCW**
+- from: Zakkary19
+- names: 2
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- material: 2
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 100 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260902-105952_plan
+- method: all-boundary cores x uncarried endings, 4 segment(s), top 100000
+- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
+- ran for: 16s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- beginnings: 0
+- endings: 100000
+- stems: 37406
+- ids hunted: 111086
+- candidates tested: 3740637406
+- new: 2
+- sketch beginnings: 
+- sketch stems: 00002b1519e1ded40001c4288d1f83f80003b69caf19a9720004a5cf1343b38600063685031d4423000f1597bb35c60d00108dc43f3f7d7100110f76cb990dc1001416b90333d31100145d41c6155d7d001501337ddd67d100152fa9c4c4534c00182aeae1fa77ef001a7e7a6d4976d3001ca7f05f38a262001da2dcd16eff55001e2c9de2cd1f4100208856d44379ec00210f78b01caf8a002373e6758040af00237f2be3916d920023ddcd130b37900024c8f466d89d420026007fd114d562002b0e53920affb1002d8c57bb566ead002ee3cf10634b04002ef5baab179fae002f2af27b7e511e002ff87367bbe25e00342faec94b823400344514e6a22c29
+- sketch endings: 00009d1c61c251e300009f0c4c8348050001b4dd72acd1050001c12df56c976600045c1367de2d76000494e09392a8ba0005fc359dfe48d80007d020b1aadee00007ebdee4342b29000869271a4714cb000872a76958d2e10009a3e71b0a91f1000a26aa4929c79c000a386057bf50ef000a40e5b489b763000a46404dbbc13f000aefccaf60d6b3000bbfb1098be4ab000e936d1430bb76000f3c2661166956000fa6d905fe55070010d236676abe5b0010edf816682b0100111bd139da50ff0011a3cd783860190011fb447bd20ff300126f0d1c4b4fd20012f03820724db60013177929c37c7600138edae33d989f001610c70a9e83930016235cd8606636
+- fingerprint: 16233389dc3bb3ab
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/Zakkary19_BLKOPSCW_20260902-110124/material_20260902-110124.txt
+++ b/submissions/Zakkary19_BLKOPSCW_20260902-110124/material_20260902-110124.txt
@@ -1,0 +1,2 @@
+1c9d3f4b4a60fddf,ei/gfx9_muzzle_gas_side_sm_pap_atlas_1p_hdrg
+49ff52e57d58e35b,ei/gfx9_muzzle_gas_side_sm_atlas_1p_hdrg_desat


### PR DESCRIPTION
**BLKOPSCW** — 2 asset names, confirmed against that game's own loaded assets.

- material: 2

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Zakkary19

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260902-105952_plan
- method: all-boundary cores x uncarried endings, 4 segment(s), top 100000
- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
- ran for: 16s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- beginnings: 0
- endings: 100000
- stems: 37406
- ids hunted: 111086
- candidates tested: 3740637406
- new: 2
- sketch beginnings: 
- sketch stems: 00002b1519e1ded40001c4288d1f83f80003b69caf19a9720004a5cf1343b38600063685031d4423000f1597bb35c60d00108dc43f3f7d7100110f76cb990dc1001416b90333d31100145d41c6155d7d001501337ddd67d100152fa9c4c4534c00182aeae1fa77ef001a7e7a6d4976d3001ca7f05f38a262001da2dcd16eff55001e2c9de2cd1f4100208856d44379ec00210f78b01caf8a002373e6758040af00237f2be3916d920023ddcd130b37900024c8f466d89d420026007fd114d562002b0e53920affb1002d8c57bb566ead002ee3cf10634b04002ef5baab179fae002f2af27b7e511e002ff87367bbe25e00342faec94b823400344514e6a22c29
- sketch endings: 00009d1c61c251e300009f0c4c8348050001b4dd72acd1050001c12df56c976600045c1367de2d76000494e09392a8ba0005fc359dfe48d80007d020b1aadee00007ebdee4342b29000869271a4714cb000872a76958d2e10009a3e71b0a91f1000a26aa4929c79c000a386057bf50ef000a40e5b489b763000a46404dbbc13f000aefccaf60d6b3000bbfb1098be4ab000e936d1430bb76000f3c2661166956000fa6d905fe55070010d236676abe5b0010edf816682b0100111bd139da50ff0011a3cd783860190011fb447bd20ff300126f0d1c4b4fd20012f03820724db60013177929c37c7600138edae33d989f001610c70a9e83930016235cd8606636
- fingerprint: 16233389dc3bb3ab

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/blkops04_sound_asset_dirs_20260826-104215.txt`
- `scripts/contributed/blkops04_sound_asset_ends_20260902-100022.txt`
- `scripts/contributed/blkops04_sound_asset_stems_20260902-100022.txt`
- `scripts/contributed/bo4snd_cores_20260901-010534.txt`
- `scripts/contributed/bo4snd_ends_20260902-095559.txt`
- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/numbered_grids_20260821-054219.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.