### PR TITLE
[BLKOPSCW] findings from Zakkary19, 20260902-130803 (1 names)

### DIFF
--- a/submissions/Zakkary19_BLKOPSCW_20260902-130803/about_20260902-130803.md
+++ b/submissions/Zakkary19_BLKOPSCW_20260902-130803/about_20260902-130803.md
@@ -1,0 +1,38 @@
+# Submission 20260902-130803
+
+- game: **BLKOPSCW**
+- from: Zakkary19
+- names: 1
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- image: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 100 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260902-130411_plan
+- method: tails of length 3
+- what it does: every known name cut short by 3 character(s), against every 3-character ending over the 37 characters names are measured to end in
+- ran for: 24s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- beginnings: 0
+- endings: 50653
+- stems: 675463
+- ids hunted: 111086
+- candidates tested: 34214902802
+- new: 1
+- sketch beginnings: 
+- sketch stems: 000012c311da10ff0000153036e7f040000041e573392669000042af8f2b9720000045e1807a46390000502a97bf06ff000051b7b6e7c3e50000595d5e43b51e00008b630b00272f00009c2abd7015410000b8292d62cf930000c63c8d67601c00012a876c73b4c100014cad6bcdce8100014f172cefd1d000015bf4b3c377a8000161fe7c7fb3bf000179ee9b7479ed0001892d1c54956d00019940fc3e141700019d19b275dbfb0001e9d263b7d55a00024dde3c116c50000253b116c73a2f00026692321156850002727cb126db540002797b0cb0c0e00002bf02439b4c180002c4406d93ab780002cc8b5409c9ed0002d9635732ab9e0002dd93ceec9074
+- sketch endings: 0000065093d2ddcb000009a9246decd30000c0ee97a841da000105e496e34f73000221c75929fb3200024e1052ecac1e00046b3d1855840d0005ae639e926f5d000cbc01b480ab4c000cbec3f4c1a1f2000d92810ddcb5dc0010d8212032c16700110b28e22c5b000011482c992f9b36001280f6cd94de880012a5925ed9cdc700148fff58e34676001538998e20f3570015ecc7299627dc00171438b6fbe1d70017285349dcf2ba001798c7451b75ee001916f3aa09d066001a6f64968748f5001cec1662cf3c52001d2cad0ab0964c001e6153b65350ad001f0b5ecc97c959001fdc30529cddff0021ad1c1ec693070021bc0e48915ced0023b92a21dde19a
+- fingerprint: 4cd76ce3c5a06d03
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/Zakkary19_BLKOPSCW_20260902-130803/image_20260902-130803.txt
+++ b/submissions/Zakkary19_BLKOPSCW_20260902-130803/image_20260902-130803.txt
@@ -1,0 +1,1 @@
+6b84d413a1c192b8,i_mtl_p9_zm_gold_message_screen_01f_c


### PR DESCRIPTION
**BLKOPSCW** — 1 asset names, confirmed against that game's own loaded assets.

- image: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Zakkary19

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260902-130411_plan
- method: tails of length 3
- what it does: every known name cut short by 3 character(s), against every 3-character ending over the 37 characters names are measured to end in
- ran for: 24s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- beginnings: 0
- endings: 50653
- stems: 675463
- ids hunted: 111086
- candidates tested: 34214902802
- new: 1
- sketch beginnings: 
- sketch stems: 000012c311da10ff0000153036e7f040000041e573392669000042af8f2b9720000045e1807a46390000502a97bf06ff000051b7b6e7c3e50000595d5e43b51e00008b630b00272f00009c2abd7015410000b8292d62cf930000c63c8d67601c00012a876c73b4c100014cad6bcdce8100014f172cefd1d000015bf4b3c377a8000161fe7c7fb3bf000179ee9b7479ed0001892d1c54956d00019940fc3e141700019d19b275dbfb0001e9d263b7d55a00024dde3c116c50000253b116c73a2f00026692321156850002727cb126db540002797b0cb0c0e00002bf02439b4c180002c4406d93ab780002cc8b5409c9ed0002d9635732ab9e0002dd93ceec9074
- sketch endings: 0000065093d2ddcb000009a9246decd30000c0ee97a841da000105e496e34f73000221c75929fb3200024e1052ecac1e00046b3d1855840d0005ae639e926f5d000cbc01b480ab4c000cbec3f4c1a1f2000d92810ddcb5dc0010d8212032c16700110b28e22c5b000011482c992f9b36001280f6cd94de880012a5925ed9cdc700148fff58e34676001538998e20f3570015ecc7299627dc00171438b6fbe1d70017285349dcf2ba001798c7451b75ee001916f3aa09d066001a6f64968748f5001cec1662cf3c52001d2cad0ab0964c001e6153b65350ad001f0b5ecc97c959001fdc30529cddff0021ad1c1ec693070021bc0e48915ced0023b92a21dde19a
- fingerprint: 4cd76ce3c5a06d03

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/blkops04_sound_asset_dirs_20260826-104215.txt`
- `scripts/contributed/blkops04_sound_asset_ends_20260902-100022.txt`
- `scripts/contributed/blkops04_sound_asset_stems_20260902-100022.txt`
- `scripts/contributed/bo4snd_cores_20260901-010534.txt`
- `scripts/contributed/bo4snd_ends_20260902-095559.txt`
- `scripts/contributed/chan_ends_20260902-113127.txt`
- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/image_siblings_wide_20260902-120635.py`
- `scripts/contributed/materials_from_images_wide_20260902-121208.py`
- `scripts/contributed/numbered_grids_20260821-054219.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.