### PR TITLE
[BLKOPSCW] findings from Zakkary19, 20260902-182738 (1 names)

### DIFF
--- a/scripts/contributed/family_shared_tails_20260902-182738.py
+++ b/scripts/contributed/family_shared_tails_20260902-182738.py
@@ -1,0 +1,74 @@
+"""Unified family shared tail grid generator across all 22 measured asset families.
+
+Combines and fixes the 22 orphaned shared-tail scripts (p8, p9, ui, uie, vm, wpn,
+weap, callingcards, emblems, zmb, att, amb, evt, fly, mus, sat, mpl, etc.),
+filling unobserved cells where an axis and a tail are each known in the family.
+"""
+
+import collections
+import os
+import sys
+
+_root = os.path.dirname(os.path.abspath(__file__))
+while _root != os.path.dirname(_root) and not os.path.isfile(
+    os.path.join(_root, "scripts", "snapshot.py")
+):
+    _root = os.path.dirname(_root)
+sys.path.insert(0, os.path.join(_root, "scripts"))
+
+import snapshot
+
+TABLES = (
+    "fnv1a_xmaterials", "fnv1a_xmaterials_v2",
+    "fnv1a_ximages", "fnv1a_ximages_v2",
+    "fnv1a_xmodels", "fnv1a_xmodels_v2",
+    "fnv1a_xanims", "fnv1a_xanims_v2",
+    "fnv1a_soundbanks_aliases", "fnv1a_soundbanks_aliases_v2",
+    "fnv1a_xsounds", "fnv1a_xsounds_v2",
+)
+
+FAMILIES = [
+    "p8", "p9", "p7", "ui", "uie", "vm", "wpn", "weap", "callingcards",
+    "emblems", "zmb", "att", "amb", "evt", "fly", "mus", "sat", "mpl",
+    "icon", "jup", "pt", "i"
+]
+
+def main():
+    target_families = sys.argv[1:] if len(sys.argv) > 1 else FAMILIES
+    
+    sys.stderr.write("Loading known names...\n")
+    have = {n.strip().lower().replace("\\", "/") for n in snapshot.table_names(*TABLES)}
+    have |= {n.strip().lower().replace("\\", "/") for n in snapshot.confirmed_names()}
+    
+    total_candidates = 0
+    
+    for family in target_families:
+        observed = []
+        prefix = family + "_"
+        for name in have:
+            if not name.startswith(prefix) or "/" in name or "." in name:
+                continue
+            parts = name.split("_", 2)
+            if len(parts) >= 3:
+                axis, tail = parts[1], parts[2]
+                if axis and tail:
+                    observed.append((axis, tail))
+                    
+        if not observed:
+            continue
+            
+        axes = {axis for axis, _ in observed}
+        counts = collections.Counter(tail for _, tail in observed)
+        tails = {tail for tail, count in counts.items() if count > 1}
+        
+        candidates = sorted({f"{family}_{axis}_{tail}" for axis in axes for tail in tails} - have)
+        sys.stderr.write(f"[{family}] {len(axes):,} axes x {len(tails):,} tails = {len(candidates):,} candidates\n")
+        
+        for cand in candidates:
+            print(cand)
+        total_candidates += len(candidates)
+        
+    sys.stderr.write(f"Total candidates across {len(target_families)} families: {total_candidates:,}\n")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/contributed/measured_shells_20260902-182738.py
+++ b/scripts/contributed/measured_shells_20260902-182738.py
@@ -1,0 +1,99 @@
+"""A known name's MIDDLE, wearing a different name's opening and a different name's ending.
+
+    python contrib/measured_shells.py --head 6 --tail 6 --top 1200
+    bin/windows/confirm_plan.exe plans/shell_h6t6.txt --size
+    bin/windows/confirm_plan.exe plans/shell_h6t6.txt
+"""
+
+import argparse
+import os
+import sys
+from collections import Counter
+
+_root = os.path.dirname(os.path.abspath(__file__))
+while _root != os.path.dirname(_root) and not os.path.isfile(
+    os.path.join(_root, "scripts", "snapshot.py")
+):
+    _root = os.path.dirname(_root)
+sys.path.insert(0, os.path.join(_root, "scripts"))
+
+import snapshot
+
+REPO = _root
+PUBLISHED = ["fnv1a_xmaterials", "fnv1a_ximages", "fnv1a_xmodels", "fnv1a_xanims"]
+GENERAL = ("image", "material", "xmodel", "xanim")
+
+
+def load():
+    names = set()
+    for fn in PUBLISHED:
+        for name in snapshot.table_names(fn):
+            name = name.strip().lower().replace("\\", "/")
+            if name:
+                names.add(name)
+    for g in GENERAL:
+        for name in snapshot.confirmed_names(g):
+            name = name.strip().lower().replace("\\", "/")
+            if name:
+                names.add(name)
+    return names
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--head", type=int, default=6, help="characters replaced at the front")
+    ap.add_argument("--tail", type=int, default=6, help="characters replaced at the end")
+    ap.add_argument("--top", type=int, default=1200,
+                    help="keep the N commonest openings and the N commonest endings")
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+    h, t = args.head, args.tail
+
+    names = [n for n in load() if len(n) > h + t + 4]
+    sys.stderr.write("names usable at head=%d tail=%d: %d\n" % (h, t, len(names)))
+
+    openings, endings, middles = Counter(), Counter(), set()
+    for n in names:
+        openings[n[:h]] += 1
+        endings[n[-t:]] += 1
+        middles.add(n[h:-t])
+
+    begins = [o for o, _ in openings.most_common(args.top)]
+    ends = [e for e, _ in endings.most_common(args.top)]
+    middles = sorted(middles)
+
+    out = args.out or os.path.join(REPO, "plans", "shell_h%dt%d" % (h, t))
+
+    def write(path, rows):
+        with open(path, "w", encoding="utf-8", newline="\n") as fh:
+            for r in rows:
+                fh.write(r + "\n")
+
+    write(out + ".begins.txt", begins)
+    write(out + ".mids.txt", middles)
+    write(out + ".ends.txt", ends)
+    rel = os.path.basename(out)
+    with open(out + ".txt", "w", encoding="utf-8", newline="\n") as fh:
+        fh.write("# Written by contrib/measured_shells.py --head %d --tail %d --top %d\n#\n"
+                 % (h, t, args.top))
+        fh.write("# Every known name with %d characters cut off the front and %d off the end,\n"
+                 % (h, t))
+        fh.write("# wearing every opening and every ending the corpus is observed to use at\n")
+        fh.write("# those lengths -- the two measured-offset methods applied at once.\n\n")
+        fh.write("label: measured shells, head %d tail %d, top %d\n" % (h, t, args.top))
+        fh.write("begin: @plans/%s.begins.txt\n" % rel)
+        fh.write("stem:  @plans/%s.mids.txt\n" % rel)
+        fh.write("end:   @plans/%s.ends.txt\n" % rel)
+
+    total = len(begins) * len(middles) * len(ends)
+    print("head=%d tail=%d top=%d: %s openings x %s middles x %s endings = %s candidates"
+          % (h, t, args.top, "{:,}".format(len(begins)), "{:,}".format(len(middles)),
+             "{:,}".format(len(ends)), "{:,}".format(total)))
+    print("      full vocabulary would be %s x %s -- capped %.0fx"
+          % ("{:,}".format(len(openings)), "{:,}".format(len(endings)),
+             (len(openings) * len(endings)) / float(max(1, len(begins) * len(ends)))))
+    print("wrote %s.txt" % out)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/contributed/zombie_models_20260902-182738.py
+++ b/scripts/contributed/zombie_models_20260902-182738.py
@@ -1,0 +1,84 @@
+"""Zombies-flavoured xmodel names, recombined from every zombies name already known to be real.
+
+    python contrib/zombie_models.py | bin/windows/confirm_list.exe - \
+        --label "zombie xmodels" --script contrib/zombie_models.py --game BLKOPS04
+"""
+import os
+import re
+import sys
+
+_root = os.path.dirname(os.path.abspath(__file__))
+while _root != os.path.dirname(_root) and not os.path.isfile(
+    os.path.join(_root, "scripts", "snapshot.py")
+):
+    _root = os.path.dirname(_root)
+sys.path.insert(0, os.path.join(_root, "scripts"))
+
+import snapshot
+
+WANTED = re.compile(r"zombie|zmb|_zm_|^zm_|/zm_")
+
+OPENINGS = [
+    "", "p9_", "p8_", "p7_", "p6_", "c_", "t9_", "vm_", "wm_", "attach_", "veh_", "ai_",
+    "p9_zmb_", "p8_zmb_", "c_zmb_", "zmb_", "zm_", "p9_zombie_", "c_zombie_", "zombie_",
+    "clt/", "splm/", "cltp/", "mc/",
+]
+
+TAILS = ["", "_lod0", "_lod1", "_lod2", "_lod3", "_body", "_head", "_hat", "_arms", "_legs",
+         "_torso", "_hands", "_fx", "_dead", "_gib", "_world", "_view", "_dmg", "_variant"]
+for number in range(0, 13):
+    TAILS.append("_%02d" % number)
+    TAILS.append("_%d" % number)
+
+
+def measured(name):
+    path = os.path.join(_root, "data", name)
+    with open(path, encoding="utf-8") as handle:
+        return [line.strip() for line in handle if line.strip()]
+
+
+def corpus():
+    for name in snapshot.table_names("fnv1a_xmodels"):
+        yield name.strip().lower().replace("\\", "/")
+    for name in snapshot.confirmed_names("xmodel"):
+        yield name.strip().lower().replace("\\", "/")
+
+
+def stems_of(name):
+    base = name.rpartition("/")[2]
+    parts = base.split("_")
+
+    for start in range(len(parts)):
+        for end in range(start + 1, len(parts) + 1):
+            piece = "_".join(parts[start:end])
+            if len(piece) >= 3:
+                yield piece
+
+
+def main():
+    seen_stems = set()
+    for name in corpus():
+        if not WANTED.search(name):
+            continue
+        for stem in stems_of(name):
+            seen_stems.add(stem)
+
+    stems = sorted(stem for stem in seen_stems
+                   if WANTED.search(stem) and stem.count("_") <= 3)
+    print("zombies stems: %d" % len(stems), file=sys.stderr)
+
+    endings = TAILS + [item for item in measured("suffixes.txt") if item.count("_") == 1][:20]
+    endings = list(dict.fromkeys(endings))
+    print("endings: %d, openings: %d" % (len(endings), len(OPENINGS)), file=sys.stderr)
+    print("candidates: %d" % (len(stems) * len(endings) * len(OPENINGS)), file=sys.stderr)
+
+    out = sys.stdout
+    for stem in stems:
+        for opening in OPENINGS:
+            head = opening + stem
+            for ending in endings:
+                out.write(head + ending + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/submissions/Zakkary19_BLKOPSCW_20260902-182738/about_20260902-182738.md
+++ b/submissions/Zakkary19_BLKOPSCW_20260902-182738/about_20260902-182738.md
@@ -1,0 +1,38 @@
+# Submission 20260902-182738
+
+- game: **BLKOPSCW**
+- from: Zakkary19
+- names: 1
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- material: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 100 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260902-182519_plan
+- method: measured shells, head 6 tail 6, top 800
+- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
+- ran for: 1m 06s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- beginnings: 800
+- endings: 800
+- stems: 535980
+- ids hunted: 111086
+- candidates tested: 343885303980
+- new: 1
+- sketch beginnings: 003e3c7aee2cda130047323183479141006f9258d67df0fb00e42f519dee6a720102ac0790eb475e017ce44c97fa021d01836ced267249b601afc6dab0e8c38201c281ae76a3bdf6024064a9da6ef4f60252e97b8a295ff60267b6277738f712036df0a2c59f836503ba9d94eda676b603df4ab2ec3360b803f88180dfe7ae63045b997cbd8f138c049fef0fec512428051c07fcae86ccdb05785bfd380d8b050589085ff6d8fdd406105e7bd1f39fb406290e3931c58d4306de625360ecf17b07bdbe5b97151c2407f1e3bbd3e73d7107fce7d598037f82085d47fcb920bd76097f1b39a53a17e10a6282e460f0ef240adaca5d6656df140b595c5f2a297a76
+- sketch stems: 00004c8260e391da00006e389774040300007f6eade625f700009c503474d3190000a9194486409c0000d871885f264000011bfaa7535f3900011e3adbb211e20001215d99f4c21800012ce98dc18d9200012f4d8bac93c900013647f685513400017c555efb05a6000186408130ebea0001962b11c181b10001a01979a3812e0001bb632aecc5c90001e8a869aae33e00020f19583cc9b0000219d79dc1db300002f9a57af02d550003ae00a872f0820003b2b3e782f2720003c69d3384668b0003e0c9f481adfb00040276ae835347000423fcb9b2bb5800042d68dc6f8c0000042fd44403810b00044502fae2f70300045497b8eab7c400047858aaa91158
+- sketch endings: 001339fb2a403aec003d7bd518fb7b79004beadb2742355b005eb9e7ed0db76c019fce1a4ac8b5540236cf03922d978902d08e6e7d211420031ed3db917e901804158d85558849d50482fc43def3740204acc838806f4e6104c52944fa5079340508d909f3fb3dfe052f036671c9e6fc06361843d2c623c80645ea6c8fabade4065f12ad2d7de9a20727f73bc169a6770730f9872675d4b807424779c5b081fe07673bf0a0f01c4907a139aa1aaaaea307daa919887082cd08276fe43db60e21089abe1a07491851099541b82847475a0a790b5ad91e58c10b24dfbf34f3f8520bd247362b71ce250bd477881b8d585f0bdcfcd4e47276460c87e0b860e0fc3f
+- fingerprint: 15fdaf906c472866
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/Zakkary19_BLKOPSCW_20260902-182738/material_20260902-182738.txt
+++ b/submissions/Zakkary19_BLKOPSCW_20260902-182738/material_20260902-182738.txt
@@ -1,0 +1,1 @@
+76d65c281d87a121,mc/mtl_p8_street_lamp_antique_set_dirty


### PR DESCRIPTION
**BLKOPSCW** — 1 asset names, confirmed against that game's own loaded assets.

- material: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Zakkary19

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260902-182519_plan
- method: measured shells, head 6 tail 6, top 800
- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
- ran for: 1m 06s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- beginnings: 800
- endings: 800
- stems: 535980
- ids hunted: 111086
- candidates tested: 343885303980
- new: 1
- sketch beginnings: 003e3c7aee2cda130047323183479141006f9258d67df0fb00e42f519dee6a720102ac0790eb475e017ce44c97fa021d01836ced267249b601afc6dab0e8c38201c281ae76a3bdf6024064a9da6ef4f60252e97b8a295ff60267b6277738f712036df0a2c59f836503ba9d94eda676b603df4ab2ec3360b803f88180dfe7ae63045b997cbd8f138c049fef0fec512428051c07fcae86ccdb05785bfd380d8b050589085ff6d8fdd406105e7bd1f39fb406290e3931c58d4306de625360ecf17b07bdbe5b97151c2407f1e3bbd3e73d7107fce7d598037f82085d47fcb920bd76097f1b39a53a17e10a6282e460f0ef240adaca5d6656df140b595c5f2a297a76
- sketch stems: 00004c8260e391da00006e389774040300007f6eade625f700009c503474d3190000a9194486409c0000d871885f264000011bfaa7535f3900011e3adbb211e20001215d99f4c21800012ce98dc18d9200012f4d8bac93c900013647f685513400017c555efb05a6000186408130ebea0001962b11c181b10001a01979a3812e0001bb632aecc5c90001e8a869aae33e00020f19583cc9b0000219d79dc1db300002f9a57af02d550003ae00a872f0820003b2b3e782f2720003c69d3384668b0003e0c9f481adfb00040276ae835347000423fcb9b2bb5800042d68dc6f8c0000042fd44403810b00044502fae2f70300045497b8eab7c400047858aaa91158
- sketch endings: 001339fb2a403aec003d7bd518fb7b79004beadb2742355b005eb9e7ed0db76c019fce1a4ac8b5540236cf03922d978902d08e6e7d211420031ed3db917e901804158d85558849d50482fc43def3740204acc838806f4e6104c52944fa5079340508d909f3fb3dfe052f036671c9e6fc06361843d2c623c80645ea6c8fabade4065f12ad2d7de9a20727f73bc169a6770730f9872675d4b807424779c5b081fe07673bf0a0f01c4907a139aa1aaaaea307daa919887082cd08276fe43db60e21089abe1a07491851099541b82847475a0a790b5ad91e58c10b24dfbf34f3f8520bd247362b71ce250bd477881b8d585f0bdcfcd4e47276460c87e0b860e0fc3f
- fingerprint: 15fdaf906c472866

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/blkops04_sound_asset_dirs_20260826-104215.txt`
- `scripts/contributed/blkops04_sound_asset_ends_20260902-100022.txt`
- `scripts/contributed/blkops04_sound_asset_stems_20260902-100022.txt`
- `scripts/contributed/bo4_sound_hunter_20260902-140851.py`
- `scripts/contributed/bo4_sound_hunter_tails_20260902-140851.txt`
- `scripts/contributed/bo4snd_cores_20260901-010534.txt`
- `scripts/contributed/bo4snd_ends_20260902-095559.txt`
- `scripts/contributed/chan_ends_20260902-113127.txt`
- `scripts/contributed/family_shared_tails_20260902-182738.py`
- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/image_siblings_wide_20260902-120635.py`
- `scripts/contributed/materials_from_images_wide_20260902-121208.py`
- `scripts/contributed/measured_shells_20260902-182738.py`
- `scripts/contributed/numbered_grids_20260821-054219.py`
- `scripts/contributed/xmodel_pairs_20260902-153205.py`
- `scripts/contributed/zombie_models_20260902-182738.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.