### PR TITLE
[BLKOPS04] findings from Zakkary19, 20260903-051624 (4 names)

### DIFF
--- a/scripts/contributed/anim_game_cross_20260903-051624.py
+++ b/scripts/contributed/anim_game_cross_20260903-051624.py
@@ -1,0 +1,87 @@
+"""Cross-Generation Animation Tag Swapper: t8 (BO4) <-> t9 (Cold War).
+
+Treyarch's viewmodel and gameplay animations frequently share common animation rig identifiers,
+differing only by their game generation tag (_t8_ vs _t9_) or the presence/absence of the tag.
+
+This generator mines all confirmed and published xanims and generates:
+1. t9 -> t8 substitutions
+2. t8 -> t9 substitutions
+3. t8 -> bare (untagged) substitutions
+4. t9 -> bare (untagged) substitutions
+5. bare -> t8 / t9 insertions where applicable
+"""
+
+import os
+import sys
+
+_root = os.path.dirname(os.path.abspath(__file__))
+while _root != os.path.dirname(_root) and not os.path.isfile(
+    os.path.join(_root, "scripts", "snapshot.py")
+):
+    _root = os.path.dirname(_root)
+sys.path.insert(0, os.path.join(_root, "scripts"))
+
+import snapshot
+
+def main():
+    known = set()
+    for name in snapshot.table_names("fnv1a_xanims"):
+        known.add(name.strip().lower().replace("\\", "/"))
+    for name in snapshot.confirmed_names("xanim"):
+        known.add(name.strip().lower().replace("\\", "/"))
+
+    sys.stderr.write(f"Loaded {len(known)} known animation names.\n")
+
+    candidates = set()
+
+    for name in known:
+        # 1. t9 -> t8 and t8 -> t9
+        if "_t9_" in name:
+            c8 = name.replace("_t9_", "_t8_")
+            if c8 not in known:
+                candidates.add(c8)
+            cbare = name.replace("_t9_", "_")
+            if cbare not in known:
+                candidates.add(cbare)
+
+        if "_t8_" in name:
+            c9 = name.replace("_t8_", "_t9_")
+            if c9 not in known:
+                candidates.add(c9)
+            cbare = name.replace("_t8_", "_")
+            if cbare not in known:
+                candidates.add(cbare)
+
+        # Endings: _t9 vs _t8
+        if name.endswith("_t9"):
+            c8 = name[:-3] + "_t8"
+            if c8 not in known:
+                candidates.add(c8)
+            cbare = name[:-3]
+            if cbare not in known:
+                candidates.add(cbare)
+
+        if name.endswith("_t8"):
+            c9 = name[:-3] + "_t9"
+            if c9 not in known:
+                candidates.add(c9)
+            cbare = name[:-3]
+            if cbare not in known:
+                candidates.add(cbare)
+
+        # Beginnings: t9_ vs t8_
+        if name.startswith("t9_"):
+            c8 = "t8_" + name[3:]
+            if c8 not in known:
+                candidates.add(c8)
+        if name.startswith("t8_"):
+            c9 = "t9_" + name[3:]
+            if c9 not in known:
+                candidates.add(c9)
+
+    sys.stderr.write(f"Generated {len(candidates)} cross-generation animation candidates.\n")
+    for cand in sorted(candidates):
+        sys.stdout.write(cand + "\n")
+
+if __name__ == "__main__":
+    main()

--- a/submissions/Zakkary19_BLKOPS04_20260903-051624/about_20260903-051624.md
+++ b/submissions/Zakkary19_BLKOPS04_20260903-051624/about_20260903-051624.md
@@ -1,0 +1,35 @@
+# Submission 20260903-051624
+
+- game: **BLKOPS04**
+- from: Zakkary19
+- names: 4
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- xanim: 4
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 100 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260903-051515_list
+- method: anim_game_cross
+- what it does: a candidate list generated outside the search and confirmed here
+- ran for: 2s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- candidates tested: 26532
+- matched: 4
+- new: 4
+- sketch stems: 0005eae10217fad2000fa2766523a26b0010e73cf9039c8f00196c3c8b250976001c1666e522cc7f001d1c6d6841f1ef001dd6aaa197e2c7001fbad35337e733002027a7e807fc8000205c2af09979fb002954eab34bdebf002b9e9fb12a54880032e42f2b60c2af003324545b55a8cb00340adbc6a4525c0038cd0aeeec962d003a7bc6d7326a45003b30bddc5af5ab003c71af5a30e200003ca1c10ef7e1a7003e2ae923b7d0d70042eeb96b37f80a0045919a49b06402004780d4feb84d25004f073bf7486448005198447e0537480055f4fefa29e2990057082202e9e25f0057eec3fb6a01e7005af18dd9156067005b485a962815b9005c0afcd4179c77
+- ids hunted: 149820
+- throughput: 0.7M candidates/s
+- fingerprint: 4a556428270d0659
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/Zakkary19_BLKOPS04_20260903-051624/xanim_20260903-051624.txt
+++ b/submissions/Zakkary19_BLKOPS04_20260903-051624/xanim_20260903-051624.txt
@@ -1,0 +1,4 @@
+1517c83deaad0f69,pt_shotgun_t8_semiauto_prone_inspect
+229dbe947bf7533e,pt_shotgun_t8_pump_prone_inspect
+42612abf42e7aa3b,pt_shotgun_t8_semiauto_stand_inspect
+4d30bb828b7bdfa4,pt_shotgun_t8_pump_stand_inspect


### PR DESCRIPTION
**BLKOPS04** — 4 asset names, confirmed against that game's own loaded assets.

- xanim: 4

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Zakkary19

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260903-051515_list
- method: anim_game_cross
- what it does: a candidate list generated outside the search and confirmed here
- ran for: 2s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- candidates tested: 26532
- matched: 4
- new: 4
- sketch stems: 0005eae10217fad2000fa2766523a26b0010e73cf9039c8f00196c3c8b250976001c1666e522cc7f001d1c6d6841f1ef001dd6aaa197e2c7001fbad35337e733002027a7e807fc8000205c2af09979fb002954eab34bdebf002b9e9fb12a54880032e42f2b60c2af003324545b55a8cb00340adbc6a4525c0038cd0aeeec962d003a7bc6d7326a45003b30bddc5af5ab003c71af5a30e200003ca1c10ef7e1a7003e2ae923b7d0d70042eeb96b37f80a0045919a49b06402004780d4feb84d25004f073bf7486448005198447e0537480055f4fefa29e2990057082202e9e25f0057eec3fb6a01e7005af18dd9156067005b485a962815b9005c0afcd4179c77
- ids hunted: 149820
- throughput: 0.7M candidates/s
- fingerprint: 4a556428270d0659

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/anim_game_cross_20260903-051624.py`
- `scripts/contributed/blkops04_sound_asset_dirs_20260826-104215.txt`
- `scripts/contributed/blkops04_sound_asset_ends_20260902-100022.txt`
- `scripts/contributed/blkops04_sound_asset_stems_20260902-100022.txt`
- `scripts/contributed/bo4_sound_hunter_20260902-140851.py`
- `scripts/contributed/bo4_sound_hunter_tails_20260902-140851.txt`
- `scripts/contributed/bo4snd_cores_20260901-010534.txt`
- `scripts/contributed/bo4snd_ends_20260902-095559.txt`
- `scripts/contributed/cdl_cosmetics_20260903-045836.py`
- `scripts/contributed/chan_ends_20260902-113127.txt`
- `scripts/contributed/family_shared_tails_20260902-182738.py`
- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/image_siblings_wide_20260902-120635.py`
- `scripts/contributed/materials_from_images_wide_20260902-121208.py`
- `scripts/contributed/measured_shells_20260902-182738.py`
- `scripts/contributed/numbered_grids_20260821-054219.py`
- `scripts/contributed/surface_sound_grid_20260903-045836.py`
- `scripts/contributed/xmodel_pairs_20260902-153205.py`
- `scripts/contributed/zombie_models_20260902-182738.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.