### PR TITLE
[BLKOPS04] findings from Tnt540, 20260903-100334 (6 names)

### DIFF
--- a/submissions/Tnt540_BLKOPS04_20260903-100334/about_20260903-100334.md
+++ b/submissions/Tnt540_BLKOPS04_20260903-100334/about_20260903-100334.md
@@ -1,0 +1,40 @@
+# Submission 20260903-100334
+
+- game: **BLKOPS04**
+- from: Tnt540
+- names: 6
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- material: 3
+- xmodel: 2
+- image: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 100 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260903-094655_plan
+- method: BLKOPS04-scoped all-boundary cores x ALL uncarried 6-segment endings (full vocabulary, untried depth)
+- what it does: all_names/blkops04 published cores plus confirmed names x every 6-segment ending data/suffixes.txt cannot express (854,470 of them)
+- ran for: 15m 01s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- beginnings: 0
+- endings: 854470
+- stems: 169171
+- ids hunted: 150058
+- candidates tested: 144551713541
+- new: 6
+- sketch beginnings: 
+- sketch stems: 00002b1519e1ded400002ee0bf50cc960000ef4a2113a6a7000196f66cc5bd0a0001aef44909c8860001c4288d1f83f80001d42da712184b00033cf2e70d986600033f547a90eb950003b69caf19a9720003df052c8c65a400041bbbb5029bd70004411f5ae467110004a5cf1343b3860004f9caa2916c42000624bd7bcc757200063685031d44230006518ce0f1ed4d00068f4e032473900006b5e60602d68c0007d55dbb0777ea0009fc4ea542379a000a6d6d22ada5ec000b32b8830e99c2000c7c620254ad84000c9eb9db01a880000caad68ac532c4000d02e08a26b568000d2a274f32763e000d4e4e5c704308000d843abd748604000d9cf054b1db20
+- sketch endings: 00004df6ac5d88ac000071133cc279ef000089ca3fc9e4c500009898ca25e37b00009bbddd56adea0000a44402586f160000a66a637dcd000000b41d54c536300000b4755a17c9e00000c1771acbb70c0000e81896ebcb0c0001174b7cd1efd90001384758b98bc2000146757f9e6ebe0001564fb4abdf3e000182b4dd80d0b10001dc626916c35d0001dea03ab696a5000200abbcbd4d2500020a20afe118430002184a9d06955900021d8de048b1ed000242acbf2544380002458fb54d6dd40002477e47cea47000026fd9b75a93be000287f5327a0c9c000292f5a22e36ea0002abf167471a2d0002b735b6512b450002b9a32e78ffb50002ba7c757a9991
+- fingerprint: 0c7ba9b230d18488
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/Tnt540_BLKOPS04_20260903-100334/image_20260903-100334.txt
+++ b/submissions/Tnt540_BLKOPS04_20260903-100334/image_20260903-100334.txt
@@ -1,0 +1,1 @@
+70c6ed57234f16dc,i_mtl_veh_t8_out_decal_damage_metal_scratches_n

--- a/submissions/Tnt540_BLKOPS04_20260903-100334/material_20260903-100334.txt
+++ b/submissions/Tnt540_BLKOPS04_20260903-100334/material_20260903-100334.txt
@@ -1,0 +1,3 @@
+373d1974fa05375c,mc/mtl_p8_wz_photo_frame_metal_stand_01_c
+373d1a74fa05390f,mc/mtl_p8_wz_photo_frame_metal_stand_01_b
+6af255eacd88f6e5,mc/p8_aut_decal_metal_low_tech_details_08

--- a/submissions/Tnt540_BLKOPS04_20260903-100334/xmodel_20260903-100334.txt
+++ b/submissions/Tnt540_BLKOPS04_20260903-100334/xmodel_20260903-100334.txt
@@ -1,0 +1,2 @@
+2d5751dcbadb5e68,p8_kit_col_row_01_trim_03_corner_inside_white_wood_32_01
+5aaf1bfb691cdb85,p8_kit_zt8_exd_05_railing_06_corner_outside_painted_metal_32_01


### PR DESCRIPTION
**BLKOPS04** — 6 asset names, confirmed against that game's own loaded assets.

- material: 3
- xmodel: 2
- image: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Tnt540

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260903-094655_plan
- method: BLKOPS04-scoped all-boundary cores x ALL uncarried 6-segment endings (full vocabulary, untried depth)
- what it does: all_names/blkops04 published cores plus confirmed names x every 6-segment ending data/suffixes.txt cannot express (854,470 of them)
- ran for: 15m 01s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- beginnings: 0
- endings: 854470
- stems: 169171
- ids hunted: 150058
- candidates tested: 144551713541
- new: 6
- sketch beginnings: 
- sketch stems: 00002b1519e1ded400002ee0bf50cc960000ef4a2113a6a7000196f66cc5bd0a0001aef44909c8860001c4288d1f83f80001d42da712184b00033cf2e70d986600033f547a90eb950003b69caf19a9720003df052c8c65a400041bbbb5029bd70004411f5ae467110004a5cf1343b3860004f9caa2916c42000624bd7bcc757200063685031d44230006518ce0f1ed4d00068f4e032473900006b5e60602d68c0007d55dbb0777ea0009fc4ea542379a000a6d6d22ada5ec000b32b8830e99c2000c7c620254ad84000c9eb9db01a880000caad68ac532c4000d02e08a26b568000d2a274f32763e000d4e4e5c704308000d843abd748604000d9cf054b1db20
- sketch endings: 00004df6ac5d88ac000071133cc279ef000089ca3fc9e4c500009898ca25e37b00009bbddd56adea0000a44402586f160000a66a637dcd000000b41d54c536300000b4755a17c9e00000c1771acbb70c0000e81896ebcb0c0001174b7cd1efd90001384758b98bc2000146757f9e6ebe0001564fb4abdf3e000182b4dd80d0b10001dc626916c35d0001dea03ab696a5000200abbcbd4d2500020a20afe118430002184a9d06955900021d8de048b1ed000242acbf2544380002458fb54d6dd40002477e47cea47000026fd9b75a93be000287f5327a0c9c000292f5a22e36ea0002abf167471a2d0002b735b6512b450002b9a32e78ffb50002ba7c757a9991
- fingerprint: 0c7ba9b230d18488

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/uncarried_begins_20260823-023757.txt`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.