### PR TITLE
[BLKOPSCW] findings from Zakkary19, 20260903-183350 (4 names)

### DIFF
--- a/submissions/Zakkary19_BLKOPSCW_20260903-183350/about_20260903-183350.md
+++ b/submissions/Zakkary19_BLKOPSCW_20260903-183350/about_20260903-183350.md
@@ -1,0 +1,38 @@
+# Submission 20260903-183350
+
+- game: **BLKOPSCW**
+- from: Zakkary19
+- names: 4
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- image: 4
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 100 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260903-181553_plan
+- method: uncarried beginnings
+- what it does: the 573 leading segments no cut of which `data/prefixes.txt` carries, against cores from the published names that use them and from everything this machine has confirmed
+- ran for: 16m 34s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- beginnings: 573
+- endings: 4800
+- stems: 239869
+- ids hunted: 110918
+- candidates tested: 659873142537
+- new: 4
+- sketch beginnings: 003acb539c3ec36f0084b979595f86df00ac8133506d429c013c4f1eed00e52d019b13085548754801f06f475d5e01cd022e34e844929260023406f88536a8de04738295a6d5dc970661fb30aa41db08069211787ebe84d506b447482b9b5c4c072f2e665f4fca60077e5a5892a3a55508efecb87a89cb8d093d63aa30ac6a890a7df80f944ea2dc0a8a3ee3821a9c200c6e148aebdba6100ed416e48c1f4beb10305f4ce6a3acb710ae443e5c2e4f6910ba4644e2f2362210e46cfccf95307511282ab2c751df3211b4459b54fb506e11c8b4001f66e92012abcfbc2aa7805f13a71ef39f0565921458682ce02b007b1468bd47616673c615045291765431ba
+- sketch stems: 000063a33732586900006dcf4221638900009d6043da5beb000237540b6e3f930002911d10cffd910002d170e3084a6500035a6d588aa75600035ede9efa5e900003f6860e09096b00041a795924b8050004580ec440bc3700045dbd500476f70004b220cea1973b0004ba2cf231767300053721e203b70500055b459ce7f696000572dad17c593a0005bfae70539563000691ed8bf2501b00069d83370d16da0007062ac4634403000787492ee03c490007b8194b955b970008672ecbe2454e000881f91cb06af30008a20e2daf750d0008a28e6cfebeb70008a618331e0baa0008fbb8f33ee9d600093b33cbd771cf000981d1120ea1a2000989a03fbea75e
+- sketch endings: 00013f24e9c02312000e99746e60cb0c0021ad1c1ec69307006ef56eb12e99de0079e3b242d77715008388613f891ff3009072d9a0fdb056009a7b66951c5917009c15ec9396ebe7009f2d1508ebb20700c54a81d77e708d00c85aaad3ac2ef900e6571a83b53ecb00f216ca5435be4a00f6ff637612aa210104a330f10582350109de0acab502c20113f5c1bdd185dd01209e6672fa09ae0122426a4c250c7901257c80cacd49bb0140a72543eec36d014e5a7b64d98c35017b5fae025c739d017b69b311ad8d88017e3e9d07ed17e00186a019561fbcde0190916401b2b4ca019605d7d622c68601b2b53ee592a84b01b309ae5eed3d5801b3969741599017
+- fingerprint: e609acd3f21e5b4d
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/Zakkary19_BLKOPSCW_20260903-183350/image_20260903-183350.txt
+++ b/submissions/Zakkary19_BLKOPSCW_20260903-183350/image_20260903-183350.txt
@@ -1,0 +1,4 @@
+13a21c8002f33466,hud_mp_notification_war_bronze
+1acbdc051d85f4a8,hud_mp_notification_war_gold
+564025c11036a6ef,hud_mp_notification_war_silver
+6f5612b213bf366c,hud_mp_notification_war_iron


### PR DESCRIPTION
**BLKOPSCW** — 4 asset names, confirmed against that game's own loaded assets.

- image: 4

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Zakkary19

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260903-181553_plan
- method: uncarried beginnings
- what it does: the 573 leading segments no cut of which `data/prefixes.txt` carries, against cores from the published names that use them and from everything this machine has confirmed
- ran for: 16m 34s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- beginnings: 573
- endings: 4800
- stems: 239869
- ids hunted: 110918
- candidates tested: 659873142537
- new: 4
- sketch beginnings: 003acb539c3ec36f0084b979595f86df00ac8133506d429c013c4f1eed00e52d019b13085548754801f06f475d5e01cd022e34e844929260023406f88536a8de04738295a6d5dc970661fb30aa41db08069211787ebe84d506b447482b9b5c4c072f2e665f4fca60077e5a5892a3a55508efecb87a89cb8d093d63aa30ac6a890a7df80f944ea2dc0a8a3ee3821a9c200c6e148aebdba6100ed416e48c1f4beb10305f4ce6a3acb710ae443e5c2e4f6910ba4644e2f2362210e46cfccf95307511282ab2c751df3211b4459b54fb506e11c8b4001f66e92012abcfbc2aa7805f13a71ef39f0565921458682ce02b007b1468bd47616673c615045291765431ba
- sketch stems: 000063a33732586900006dcf4221638900009d6043da5beb000237540b6e3f930002911d10cffd910002d170e3084a6500035a6d588aa75600035ede9efa5e900003f6860e09096b00041a795924b8050004580ec440bc3700045dbd500476f70004b220cea1973b0004ba2cf231767300053721e203b70500055b459ce7f696000572dad17c593a0005bfae70539563000691ed8bf2501b00069d83370d16da0007062ac4634403000787492ee03c490007b8194b955b970008672ecbe2454e000881f91cb06af30008a20e2daf750d0008a28e6cfebeb70008a618331e0baa0008fbb8f33ee9d600093b33cbd771cf000981d1120ea1a2000989a03fbea75e
- sketch endings: 00013f24e9c02312000e99746e60cb0c0021ad1c1ec69307006ef56eb12e99de0079e3b242d77715008388613f891ff3009072d9a0fdb056009a7b66951c5917009c15ec9396ebe7009f2d1508ebb20700c54a81d77e708d00c85aaad3ac2ef900e6571a83b53ecb00f216ca5435be4a00f6ff637612aa210104a330f10582350109de0acab502c20113f5c1bdd185dd01209e6672fa09ae0122426a4c250c7901257c80cacd49bb0140a72543eec36d014e5a7b64d98c35017b5fae025c739d017b69b311ad8d88017e3e9d07ed17e00186a019561fbcde0190916401b2b4ca019605d7d622c68601b2b53ee592a84b01b309ae5eed3d5801b3969741599017
- fingerprint: e609acd3f21e5b4d

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/anim_game_cross_20260903-051624.py`
- `scripts/contributed/anim_symmetry_20260903-051832.py`
- `scripts/contributed/blkops04_sound_asset_dirs_20260826-104215.txt`
- `scripts/contributed/blkops04_sound_asset_ends_20260902-100022.txt`
- `scripts/contributed/blkops04_sound_asset_stems_20260902-100022.txt`
- `scripts/contributed/bo4_sound_hunter_20260902-140851.py`
- `scripts/contributed/bo4_sound_hunter_tails_20260902-140851.txt`
- `scripts/contributed/bo4snd_cores_20260901-010534.txt`
- `scripts/contributed/bo4snd_ends_20260902-095559.txt`
- `scripts/contributed/cdl_cosmetics_20260903-045836.py`
- `scripts/contributed/chan_ends_20260902-113127.txt`
- `scripts/contributed/cross_generation_tag_20260903-084113.py`
- `scripts/contributed/family_shared_tails_20260902-182738.py`
- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/image_siblings_wide_20260902-120635.py`
- `scripts/contributed/materials_from_images_wide_20260902-121208.py`
- `scripts/contributed/measured_shells_20260902-182738.py`
- `scripts/contributed/numbered_grids_20260821-054219.py`
- `scripts/contributed/surface_sound_grid_20260903-045836.py`
- `scripts/contributed/weapon_anim_grid_20260903-052015.py`
- `scripts/contributed/xanim_final_byte_20260903-061522.py`
- `scripts/contributed/xmodel_pairs_20260902-153205.py`
- `scripts/contributed/zombie_models_20260902-182738.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.