### PR TITLE
[BLKOPS04] findings from Zakkary19, 20260904-054230 (7 names)

### DIFF
--- a/scripts/contributed/bo4_zmb_ai_sounds_20260904-054230.py
+++ b/scripts/contributed/bo4_zmb_ai_sounds_20260904-054230.py
@@ -1,0 +1,96 @@
+"""Systematic generator for Black Ops 4 Zombie AI sound assets.
+
+Uses exact directory structures from bo4_snd_dirs for all zombie enemy types
+(werewolf, spartoi, hellephant, gladiator, nosferatu, blightfather, catalyst,
+hellhounds, tiger, quads, nos_bat, standard zombie).
+"""
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+import snapshot
+
+TAILS = (
+    ".ln100.pc.snd",
+    ".ll100.pc.snd",
+    ".sn100.pc.snd",
+    ".sl100.pc.snd",
+    ".pn100.pc.snd",
+    ".pl100.pc.snd",
+)
+
+def generate():
+    candidates = set()
+    
+    # Read bo4 sound dirs
+    snd_dirs_file = ROOT / "scripts" / "contributed" / "bo4_snd_dirs_20260823-030223.txt"
+    all_dirs = [l.strip() for l in snd_dirs_file.read_text().splitlines() if l.strip()]
+    zmb_ai_dirs = [d for d in all_dirs if d.startswith("zmb\\ai\\")]
+    
+    # Enemy prefixes
+    enemy_map = {
+        "werewolf": ["wwolf_", "werewolf_", ""],
+        "spartoi": ["spartoi_", ""],
+        "hellephant": ["hellephant_", "elephant_", ""],
+        "gladiator": ["gladiator_", "destroyer_", "marauder_", ""],
+        "nosferatu": ["nosferatu_", "nos_", ""],
+        "nos_bat": ["nos_bat_", "bat_", ""],
+        "blightfather": ["blightfather_", "blight_", ""],
+        "catalyst": ["catalyst_", ""],
+        "hellhounds": ["fly_hellhound_", "hellhound_", ""],
+        "tiger": ["tiger_", ""],
+        "stoker": ["stoker_", ""],
+        "quads": ["quad_", "quads_", ""],
+        "standard": ["zmb_", "vox_zmb_", "vox_", ""],
+    }
+
+    for d in zmb_ai_dirs:
+        # Determine enemy
+        parts = d.rstrip("\\").split("\\")
+        enemy = parts[1] if len(parts) > 1 else ""
+        leaf = parts[-1]
+        
+        # Base names derived from leaf
+        prefixes = enemy_map.get(enemy, [""])
+        
+        base_stems = set()
+        # Leaf action directly
+        base_stems.add(leaf)
+        if leaf.endswith("_2.0"):
+            base_stems.add(leaf[:-4])
+        
+        # Variations on leaf
+        if leaf in ("atk", "attack", "swing", "sword_swipe", "axe_swing", "melee"):
+            base_stems.update(["attack", "atk", "swing", "attack_swipe", "swipe", "melee"])
+        elif leaf in ("amb", "ambient"):
+            base_stems.update(["amb", "ambient", "growl", "idle"])
+        elif leaf in ("death", "pain", "scream", "roar", "howl", "growl"):
+            base_stems.update(["death", "pain", "scream", "roar", "howl", "growl"])
+        elif leaf.startswith("series_"):
+            # Inside series_1, series_2, etc. Parent is action (e.g. amb, attack, pain, sprint)
+            parent_act = parts[-2] if len(parts) > 2 else "amb"
+            base_stems.update([parent_act, f"{parent_act}_{leaf}"])
+            
+        for pfx in prefixes:
+            for stem in base_stems:
+                for i in range(25):
+                    # Unnumbered and numbered
+                    for tail in TAILS:
+                        candidates.add(f"{d}{pfx}{stem}_{i:02d}{tail}")
+                        candidates.add(f"{d}{pfx}{stem}_{i}{tail}")
+                        if i == 0:
+                            candidates.add(f"{d}{pfx}{stem}{tail}")
+                            candidates.add(f"{d}{pfx}{stem}_lp{tail}")
+                            candidates.add(f"{d}{pfx}{stem}_loop{tail}")
+
+    return sorted(candidates)
+
+def main():
+    cands = generate()
+    print(f"Generated {len(cands):,} candidate names", file=sys.stderr)
+    for c in cands:
+        print(c)
+
+if __name__ == "__main__":
+    main()

--- a/submissions/Zakkary19_BLKOPS04_20260904-054230/about_20260904-054230.md
+++ b/submissions/Zakkary19_BLKOPS04_20260904-054230/about_20260904-054230.md
@@ -1,0 +1,35 @@
+# Submission 20260904-054230
+
+- game: **BLKOPS04**
+- from: Zakkary19
+- names: 7
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- sound_asset: 7
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 10 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260904-054214_list
+- method: an unnamed method
+- what it does: a candidate list generated outside the search and confirmed here
+- ran for: 1s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- candidates tested: 7
+- matched: 7
+- new: 7
+- sketch stems: 303c3df4a297ebe16562e33a536e9995960bad535db68a2fab0f967e0262c7f3c64536828e9c5b5ee2923430179dd17ef6633d6cebac3460
+- ids hunted: 148211
+- throughput: 0.0M candidates/s
+- fingerprint: beaee93cb00c396e
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/Zakkary19_BLKOPS04_20260904-054230/sound_asset_20260904-054230.txt
+++ b/submissions/Zakkary19_BLKOPS04_20260904-054230/sound_asset_20260904-054230.txt
@@ -1,0 +1,7 @@
+c5a4eb3d8d321b1,zmb\ai\werewolf\vox\pain_2.0\wwolf_pain_02.ln100.pc.snd
+2cd94afc9291fc0d,zmb\ai\werewolf\vox\pain_2.0\wwolf_pain_06.ln100.pc.snd
+2dbdfbc69b43fde6,zmb\ai\werewolf\vox\pain_2.0\wwolf_pain_01.ln100.pc.snd
+2f8f647b47219002,zmb\ai\werewolf\vox\pain_2.0\wwolf_pain_05.ln100.pc.snd
+51d194b531330e6c,zmb\ai\werewolf\vox\pain_2.0\wwolf_pain_03.ln100.pc.snd
+592c63cbacc6d7ff,zmb\ai\werewolf\vox\pain_2.0\wwolf_pain_04.ln100.pc.snd
+72406e5b660b1203,zmb\ai\werewolf\vox\pain_2.0\wwolf_pain_00.ln100.pc.snd


### PR DESCRIPTION
**BLKOPS04** — 7 asset names, confirmed against that game's own loaded assets.

- sound_asset: 7

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Zakkary19

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260904-054214_list
- method: an unnamed method
- what it does: a candidate list generated outside the search and confirmed here
- ran for: 1s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- candidates tested: 7
- matched: 7
- new: 7
- sketch stems: 303c3df4a297ebe16562e33a536e9995960bad535db68a2fab0f967e0262c7f3c64536828e9c5b5ee2923430179dd17ef6633d6cebac3460
- ids hunted: 148211
- throughput: 0.0M candidates/s
- fingerprint: beaee93cb00c396e

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/anim_game_cross_20260903-051624.py`
- `scripts/contributed/anim_symmetry_20260903-051832.py`
- `scripts/contributed/announcer_grid_20260904-004645.py`
- `scripts/contributed/blkops04_sound_asset_dirs_20260826-104215.txt`
- `scripts/contributed/blkops04_sound_asset_ends_20260902-100022.txt`
- `scripts/contributed/blkops04_sound_asset_stems_20260902-100022.txt`
- `scripts/contributed/bo4_sound_hunter_20260902-140851.py`
- `scripts/contributed/bo4_sound_hunter_tails_20260902-140851.txt`
- `scripts/contributed/bo4_zmb_ai_sounds_20260904-054230.py`
- `scripts/contributed/bo4snd_cores_20260901-010534.txt`
- `scripts/contributed/bo4snd_ends_20260902-095559.txt`
- `scripts/contributed/cdl_cosmetics_20260903-045836.py`
- `scripts/contributed/chan_ends_20260831-165139.txt`
- `scripts/contributed/cross_generation_tag_20260903-084113.py`
- `scripts/contributed/family_shared_tails_20260902-182738.py`
- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/image_siblings_wide_20260902-120635.py`
- `scripts/contributed/materials_from_images_wide_20260902-121208.py`
- `scripts/contributed/measured_shells_20260902-182738.py`
- `scripts/contributed/numbered_grids_20260821-054219.py`
- `scripts/contributed/surface_sound_grid_20260903-045836.py`
- `scripts/contributed/weapon_anim_grid_20260903-052015.py`
- `scripts/contributed/xanim_final_byte_20260903-061522.py`
- `scripts/contributed/xmodel_pairs_20260902-153205.py`
- `scripts/contributed/zombie_models_20260902-182738.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.