### PR TITLE
[BLKOPSCW] findings from Zakkary19, 20260904-065107 (7 names)

### DIFF
--- a/submissions/Zakkary19_BLKOPSCW_20260904-065107/about_20260904-065107.md
+++ b/submissions/Zakkary19_BLKOPSCW_20260904-065107/about_20260904-065107.md
@@ -1,0 +1,42 @@
+# Submission 20260904-065107
+
+- game: **BLKOPSCW**
+- from: Zakkary19
+- names: 7
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- sound_asset: 7
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 20 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260904-063758_soundfiles
+- method: sound files and aliases (confirm_cw --sounds)
+- what it does: every seed cut to pieces at its marks and recombined as beginning + stem + ending, each candidate hashed and looked up among the game's unnamed ids
+- ran for: 12m 35s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- pools searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- seed lines: 3372652
+- distinct pieces: 32293012
+- beginnings: 700
+- endings: 2890
+- ids hunted: 30802
+- candidates tested: 65444727482092
+- matches: 35
+- distinct names reached: 7
+- new here: 7
+- sketch beginnings: 0144986374223e9c01aa23ff78c43bf70292cf42f42b4aea02d4b4351224cbfa03373c2108c69fff0396afaecc460bbc039dd5d99e2f9d1104ce2334f3e0deb10555ec5ec24c247c05ee597280f1d5a306612a8a75156bff06871617c79df54607101de92871b64407231e76b02644f30774cc8667cecc64077d0f86fe9f7aa7078a51db4589c13e07adf38428243a5607c66c9c56614c360808972299f305bd090022b3599273320907ad5a1855b48109d289302e2fce7e0a2b9e892b5ec77d0a50bf0b7d5463340a5a33ac9531bfbf0a8812dc36d6d0070a9d14b92833a9d20b0d4c2208bed6610b2a8b88a8bf9bdf0b777e1055572b650b792a25745e3147
+- sketch stems: 0000003d0b47de55000000d45e0ab3780000013723f320a30000016a4ab426f7000001bc85c24ba9000001c029a8efd70000024fa9031a32000002a3bce4ea7d0000034514625b510000038d3139e634000004259ad9a28900000491769b2dcb000004cf8f880bd4000005c8a9699da00000069733a15329000007da7ab81343000008527395fce00000095ca492a028000009ac7953308b00000ab4ba1aeee400000ac9194dd2c300000b61d1f9c0d000000bf2fcc0175f00000c117bc1e74e00000c3f4f949a9e00000c5e26ddd31500000c76c90665c700000cb0e2df3f6900000d2f6c89fd3100000d4a310a34d800000d70dcf0d5eb00000dd14f3c6f1a
+- sketch endings: 0021ad1c1ec6930700255f82a3722ab90067c12c53bd8af800756a1875f8f3310079e3b242d77715007ac06c033e18f2009072d9a0fdb05600ae971c503f3d9800c3cae55cbba0c800c4da67057742ff00fc46b2041ceec50113f5c1bdd185dd01209e6672fa09ae01499de0440f5952017b5fae025c739d0190916401b2b4ca01ba3a794398981301bc0d82939e166901f3231a898024470209afb75a2b7ec2021bdcd8518ed867025dbe9ead38bdb5025f7de0512cd85a0277fb222ccb4976027ab07d1457713c027d69e2d4f44b9402a31c384f5fc27c02d056c6cc92c88b03145f24dfbd79470339e127fb8b79f4034533951d9874cc0373d851957f0390
+- fingerprint: cec02174c2d71780
+
+**Next:** this configuration is now exhausted, and what reopens it is different ground rather than a different name. Re-measuring the lists is not the remedy this line used to recommend: measured over three consecutive folds it returned 55 names, then 294, then 51, the last on a corpus two and a half times larger. It changes the fingerprint without changing what the search can reach, and following it is most of how the yield here collapsed. Run a method that reaches somewhere else -- METHODS.md says what each one gets at that nothing else does -- or invent one: `confirm_list` takes candidate names on standard input, so a method is a script that prints names.

--- a/submissions/Zakkary19_BLKOPSCW_20260904-065107/sound_asset_20260904-065107.txt
+++ b/submissions/Zakkary19_BLKOPSCW_20260904-065107/sound_asset_20260904-065107.txt
@@ -1,0 +1,7 @@
+1885fdc0f1c4a71,zmb/ai/werewolf/vox/pain_2.0/wwolf_pain_03.rn75.pc.all.snd
+98d8564e853b1ac,zmb/ai/werewolf/vox/pain_2.0/wwolf_pain_00.rn75.pc.all.snd
+1f4686be8e743c77,zmb/ai/werewolf/vox/pain_2.0/wwolf_pain_01.rn75.pc.all.snd
+6592681d78d5a2e8,zmb/ai/werewolf/vox/pain_2.0/wwolf_pain_04.rn75.pc.all.snd
+65fabb5d3e212bc6,zmb/ai/werewolf/vox/pain_2.0/wwolf_pain_02.rn75.pc.all.snd
+69a5ac01575778e3,zmb/ai/werewolf/vox/pain_2.0/wwolf_pain_05.rn75.pc.all.snd
+7c42a983d69114c2,zmb/ai/werewolf/vox/pain_2.0/wwolf_pain_06.rn75.pc.all.snd


### PR DESCRIPTION
**BLKOPSCW** — 7 asset names, confirmed against that game's own loaded assets.

- sound_asset: 7

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Zakkary19

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260904-063758_soundfiles
- method: sound files and aliases (confirm_cw --sounds)
- what it does: every seed cut to pieces at its marks and recombined as beginning + stem + ending, each candidate hashed and looked up among the game's unnamed ids
- ran for: 12m 35s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- pools searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
- seed lines: 3372652
- distinct pieces: 32293012
- beginnings: 700
- endings: 2890
- ids hunted: 30802
- candidates tested: 65444727482092
- matches: 35
- distinct names reached: 7
- new here: 7
- sketch beginnings: 0144986374223e9c01aa23ff78c43bf70292cf42f42b4aea02d4b4351224cbfa03373c2108c69fff0396afaecc460bbc039dd5d99e2f9d1104ce2334f3e0deb10555ec5ec24c247c05ee597280f1d5a306612a8a75156bff06871617c79df54607101de92871b64407231e76b02644f30774cc8667cecc64077d0f86fe9f7aa7078a51db4589c13e07adf38428243a5607c66c9c56614c360808972299f305bd090022b3599273320907ad5a1855b48109d289302e2fce7e0a2b9e892b5ec77d0a50bf0b7d5463340a5a33ac9531bfbf0a8812dc36d6d0070a9d14b92833a9d20b0d4c2208bed6610b2a8b88a8bf9bdf0b777e1055572b650b792a25745e3147
- sketch stems: 0000003d0b47de55000000d45e0ab3780000013723f320a30000016a4ab426f7000001bc85c24ba9000001c029a8efd70000024fa9031a32000002a3bce4ea7d0000034514625b510000038d3139e634000004259ad9a28900000491769b2dcb000004cf8f880bd4000005c8a9699da00000069733a15329000007da7ab81343000008527395fce00000095ca492a028000009ac7953308b00000ab4ba1aeee400000ac9194dd2c300000b61d1f9c0d000000bf2fcc0175f00000c117bc1e74e00000c3f4f949a9e00000c5e26ddd31500000c76c90665c700000cb0e2df3f6900000d2f6c89fd3100000d4a310a34d800000d70dcf0d5eb00000dd14f3c6f1a
- sketch endings: 0021ad1c1ec6930700255f82a3722ab90067c12c53bd8af800756a1875f8f3310079e3b242d77715007ac06c033e18f2009072d9a0fdb05600ae971c503f3d9800c3cae55cbba0c800c4da67057742ff00fc46b2041ceec50113f5c1bdd185dd01209e6672fa09ae01499de0440f5952017b5fae025c739d0190916401b2b4ca01ba3a794398981301bc0d82939e166901f3231a898024470209afb75a2b7ec2021bdcd8518ed867025dbe9ead38bdb5025f7de0512cd85a0277fb222ccb4976027ab07d1457713c027d69e2d4f44b9402a31c384f5fc27c02d056c6cc92c88b03145f24dfbd79470339e127fb8b79f4034533951d9874cc0373d851957f0390
- fingerprint: cec02174c2d71780

**Next:** this configuration is now exhausted, and what reopens it is different ground rather than a different name. Re-measuring the lists is not the remedy this line used to recommend: measured over three consecutive folds it returned 55 names, then 294, then 51, the last on a corpus two and a half times larger. It changes the fingerprint without changing what the search can reach, and following it is most of how the yield here collapsed. Run a method that reaches somewhere else -- METHODS.md says what each one gets at that nothing else does -- or invent one: `confirm_list` takes candidate names on standard input, so a method is a script that prints names.


## Tooling this run leaves behind

- `scripts/contributed/anim_game_cross_20260903-051624.py`
- `scripts/contributed/anim_symmetry_20260903-051832.py`
- `scripts/contributed/announcer_grid_20260904-004645.py`
- `scripts/contributed/blkops04_sound_asset_dirs_20260826-104215.txt`
- `scripts/contributed/blkops04_sound_asset_ends_20260902-100022.txt`
- `scripts/contributed/blkops04_sound_asset_stems_20260902-100022.txt`
- `scripts/contributed/bo2_bo3_sab_to_bo4_20260904-063516.py`
- `scripts/contributed/bo4_blackmarket_grid_20260904-061818.py`
- `scripts/contributed/bo4_blackout_destinations_20260904-061818.py`
- `scripts/contributed/bo4_mastercraft_themes_20260904-063516.py`
- `scripts/contributed/bo4_mk2_blackmarket_20260904-063516.py`
- `scripts/contributed/bo4_music_sound_assets_20260904-063516.py`
- `scripts/contributed/bo4_sound_asset_gaps_20260904-061818.py`
- `scripts/contributed/bo4_sound_cw_transplant_20260904-061818.py`
- `scripts/contributed/bo4_sound_hunter_20260902-140851.py`
- `scripts/contributed/bo4_sound_hunter_tails_20260902-140851.txt`
- `scripts/contributed/bo4_wpn_sounds_probe_20260904-061818.py`
- `scripts/contributed/bo4_zmb_ai_sounds_20260904-054230.py`
- `scripts/contributed/bo4_zmb_boss_sounds_20260904-061017.py`
- `scripts/contributed/bo4snd_cores_20260901-010534.txt`
- `scripts/contributed/bo4snd_ends_20260902-095559.txt`
- `scripts/contributed/cdl_cosmetics_20260903-045836.py`
- `scripts/contributed/chan_ends_20260831-165139.txt`
- `scripts/contributed/cross_gen_p7_p8_p9_20260904-063516.py`
- `scripts/contributed/cross_generation_tag_20260903-084113.py`
- `scripts/contributed/cw_executions_probe_20260904-060736.py`
- `scripts/contributed/cw_intros_probe_20260904-061403.py`
- `scripts/contributed/cw_operator_vox_grid_20260904-063516.py`
- `scripts/contributed/family_shared_tails_20260902-182738.py`
- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/image_siblings_wide_20260902-120635.py`
- `scripts/contributed/materials_from_images_wide_20260902-121208.py`
- `scripts/contributed/measured_shells_20260902-182738.py`
- `scripts/contributed/numbered_grids_20260821-054219.py`
- `scripts/contributed/surface_sound_grid_20260903-045836.py`
- `scripts/contributed/weapon_anim_grid_20260903-052015.py`
- `scripts/contributed/xanim_final_byte_20260903-061522.py`
- `scripts/contributed/xmodel_pairs_20260902-153205.py`
- `scripts/contributed/zombie_models_20260902-182738.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.