### PR TITLE
[BLKOPSCW] findings from Hexeption, 20260904-070316 (2 names)

### DIFF
--- a/scripts/contributed/cw_xmodel_view_world_20260904-070316.py
+++ b/scripts/contributed/cw_xmodel_view_world_20260904-070316.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Fill terminal `_view`/`_world` xmodel mirrors from recovered CW xmodels."""
+from collections import defaultdict
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = ROOT / "all_names" / "blkopscw" / "xmodel.txt"
+ENDS = ("view", "world")
+MIN_CONTROLS = 50
+
+
+def split_end(name: str):
+    for ending in ENDS:
+        marker = "_" + ending
+        if name.endswith(marker) and len(name) > len(marker) + 4:
+            return name[:-len(marker)], ending
+    return None
+
+
+def main() -> None:
+    known = set()
+    for line in SOURCE.read_text(encoding="utf-8", errors="ignore").splitlines():
+        _, _, name = line.partition(",")
+        if name:
+            known.add(name.strip().lower().replace("\\", "/"))
+    grouped = defaultdict(set)
+    for name in known:
+        parsed = split_end(name)
+        if parsed:
+            base, ending = parsed
+            grouped[base].add(ending)
+    controls = sum(1 for seen in grouped.values() if len(seen) == len(ENDS))
+    if controls < MIN_CONTROLS:
+        return
+    candidates = {
+        f"{base}_{ending}"
+        for base, seen in grouped.items()
+        if len(seen) == 1
+        for ending in ENDS if ending not in seen
+    }
+    print("\n".join(sorted(candidates)))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/contributed/figglefx_bo4_fx_beams_20260904-070316.py
+++ b/scripts/contributed/figglefx_bo4_fx_beams_20260904-070316.py
@@ -1,0 +1,24 @@
+"""Emit FiggleFX's separate verified BO4 beam and FX-name exports."""
+
+from pathlib import Path
+import sys
+
+
+ROOT = Path("borrowed/FiggleFX/hashes")
+SOURCES = (ROOT / "beams_recovered.csv", ROOT / "fx_names.csv")
+
+
+def main() -> None:
+    sys.stdout.reconfigure(encoding="utf-8")
+    seen: set[str] = set()
+    for source in SOURCES:
+        for raw in source.read_text(encoding="utf-8", errors="replace").splitlines():
+            _hash, separator, name = raw.partition(",")
+            name = name.strip()
+            if separator and name and name not in seen:
+                seen.add(name)
+                print(name)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/contributed/modme_typed_manifest_literals_20260904-070316.py
+++ b/scripts/contributed/modme_typed_manifest_literals_20260904-070316.py
@@ -1,0 +1,22 @@
+"""Emit explicit typed asset-manifest labels from the frozen ModMe forum archive."""
+
+from pathlib import Path
+import re
+
+
+ROOT = Path("borrowed/ModmeForum")
+ROW = re.compile(
+    r"(?im)^\s*(?:xmodel|xanim|ximage|xmaterial|material|image)\s*,\s*"
+    r"([A-Za-z0-9_./\\-]{3,240})\s*$"
+)
+
+
+def main() -> None:
+    names: set[str] = set()
+    for source in ROOT.rglob("*.md"):
+        names.update(ROW.findall(source.read_text(encoding="utf-8", errors="replace")))
+    print("\n".join(sorted(names)))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/contributed/terminal_pair_counterparts_20260904-070316.py
+++ b/scripts/contributed/terminal_pair_counterparts_20260904-070316.py
@@ -1,0 +1,120 @@
+"""Try previously unseen, well-controlled terminal-token counterpart pairs.
+
+Only alphabetic final underscore tokens are considered.  A pair is eligible only
+when at least 20 exact same-base names carry both sides, and the established
+prone/stand, L/R, diagonal, left/right, exo1/exo2, and view/world relations are
+excluded.  This is deliberately a single census, not a state-grid generator.
+"""
+
+import argparse
+import collections
+import os
+import re
+import sys
+
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+while ROOT != os.path.dirname(ROOT) and not os.path.isfile(
+    os.path.join(ROOT, "scripts", "snapshot.py")
+):
+    ROOT = os.path.dirname(ROOT)
+sys.path.insert(0, os.path.join(ROOT, "scripts"))
+
+import snapshot
+
+
+TABLES = (
+    "fnv1a_xmodels",
+    "fnv1a_xmaterials",
+    "fnv1a_ximages",
+    "fnv1a_xanims",
+    "fnv1a_xsounds",
+    "fnv1a_soundbanks_aliases",
+)
+TOKEN = re.compile(r"^[a-z]+$")
+EXCLUDED = {
+    frozenset(("prone", "stand")),
+    frozenset(("l", "r")),
+    frozenset(("fl", "fr")),
+    frozenset(("bl", "br")),
+    frozenset(("left", "right")),
+    frozenset(("exo1", "exo2")),
+    frozenset(("view", "world")),
+}
+MAX_TOKENS_PER_BASE = 8
+
+
+def corpus() -> set[str]:
+    names = set(snapshot.table_names(*TABLES))
+    names.update(snapshot.confirmed_names())
+    return {
+        name.strip().lower().replace("\\", "/")
+        for name in names
+        if name.strip() and len(name) <= 240
+    }
+
+
+def split(name: str) -> tuple[str, str] | None:
+    base, separator, token = name.rpartition("_")
+    if not separator or not base or not TOKEN.fullmatch(token):
+        return None
+    return base, token
+
+
+def candidates(known: set[str], minimum_controls: int) -> tuple[set[str], int, int]:
+    families: dict[str, set[str]] = collections.defaultdict(set)
+    for name in known:
+        parsed = split(name)
+        if parsed:
+            base, token = parsed
+            families[base].add(token)
+
+    controls: collections.Counter[frozenset[str]] = collections.Counter()
+    # Large terminal sets are state grids; they neither provide a constrained
+    # counterpart relation nor justify quadratic pair enumeration.
+    families = {
+        base: tokens
+        for base, tokens in families.items()
+        if len(tokens) <= MAX_TOKENS_PER_BASE
+    }
+    for tokens in families.values():
+        for left in tokens:
+            for right in tokens:
+                if left < right:
+                    controls[frozenset((left, right))] += 1
+
+    eligible = {
+        pair
+        for pair, count in controls.items()
+        if count >= minimum_controls and pair not in EXCLUDED
+    }
+    output: set[str] = set()
+    for base, tokens in families.items():
+        for pair in eligible:
+            left, right = tuple(pair)
+            if left in tokens and right not in tokens:
+                output.add(f"{base}_{right}")
+            elif right in tokens and left not in tokens:
+                output.add(f"{base}_{left}")
+    return output - known, len(eligible), sum(controls[pair] for pair in eligible)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--count", action="store_true")
+    parser.add_argument("--min-controls", type=int, default=20)
+    options = parser.parse_args()
+    known = corpus()
+    output, pairs, controls = candidates(known, options.min_controls)
+    print(
+        f"{len(known):,} known names; {pairs:,} eligible terminal pairs at "
+        f"{options.min_controls:,}+ controls; "
+        f"{controls:,} complete-base controls; {len(output):,} unseen candidates",
+        file=sys.stderr,
+    )
+    if not options.count:
+        print("\n".join(sorted(output)))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/contributed/xcortland_bo4_assetlog_strings_20260904-070316.py
+++ b/scripts/contributed/xcortland_bo4_assetlog_strings_20260904-070316.py
@@ -1,0 +1,36 @@
+"""Emit literal BO4 build strings from xCortlandx/fnvHashFinder's AssetLog archive.
+
+The archive's Anim, Image, Material, Model, and Sound records are mostly generated
+hash labels.  Its String records, in contrast, are literal names extracted from the
+BO4 build and include structured asset-family fragments.  Keep only ordinary
+asset-name characters so confirm_list receives the source text unchanged.
+"""
+
+from pathlib import Path
+import re
+
+
+SOURCE = Path("borrowed/fnvHashFinder/AssetLogs/AssetLog_BO4.txt")
+NAME = re.compile(r"^[A-Za-z0-9_./\\-]+$")
+
+
+def main() -> None:
+    seen: set[str] = set()
+    with SOURCE.open("r", encoding="utf-8", errors="replace") as source:
+        for raw in source:
+            kind, separator, name = raw.rstrip("\r\n").partition(",")
+            if (
+                kind != "String"
+                or not separator
+                or not 3 <= len(name) <= 240
+                or not NAME.fullmatch(name)
+                or sum(character.isalpha() for character in name) < 3
+                or name in seen
+            ):
+                continue
+            seen.add(name)
+            print(name)
+
+
+if __name__ == "__main__":
+    main()

--- a/submissions/Hexeption_BLKOPSCW_20260904-070316/about_20260904-070316.md
+++ b/submissions/Hexeption_BLKOPSCW_20260904-070316/about_20260904-070316.md
@@ -1,0 +1,35 @@
+# Submission 20260904-070316
+
+- game: **BLKOPSCW**
+- from: Hexeption
+- names: 2
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- material: 2
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 22 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260904-070148_list
+- method: high-control terminal token counterparts
+- what it does: alphabetic terminal counterparts with 100+ exact same-base controls; closed pairs and grids excluded
+- ran for: 28s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- candidates tested: 2065021
+- matched: 2
+- new: 2
+- sketch stems: 00000af234f70d0a000014b96c79cc3d000017d06dee78c5000021d60eb05f1c000027f41837bccf00002b6cb376d85600002c62017ee7750000411ce82002be0000473ee8fa84df000054fbe6ae5a1000005cb01562dc1300005d0ed36c5a0300006086707e6ebf0000629afd919599000066916edb750f000067df0de6d53e0000750efd34276a0000817aac851fb3000093f899210cce0000ac84041e550c0000b527a832515d0000b83334faa2bb0000bd96dfe376a60000be0d6d15b58a0000c0b765c8bdfa0000c3f1cc6a3ea40000c63116955f850000cc2c8a694d920000d99cbce6fc8e0000da3d58e1e2630000df8a27b1f9b50000e8d901575b71
+- ids hunted: 109211
+- throughput: 0.1M candidates/s
+- fingerprint: 3044eff1b7602c0d
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/Hexeption_BLKOPSCW_20260904-070316/material_20260904-070316.txt
+++ b/submissions/Hexeption_BLKOPSCW_20260904-070316/material_20260904-070316.txt
@@ -1,0 +1,2 @@
+43d08038ce3a6c42,mc/mtl_veh_t9_civ_truck_semi_80s_base_body_roof_reflector_snow
+4589b5fac71fff1f,mc/mtl_veh_t9_civ_truck_semi_80s_base_body_front_d_plastic_orange_snow


### PR DESCRIPTION
**BLKOPSCW** — 2 asset names, confirmed against that game's own loaded assets.

- material: 2

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Hexeption

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260904-070148_list
- method: high-control terminal token counterparts
- what it does: alphabetic terminal counterparts with 100+ exact same-base controls; closed pairs and grids excluded
- ran for: 28s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- candidates tested: 2065021
- matched: 2
- new: 2
- sketch stems: 00000af234f70d0a000014b96c79cc3d000017d06dee78c5000021d60eb05f1c000027f41837bccf00002b6cb376d85600002c62017ee7750000411ce82002be0000473ee8fa84df000054fbe6ae5a1000005cb01562dc1300005d0ed36c5a0300006086707e6ebf0000629afd919599000066916edb750f000067df0de6d53e0000750efd34276a0000817aac851fb3000093f899210cce0000ac84041e550c0000b527a832515d0000b83334faa2bb0000bd96dfe376a60000be0d6d15b58a0000c0b765c8bdfa0000c3f1cc6a3ea40000c63116955f850000cc2c8a694d920000d99cbce6fc8e0000da3d58e1e2630000df8a27b1f9b50000e8d901575b71
- ids hunted: 109211
- throughput: 0.1M candidates/s
- fingerprint: 3044eff1b7602c0d

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/cw_xmodel_view_world_20260904-070316.py`
- `scripts/contributed/figglefx_bo4_fx_beams_20260904-070316.py`
- `scripts/contributed/modme_typed_manifest_literals_20260904-070316.py`
- `scripts/contributed/terminal_pair_counterparts_20260904-070316.py`
- `scripts/contributed/xcortland_bo4_assetlog_strings_20260904-070316.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.