### PR TITLE
[BLKOPS04] findings from Hexeption, 20260904-073121 (2 names)

### DIFF
--- a/scripts/contributed/material_clt_to_cltp_20260904-073121.py
+++ b/scripts/contributed/material_clt_to_cltp_20260904-073121.py
@@ -1,0 +1,44 @@
+"""Emit exact material cores observed under clt/ but absent under cltp/.
+
+The directional relation is admitted only because 2,531 complete full-core
+clt/cltp controls establish cltp as a strict subset.  It changes no basename
+byte and is intentionally not a general material-directory sweep.
+"""
+
+from pathlib import Path
+import sys
+
+
+ROOT = Path.cwd()
+sys.path.insert(0, str(ROOT / "scripts"))
+import snapshot
+
+
+SOURCE = "clt/"
+TARGET = "cltp/"
+
+
+def main() -> None:
+    known = {
+        name.strip().lower().replace("\\", "/")
+        for name in snapshot.table_names("fnv1a_xmaterials")
+        if name.strip()
+    }
+    known.update(
+        name.strip().lower().replace("\\", "/")
+        for name in snapshot.confirmed_names("material")
+        if name.strip()
+    )
+    source_cores = {name[len(SOURCE) :] for name in known if name.startswith(SOURCE)}
+    target_cores = {name[len(TARGET) :] for name in known if name.startswith(TARGET)}
+    controls = len(source_cores & target_cores)
+    candidates = {TARGET + core for core in source_cores - target_cores}
+    print(
+        f"{controls:,} clt/cltp exact-core controls; {len(candidates):,} clt-only candidates",
+        file=sys.stderr,
+    )
+    print("\n".join(sorted(candidates)))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/contributed/phantom_t8_hash_map_20260904-073121.py
+++ b/scripts/contributed/phantom_t8_hash_map_20260904-073121.py
@@ -1,0 +1,22 @@
+"""Emit literal labels from Lurkzy/phantom-t8's versioned BO4 hash map."""
+
+from pathlib import Path
+import re
+
+
+SOURCE = Path("borrowed/phantom-t8/hashes.txt")
+NAME = re.compile(r"^[A-Za-z0-9_./\\-]{3,240}$")
+
+
+def main() -> None:
+    names: set[str] = set()
+    for raw in SOURCE.read_text(encoding="utf-8", errors="replace").splitlines():
+        _hash, separator, name = raw.partition(",")
+        name = name.strip()
+        if separator and NAME.fullmatch(name) and sum(char.isalpha() for char in name) >= 3:
+            names.add(name)
+    print("\n".join(sorted(names)))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/contributed/reversible_endpoint_swaps_20260904-073121.py
+++ b/scripts/contributed/reversible_endpoint_swaps_20260904-073121.py
@@ -1,0 +1,83 @@
+"""Swap endpoints around an unchanged token only for observed reversible triples.
+
+For an interior ``left_middle_right`` triple, emit ``right_middle_left`` only
+when that reverse triple occurs in a real name somewhere in the corpus.  The
+directory and every other token stay fixed.  This is a distance-two, in-place
+relation, not an adjacent-token permutation or fragment recombination.
+"""
+
+from pathlib import Path
+import sys
+
+
+ROOT = Path.cwd()
+sys.path.insert(0, str(ROOT / "scripts"))
+import snapshot
+
+
+TABLES = (
+    "fnv1a_xmodels",
+    "fnv1a_xmaterials",
+    "fnv1a_ximages",
+    "fnv1a_xanims",
+    "fnv1a_soundbanks_aliases",
+)
+
+
+def corpus() -> set[str]:
+    names = set(snapshot.table_names(*TABLES))
+    names.update(snapshot.confirmed_names())
+    return {
+        name.strip().lower().replace("\\", "/")
+        for name in names
+        if name.strip() and len(name) <= 240
+    }
+
+
+def split(name: str) -> tuple[str, list[str]] | None:
+    directory, marker, basename = name.rpartition("/")
+    if "." in basename:
+        return None
+    tokens = basename.split("_")
+    if len(tokens) < 3 or any(not token for token in tokens):
+        return None
+    return (directory + marker if marker else ""), tokens
+
+
+def main() -> None:
+    known = corpus()
+    parsed = [item for name in known if (item := split(name))]
+    triples = {
+        (tokens[index - 1], tokens[index], tokens[index + 1])
+        for _, tokens in parsed
+        for index in range(1, len(tokens) - 1)
+    }
+    reversible = {
+        triple
+        for triple in triples
+        if (triple[2], triple[1], triple[0]) in triples and triple[0] != triple[2]
+    }
+    output: set[str] = set()
+    controls = 0
+    for directory, tokens in parsed:
+        for index in range(1, len(tokens) - 1):
+            triple = (tokens[index - 1], tokens[index], tokens[index + 1])
+            if triple not in reversible:
+                continue
+            changed = list(tokens)
+            changed[index - 1], changed[index + 1] = changed[index + 1], changed[index - 1]
+            candidate = directory + "_".join(changed)
+            if candidate in known:
+                controls += 1
+            else:
+                output.add(candidate)
+    print(
+        f"{len(known):,} known names; {len(reversible):,} reversible triples; "
+        f"{controls:,} full-name controls; {len(output):,} unseen candidates",
+        file=sys.stderr,
+    )
+    print("\n".join(sorted(output)))
+
+
+if __name__ == "__main__":
+    main()

--- a/submissions/Hexeption_BLKOPS04_20260904-073121/about_20260904-073121.md
+++ b/submissions/Hexeption_BLKOPS04_20260904-073121/about_20260904-073121.md
@@ -1,0 +1,35 @@
+# Submission 20260904-073121
+
+- game: **BLKOPS04**
+- from: Hexeption
+- names: 2
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- material: 2
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 28 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260904-072954_list
+- method: reversible endpoint token swaps
+- what it does: in-place endpoint swaps around an unchanged middle token, only for observed reversible triples
+- ran for: 11s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- candidates tested: 49872
+- matched: 2
+- new: 2
+- sketch stems: 00009b063f9fd63f0004ae6744c0c48f00061f658c8e2a200009c5586a441136000a7ba78620f9bc000a873da4df67b6000d49a15f8bbae5000de44aefec6202000e5f2d98aef82b00104f06d0333a8f00113fc68253bf3e0011bee19c6914cd0013d3468d52df750014576b0e3caeaa0015a1e8126f35cc0015b2629998c852001603481a7f8b840016079066ba6101001a73ba2bdbbba0001b5b8f3d835915001c7f51270fb12a001f0f3de7f640fa002355fa9331ad920024ee3d17528c0600276c0252e11bca0027d040677079950028aa3c9adc1519002c5bd9c3fb4f94002cc0dc1899ea16002ebc04e4a19cad0031e18b2fdcc2890031f3d7ee589bdc
+- ids hunted: 147810
+- throughput: 0.0M candidates/s
+- fingerprint: b80d87dbec186051
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/Hexeption_BLKOPS04_20260904-073121/material_20260904-073121.txt
+++ b/submissions/Hexeption_BLKOPS04_20260904-073121/material_20260904-073121.txt
@@ -1,0 +1,2 @@
+377dc7462cf066d5,mc/mtl_veh_t8_mil_air_razorback_tail_light_mp_dark
+7ccb099ed8403104,mc/mtl_veh_t8_mil_air_razorback_wing_light_mp_dark


### PR DESCRIPTION
**BLKOPS04** — 2 asset names, confirmed against that game's own loaded assets.

- material: 2

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Hexeption

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260904-072954_list
- method: reversible endpoint token swaps
- what it does: in-place endpoint swaps around an unchanged middle token, only for observed reversible triples
- ran for: 11s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- candidates tested: 49872
- matched: 2
- new: 2
- sketch stems: 00009b063f9fd63f0004ae6744c0c48f00061f658c8e2a200009c5586a441136000a7ba78620f9bc000a873da4df67b6000d49a15f8bbae5000de44aefec6202000e5f2d98aef82b00104f06d0333a8f00113fc68253bf3e0011bee19c6914cd0013d3468d52df750014576b0e3caeaa0015a1e8126f35cc0015b2629998c852001603481a7f8b840016079066ba6101001a73ba2bdbbba0001b5b8f3d835915001c7f51270fb12a001f0f3de7f640fa002355fa9331ad920024ee3d17528c0600276c0252e11bca0027d040677079950028aa3c9adc1519002c5bd9c3fb4f94002cc0dc1899ea16002ebc04e4a19cad0031e18b2fdcc2890031f3d7ee589bdc
- ids hunted: 147810
- throughput: 0.0M candidates/s
- fingerprint: b80d87dbec186051

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/material_clt_to_cltp_20260904-073121.py`
- `scripts/contributed/phantom_t8_hash_map_20260904-073121.py`
- `scripts/contributed/reversible_endpoint_swaps_20260904-073121.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.