### PR TITLE
[BLKOPS04] findings from Hexeption, 20260904-092629 (2 names)

### DIFF
--- a/scripts/contributed/eric_p9_perk_archive_20260904-092629.py
+++ b/scripts/contributed/eric_p9_perk_archive_20260904-092629.py
@@ -1,0 +1,47 @@
+"""Emit original T9 asset basenames from Eric Maynard's ModelGetter perk archive.
+
+Run:
+    python contrib/eric_p9_perk_archive_20260904.py | target\\release\\confirm_list.exe - --game BLKOPSCW --label "Eric P9 perk archive original names" --script contrib/eric_p9_perk_archive_20260904.py
+
+Reads the downloaded `borrowed/eric_p9_perk_machines.rar` archive through the system `tar`
+reader and writes one exact basename per line.  The archive includes imported T8/T7 files for
+placement; only original T9/P9 image, xmodel, and xanim export names are retained.  Reusable
+after downloading the public ModMe MediaFire attachment recorded in METHODS.md.
+"""
+import os
+import re
+import subprocess
+import sys
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+ARCHIVE = os.path.join(ROOT, "borrowed", "eric_p9_perk_machines.rar")
+EXTENSIONS = (".png", ".xmodel_bin", ".xanim_bin")
+ORIGINAL = re.compile(r"^(?:i_p9_|i_mtl_wpn_t9_|i_wpn_t9_|p9_|t9_|wpn_zm_.*t9$|vm_.*t9$)")
+
+
+def main():
+    if not os.path.isfile(ARCHIVE):
+        raise SystemExit("download the documented ModMe attachment to borrowed/ first")
+    paths = subprocess.check_output(["tar", "-tf", ARCHIVE], text=True, encoding="utf-8")
+    names = set()
+    for path in paths.splitlines():
+        name = os.path.basename(path).lower()
+        if not name.endswith(EXTENSIONS):
+            continue
+        name = name.rsplit(".", 1)[0]
+        if ORIGINAL.match(name):
+            names.add(name)
+    # `vm_` assets have no T9 marker in their basename, but this archive's only xanim exports
+    # sit inside `model_export/t9_perks/`; retain those by rechecking their full archive path.
+    for path in paths.splitlines():
+        if "/t9_perks/" not in path.lower() or not path.lower().endswith(".xanim_bin"):
+            continue
+        names.add(os.path.basename(path).lower().rsplit(".", 1)[0])
+    print("Eric P9 perk archive: {:,} original-looking T9/P9 basenames".format(len(names)), file=sys.stderr)
+    for name in sorted(names):
+        print(name)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/contributed/misty_bo4_dropbox_export_20260904-092629.py
+++ b/scripts/contributed/misty_bo4_dropbox_export_20260904-092629.py
@@ -1,0 +1,39 @@
+"""Emit exact BO4 model and image basenames from the Misty Dropbox Greyhound export.
+
+Run:
+    python contrib/misty_bo4_dropbox_export_20260904.py | target\\release\\confirm_list.exe - --game BLKOPS04 --label "Misty BO4 Dropbox export" --script contrib/misty_bo4_dropbox_export_20260904.py
+
+Reads `borrowed/t8_farmgirl_misty_bo4.zip` through the system tar reader.  It writes names only
+from the archive's `model_export/` tree, retaining native TIFF image and XMODEL/XANIM export
+basenames while excluding `source_data`, custom map placement, and directory strings.  Reusable
+after downloading the public ModMe-linked Dropbox folder recorded in METHODS.md.
+"""
+import os
+import subprocess
+import sys
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+ARCHIVE = os.path.join(ROOT, "borrowed", "t8_farmgirl_misty_bo4.zip")
+EXTENSIONS = (".tiff", ".xmodel_bin", ".xanim_bin")
+
+
+def main():
+    if not os.path.isfile(ARCHIVE):
+        raise SystemExit("download the documented Misty Dropbox export to borrowed/ first")
+    listing = subprocess.check_output(["tar", "-tf", ARCHIVE], text=True, encoding="utf-8")
+    names = set()
+    for path in listing.splitlines():
+        lowered = path.lower()
+        if not lowered.startswith("model_export/") or not lowered.endswith(EXTENSIONS):
+            continue
+        names.add(os.path.basename(lowered).rsplit(".", 1)[0])
+    if len(names) < 20:
+        raise SystemExit("archive did not expose the expected model-export name corpus")
+    print("Misty BO4 Dropbox export: {:,} exact model/image basenames".format(len(names)), file=sys.stderr)
+    for name in sorted(names):
+        print(name)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/contributed/pmr360_t9_weapon_forum_paths_20260904-092629.py
+++ b/scripts/contributed/pmr360_t9_weapon_forum_paths_20260904-092629.py
@@ -1,0 +1,32 @@
+"""Emit exact native T9 weapon sound paths posted on pmr360's ModMe export page.
+
+Run:
+    python contrib/pmr360_t9_weapon_forum_paths_20260904.py | target\\release\\confirm_list.exe - --game BLKOPSCW --sounds --label "pmr360 posted T9 weapon sound paths" --script contrib/pmr360_t9_weapon_forum_paths_20260904.py
+
+Reads the public forum page's compiler-log text and writes only complete `t9_weapons\\...wav`
+paths to stdout.  The linked full weapon archive is unavailable on Mega, but these paths are
+explicit native source literals, not inferred spellings.  Reusable while the public page exists.
+"""
+import html
+import re
+import sys
+import urllib.request
+
+
+SOURCE = "https://forum.modme.co/wiki/threads/3540.html"
+PATH = re.compile(r"t9_weapons\\(?:[a-z0-9_]+\\)*[a-z0-9_]+\.wav", re.I)
+
+
+def main():
+    request = urllib.request.Request(SOURCE, headers={"User-Agent": "Mozilla/5.0"})
+    page = urllib.request.urlopen(request, timeout=60).read().decode("utf-8")
+    names = {match.group(0).lower() for match in PATH.finditer(html.unescape(page))}
+    if len(names) < 20:
+        raise SystemExit("forum source did not expose the expected native path corpus")
+    print("pmr360 forum page: {:,} exact T9 weapon sound paths".format(len(names)), file=sys.stderr)
+    for name in sorted(names):
+        print(name)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/contributed/skye_bo4_weapon_aliases_20260904-092629.py
+++ b/scripts/contributed/skye_bo4_weapon_aliases_20260904-092629.py
@@ -1,0 +1,32 @@
+"""Emit BO4-namespaced aliases, but never transformed Skye port file paths."""
+
+import csv
+import io
+import re
+import sys
+import urllib.request
+
+
+URL = (
+    "https://raw.githubusercontent.com/FanaticSoftware/Skye-Weapon-Templates/"
+    "master/share/raw/sound/aliases/skye_bo4_weapons.csv"
+)
+ALIAS = re.compile(r"wpn_t8_[a-z0-9_]+$")
+
+
+def main() -> None:
+    request = urllib.request.Request(URL, headers={"User-Agent": "hash-slinging-slasher"})
+    with urllib.request.urlopen(request, timeout=60) as response:
+        text = response.read().decode("utf-8-sig")
+    names = {
+        (row.get("Name") or "").strip().lower()
+        for row in csv.DictReader(io.StringIO(text))
+    }
+    names = {name for name in names if ALIAS.fullmatch(name)}
+    for name in sorted(names):
+        print(name)
+    print(f"[source] {len(names)} unique wpn_t8 aliases", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/contributed/skye_bocw_weapon_aliases_20260904-092629.py
+++ b/scripts/contributed/skye_bocw_weapon_aliases_20260904-092629.py
@@ -1,0 +1,38 @@
+"""Emit original-looking T9 weapon aliases preserved by Skye's public template.
+
+The CSV's FileSpec column deliberately points at ported ``skye_ports`` files;
+only its Name aliases are source candidates.  Keep the T9-specific namespace
+so BO3/port-framework helper rows cannot leak into the live-game check.
+"""
+
+import csv
+import io
+import re
+import sys
+import urllib.request
+
+
+URL = (
+    "https://raw.githubusercontent.com/FanaticSoftware/Skye-Weapon-Templates/"
+    "main/share/raw/sound/aliases/skye_bocw_weapons.csv"
+)
+ALIAS = re.compile(r"wpn_t9_[a-z0-9_]+$")
+
+
+def main() -> None:
+    request = urllib.request.Request(URL, headers={"User-Agent": "hash-slinging-slasher"})
+    with urllib.request.urlopen(request, timeout=60) as response:
+        text = response.read().decode("utf-8-sig")
+    rows = csv.DictReader(io.StringIO(text))
+    names = set()
+    for row in rows:
+        name = (row.get("Name") or "").strip().lower()
+        if ALIAS.fullmatch(name):
+            names.add(name)
+    for name in sorted(names):
+        print(name)
+    print(f"[source] {len(names)} unique wpn_t9 aliases", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/submissions/Hexeption_BLKOPS04_20260904-092629/about_20260904-092629.md
+++ b/submissions/Hexeption_BLKOPS04_20260904-092629/about_20260904-092629.md
@@ -1,0 +1,35 @@
+# Submission 20260904-092629
+
+- game: **BLKOPS04**
+- from: Hexeption
+- names: 2
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- image: 2
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 40 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260904-092536_list
+- method: deep image channel completion after Richkiller ledger
+- what it does: Two-token channel variants derived in-place from the 7,488-image Richkiller BO4 seed gain; standard channel closure does not include --deep.
+- ran for: 13s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- candidates tested: 3906974
+- matched: 2
+- new: 2
+- sketch stems: 000009b849bc13300000102ecfb034d9000013b6a770442600001f5059d15ed3000021d60eb05f1c00002991ea507aa6000030905a70ba1d000031e6ae3a4053000033f4eab885460000390928de220c00003add22b66a6600003b9f496e1f310000411ce82002be0000456f94434834000045b4ed8276b3000049c0d31c346500004fab14d8a3ad000052eddb08e5db000054f3951b8a2d0000598d8b071f4b00005cb01562dc1300005d0ed36c5a0300006086707e6ebf0000629afd919599000064c4056c6a8f000067df0de6d53e00006fe5fe95cabd000072645533decb000082fc0f538339000096e8c6f1189300009af668f959470000a50ef8438ecf
+- ids hunted: 139563
+- throughput: 0.4M candidates/s
+- fingerprint: 836b6161f7c9b639
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/Hexeption_BLKOPS04_20260904-092629/image_20260904-092629.txt
+++ b/submissions/Hexeption_BLKOPS04_20260904-092629/image_20260904-092629.txt
@@ -1,0 +1,2 @@
+470b857a3185ed7c,img_t8_menu_zm_preview_all_dlc_maps
+6af48238953f750e,img_t8_menu_zm_preview_all_maps


### PR DESCRIPTION
**BLKOPS04** — 2 asset names, confirmed against that game's own loaded assets.

- image: 2

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Hexeption

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260904-092536_list
- method: deep image channel completion after Richkiller ledger
- what it does: Two-token channel variants derived in-place from the 7,488-image Richkiller BO4 seed gain; standard channel closure does not include --deep.
- ran for: 13s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- candidates tested: 3906974
- matched: 2
- new: 2
- sketch stems: 000009b849bc13300000102ecfb034d9000013b6a770442600001f5059d15ed3000021d60eb05f1c00002991ea507aa6000030905a70ba1d000031e6ae3a4053000033f4eab885460000390928de220c00003add22b66a6600003b9f496e1f310000411ce82002be0000456f94434834000045b4ed8276b3000049c0d31c346500004fab14d8a3ad000052eddb08e5db000054f3951b8a2d0000598d8b071f4b00005cb01562dc1300005d0ed36c5a0300006086707e6ebf0000629afd919599000064c4056c6a8f000067df0de6d53e00006fe5fe95cabd000072645533decb000082fc0f538339000096e8c6f1189300009af668f959470000a50ef8438ecf
- ids hunted: 139563
- throughput: 0.4M candidates/s
- fingerprint: 836b6161f7c9b639

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/eric_p9_perk_archive_20260904-092629.py`
- `scripts/contributed/misty_bo4_dropbox_export_20260904-092629.py`
- `scripts/contributed/pmr360_t9_weapon_forum_paths_20260904-092629.py`
- `scripts/contributed/skye_bo4_weapon_aliases_20260904-092629.py`
- `scripts/contributed/skye_bocw_weapon_aliases_20260904-092629.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.