### PR TITLE
[BLKOPS04] findings from Hexeption, 20260904-092915 (2 names)

### DIFF
--- a/scripts/contributed/greyhound_early_bo4_wni_20260904-092915.py
+++ b/scripts/contributed/greyhound_early_bo4_wni_20260904-092915.py
@@ -1,0 +1,95 @@
+"""Emit the BO4 name delta carried by Greyhound's early public releases.
+
+Versions 1.3.60, 1.3.81 and 1.7.10 are dated BO4 cache snapshots.  Keep only
+spellings absent from the already-audited 1.9.9 snapshot; this is a bounded
+release-history source, not a re-run of the same package index.
+"""
+
+from pathlib import Path
+import argparse
+import struct
+
+
+ROOT = Path("borrowed")
+EARLY = ("greyhound_1_3_60_0", "greyhound_1_3_81_0", "greyhound_1_7_10_0")
+BASELINE = "greyhound_1_9_9_0"
+TYPED_FILES = ("bo4_xanim.wni", "bo4_ximage.wni", "bo4_xmodel.wni", "bo4_xmaterial.wni")
+SOUND_FILES = ("bo4_sab.wni",)
+
+
+def unpack_lz4(source: bytes, expected: int) -> bytes:
+    output = bytearray()
+    at = 0
+    while at < len(source):
+        token = source[at]
+        at += 1
+        literal = token >> 4
+        if literal == 15:
+            while True:
+                extra = source[at]
+                at += 1
+                literal += extra
+                if extra != 255:
+                    break
+        output.extend(source[at : at + literal])
+        at += literal
+        if at == len(source):
+            break
+        offset = source[at] | source[at + 1] << 8
+        at += 2
+        match = token & 15
+        if match == 15:
+            while True:
+                extra = source[at]
+                at += 1
+                match += extra
+                if extra != 255:
+                    break
+        match += 4
+        if not offset or offset > len(output):
+            raise ValueError("invalid LZ4 match")
+        for _ in range(match):
+            output.append(output[-offset])
+    if len(output) != expected:
+        raise ValueError(f"LZ4 size mismatch: {len(output)} != {expected}")
+    return bytes(output)
+
+
+def names(path: Path) -> set[str]:
+    raw = path.read_bytes()
+    magic, version, entries, packed, unpacked = struct.unpack_from("<I H I I I", raw)
+    if (magic, version) != (0x20494E57, 1):
+        raise ValueError(f"unexpected WNI header: {path}")
+    data = unpack_lz4(raw[18 : 18 + packed], unpacked)
+    at = 0
+    result: set[str] = set()
+    for _ in range(entries):
+        at += 8
+        end = data.index(0, at)
+        name = data[at:end].decode("utf-8", errors="strict")
+        at = end + 1
+        if 3 <= len(name) <= 240 and sum(c.isalpha() for c in name) >= 3:
+            result.add(name)
+    if at != len(data):
+        raise ValueError(f"trailing WNI data: {path}")
+    return result
+
+
+def read_release(release: str, files: tuple[str, ...]) -> set[str]:
+    path = ROOT / release / "package_index"
+    return set().union(*(names(path / filename) for filename in files))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--sounds", action="store_true", help="emit SAB paths only")
+    options = parser.parse_args()
+    files = SOUND_FILES if options.sounds else TYPED_FILES
+    baseline = read_release(BASELINE, files)
+    early = set().union(*(read_release(release, files) for release in EARLY))
+    for name in sorted(early - baseline):
+        print(name)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/contributed/terminal_pair_counterparts_20260904-092915.py
+++ b/scripts/contributed/terminal_pair_counterparts_20260904-092915.py
@@ -1,0 +1,128 @@
+"""Try previously unseen, well-controlled terminal-token counterpart pairs.
+
+Only alphabetic final underscore tokens are considered.  A pair is eligible only
+when at least 20 exact same-base names carry both sides, and the established
+prone/stand, L/R, diagonal, left/right, exo1/exo2, and view/world relations are
+excluded.  This is deliberately a single census, not a state-grid generator.
+"""
+
+import argparse
+import collections
+import os
+import re
+import sys
+
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+while ROOT != os.path.dirname(ROOT) and not os.path.isfile(
+    os.path.join(ROOT, "scripts", "snapshot.py")
+):
+    ROOT = os.path.dirname(ROOT)
+sys.path.insert(0, os.path.join(ROOT, "scripts"))
+
+import snapshot
+
+
+TABLES = (
+    "fnv1a_xmodels",
+    "fnv1a_xmaterials",
+    "fnv1a_ximages",
+    "fnv1a_xanims",
+    "fnv1a_xsounds",
+    "fnv1a_soundbanks_aliases",
+)
+TOKEN = re.compile(r"^[a-z]+$")
+EXCLUDED = {
+    frozenset(("prone", "stand")),
+    frozenset(("l", "r")),
+    frozenset(("fl", "fr")),
+    frozenset(("bl", "br")),
+    frozenset(("left", "right")),
+    frozenset(("exo1", "exo2")),
+    frozenset(("view", "world")),
+}
+MAX_TOKENS_PER_BASE = 8
+
+
+def corpus() -> set[str]:
+    names = set(snapshot.table_names(*TABLES))
+    names.update(snapshot.confirmed_names())
+    return {
+        name.strip().lower().replace("\\", "/")
+        for name in names
+        if name.strip() and len(name) <= 240
+    }
+
+
+def split(name: str) -> tuple[str, str] | None:
+    base, separator, token = name.rpartition("_")
+    if not separator or not base or not TOKEN.fullmatch(token):
+        return None
+    return base, token
+
+
+def candidates(known: set[str], minimum_controls: int) -> tuple[set[str], int, int]:
+    families: dict[str, set[str]] = collections.defaultdict(set)
+    for name in known:
+        parsed = split(name)
+        if parsed:
+            base, token = parsed
+            families[base].add(token)
+
+    controls: collections.Counter[frozenset[str]] = collections.Counter()
+    # Large terminal sets are state grids; they neither provide a constrained
+    # counterpart relation nor justify quadratic pair enumeration.
+    families = {
+        base: tokens
+        for base, tokens in families.items()
+        if len(tokens) <= MAX_TOKENS_PER_BASE
+    }
+    for tokens in families.values():
+        for left in tokens:
+            for right in tokens:
+                if left < right:
+                    controls[frozenset((left, right))] += 1
+
+    eligible = {
+        pair
+        for pair, count in controls.items()
+        if count >= minimum_controls and pair not in EXCLUDED
+    }
+    # Index by the side actually present.  Iterating every eligible pair for
+    # every base was harmless before the texture-ledger recovery, but makes a
+    # bounded census accidentally quadratic once a large new image family is
+    # added.  This retains exactly the same control gate and emitted relation.
+    counterparts: dict[str, set[str]] = collections.defaultdict(set)
+    for pair in eligible:
+        left, right = tuple(pair)
+        counterparts[left].add(right)
+        counterparts[right].add(left)
+
+    output: set[str] = set()
+    for base, tokens in families.items():
+        for token in tokens:
+            for counterpart in counterparts[token]:
+                if counterpart not in tokens:
+                    output.add(f"{base}_{counterpart}")
+    return output - known, len(eligible), sum(controls[pair] for pair in eligible)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--count", action="store_true")
+    parser.add_argument("--min-controls", type=int, default=20)
+    options = parser.parse_args()
+    known = corpus()
+    output, pairs, controls = candidates(known, options.min_controls)
+    print(
+        f"{len(known):,} known names; {pairs:,} eligible terminal pairs at "
+        f"{options.min_controls:,}+ controls; "
+        f"{controls:,} complete-base controls; {len(output):,} unseen candidates",
+        file=sys.stderr,
+    )
+    if not options.count:
+        print("\n".join(sorted(output)))
+
+
+if __name__ == "__main__":
+    main()

--- a/submissions/Hexeption_BLKOPS04_20260904-092915/about_20260904-092915.md
+++ b/submissions/Hexeption_BLKOPS04_20260904-092915/about_20260904-092915.md
@@ -1,0 +1,35 @@
+# Submission 20260904-092915
+
+- game: **BLKOPS04**
+- from: Hexeption
+- names: 2
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- material: 2
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 41 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260904-092811_list
+- method: high-control terminal token counterparts after BO4 texture ledger
+- what it does: re-measured bounded terminal-token counterpart relation after independent Richkiller BO4 image ledger recovery; only pairs with 20+ complete same-base controls
+- ran for: 24s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- candidates tested: 5190062
+- matched: 2
+- new: 2
+- sketch stems: 0000061605654f9500000a2be0c8804f00000ae7c3a2ade600000af234f70d0a000013b6a7704426000014b96c79cc3d000017d06dee78c500001cfefa0c3e30000021d60eb05f1c000027f41837bccf0000295fe0405b0100002b6cb376d85600002c62017ee7750000310f8b06a6e4000032a9e6c0072f0000360c92b42bcd0000411ce82002be0000454cba876093000046d206846b980000473ee8fa84df00004ed013462a01000054fbe6ae5a100000574d0311cc23000059478d3f145600005b179abb1a4300005cb01562dc1300005cf355dc309500005d0ed36c5a0300006086707e6ebf0000629afd9195990000664f0e179a16000066916edb750f
+- ids hunted: 139561
+- throughput: 0.3M candidates/s
+- fingerprint: b49775b18edc917d
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/Hexeption_BLKOPS04_20260904-092915/material_20260904-092915.txt
+++ b/submissions/Hexeption_BLKOPS04_20260904-092915/material_20260904-092915.txt
@@ -1,0 +1,2 @@
+1d14dcfca9c796b9,mc/mtl_p8_zm_red_tool_pegasus_tong_metal
+3810f3993e4e6ec3,mc/mtl_c_t8_zmb_dlc4_child_richtofen_body


### PR DESCRIPTION
**BLKOPS04** — 2 asset names, confirmed against that game's own loaded assets.

- material: 2

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Hexeption

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260904-092811_list
- method: high-control terminal token counterparts after BO4 texture ledger
- what it does: re-measured bounded terminal-token counterpart relation after independent Richkiller BO4 image ledger recovery; only pairs with 20+ complete same-base controls
- ran for: 24s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- candidates tested: 5190062
- matched: 2
- new: 2
- sketch stems: 0000061605654f9500000a2be0c8804f00000ae7c3a2ade600000af234f70d0a000013b6a7704426000014b96c79cc3d000017d06dee78c500001cfefa0c3e30000021d60eb05f1c000027f41837bccf0000295fe0405b0100002b6cb376d85600002c62017ee7750000310f8b06a6e4000032a9e6c0072f0000360c92b42bcd0000411ce82002be0000454cba876093000046d206846b980000473ee8fa84df00004ed013462a01000054fbe6ae5a100000574d0311cc23000059478d3f145600005b179abb1a4300005cb01562dc1300005cf355dc309500005d0ed36c5a0300006086707e6ebf0000629afd9195990000664f0e179a16000066916edb750f
- ids hunted: 139561
- throughput: 0.3M candidates/s
- fingerprint: b49775b18edc917d

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/greyhound_early_bo4_wni_20260904-092915.py`
- `scripts/contributed/terminal_pair_counterparts_20260904-092915.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.