### PR TITLE
[BLKOPS04] findings from Tnt540, 20260904-100723 (4 names)

### DIFF
--- a/submissions/Tnt540_BLKOPS04_20260904-100723/about_20260904-100723.md
+++ b/submissions/Tnt540_BLKOPS04_20260904-100723/about_20260904-100723.md
@@ -1,0 +1,40 @@
+# Submission 20260904-100723
+
+- game: **BLKOPS04**
+- from: Tnt540
+- names: 4
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- xmodel: 2
+- material: 1
+- sound_alias: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 44 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260904-095246_plan
+- method: BLKOPS04-scoped all-boundary cores x ALL uncarried 4-segment endings (full vocabulary)
+- what it does: all_names/blkops04 published cores plus confirmed names x every 4-segment ending data/suffixes.txt cannot express (957,772 of them)
+- ran for: 13m 50s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- beginnings: 0
+- endings: 960800
+- stems: 174900
+- ids hunted: 148182
+- candidates tested: 168044094900
+- new: 4
+- sketch beginnings: 
+- sketch stems: 00002b1519e1ded400002ee0bf50cc960000ef4a2113a6a70001350db49850c6000196f66cc5bd0a0001aef44909c8860001c4288d1f83f80001d42da712184b0002257ec18410d600033cf2e70d986600033f547a90eb950003b69caf19a9720003df052c8c65a400041bbbb5029bd70004411f5ae467110004a5cf1343b3860004f9caa2916c42000624bd7bcc757200063685031d44230006518ce0f1ed4d00068f4e032473900006b5e60602d68c0007d55dbb0777ea0009fc4ea542379a000a6d6d22ada5ec000b32b8830e99c2000c7c620254ad84000c9eb9db01a880000caad68ac532c4000d02e08a26b568000d2a274f32763e000d4e4e5c704308
+- sketch endings: 00004d5bfe8b097d00005f28cfbe8c67000086a660b82c01000098eeb76eb67f00009d1c61c251e300009f0c4c8348050000abb2c3e0c4ec0000b5b0ca15482c0000b70759729ede0000beef24460dae0000f2db1a6f55ed0001238dd86a088e00014512b938578d000159eef4da28ab00017217509b55f500017539d5109bf900018087c112b10500019061b0595ef300019a247e2103f20001aae68453c4070001b15f5819a0720001b4dd72acd1050001c12df56c97660001c9f9391b9ffa0001fe0522a7cdda00021554165755a000021e6b5a7a6ba60002356d2648c5c200024f79c5769e2c00025cfe78d0bccb00029ad4cda6d7d00002a7e6acebe318
+- fingerprint: 44c08d271d440971
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/Tnt540_BLKOPS04_20260904-100723/material_20260904-100723.txt
+++ b/submissions/Tnt540_BLKOPS04_20260904-100723/material_20260904-100723.txt
@@ -1,0 +1,1 @@
+22f6b5d9413f249b,mc/mtl_zm_red_vista_cave_occluder

--- a/submissions/Tnt540_BLKOPS04_20260904-100723/sound_alias_20260904-100723.txt
+++ b/submissions/Tnt540_BLKOPS04_20260904-100723/sound_alias_20260904-100723.txt
@@ -1,0 +1,1 @@
+4efda9ba3658bc4c,vox_engi_ae_smrt_cvr_use

--- a/submissions/Tnt540_BLKOPS04_20260904-100723/xmodel_20260904-100723.txt
+++ b/submissions/Tnt540_BLKOPS04_20260904-100723/xmodel_20260904-100723.txt
@@ -1,0 +1,2 @@
+19435de016e5aa22,p8_kit_zod_wall_02_corner_outside_32_01
+7da4bb17eac88b77,p8_kit_zod_wall_02_corner_inside_32_01


### PR DESCRIPTION
**BLKOPS04** — 4 asset names, confirmed against that game's own loaded assets.

- xmodel: 2
- material: 1
- sound_alias: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Tnt540

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260904-095246_plan
- method: BLKOPS04-scoped all-boundary cores x ALL uncarried 4-segment endings (full vocabulary)
- what it does: all_names/blkops04 published cores plus confirmed names x every 4-segment ending data/suffixes.txt cannot express (957,772 of them)
- ran for: 13m 50s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- beginnings: 0
- endings: 960800
- stems: 174900
- ids hunted: 148182
- candidates tested: 168044094900
- new: 4
- sketch beginnings: 
- sketch stems: 00002b1519e1ded400002ee0bf50cc960000ef4a2113a6a70001350db49850c6000196f66cc5bd0a0001aef44909c8860001c4288d1f83f80001d42da712184b0002257ec18410d600033cf2e70d986600033f547a90eb950003b69caf19a9720003df052c8c65a400041bbbb5029bd70004411f5ae467110004a5cf1343b3860004f9caa2916c42000624bd7bcc757200063685031d44230006518ce0f1ed4d00068f4e032473900006b5e60602d68c0007d55dbb0777ea0009fc4ea542379a000a6d6d22ada5ec000b32b8830e99c2000c7c620254ad84000c9eb9db01a880000caad68ac532c4000d02e08a26b568000d2a274f32763e000d4e4e5c704308
- sketch endings: 00004d5bfe8b097d00005f28cfbe8c67000086a660b82c01000098eeb76eb67f00009d1c61c251e300009f0c4c8348050000abb2c3e0c4ec0000b5b0ca15482c0000b70759729ede0000beef24460dae0000f2db1a6f55ed0001238dd86a088e00014512b938578d000159eef4da28ab00017217509b55f500017539d5109bf900018087c112b10500019061b0595ef300019a247e2103f20001aae68453c4070001b15f5819a0720001b4dd72acd1050001c12df56c97660001c9f9391b9ffa0001fe0522a7cdda00021554165755a000021e6b5a7a6ba60002356d2648c5c200024f79c5769e2c00025cfe78d0bccb00029ad4cda6d7d00002a7e6acebe318
- fingerprint: 44c08d271d440971

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/uncarried_begins_20260823-023757.txt`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.