### PR TITLE
[BLKOPSCW] findings from Hexeption, 20260904-135452 (1 names)

### DIFF
--- a/scripts/contributed/bo4_material_interior_counterparts_20260904-135452.py
+++ b/scripts/contributed/bo4_material_interior_counterparts_20260904-135452.py
@@ -1,0 +1,110 @@
+"""Offer strongly attested BO4 material-token counterparts at an interior position.
+
+This is the material-only counterpart to the BO4 image whole-frame relation.
+It retains the directory, token position, and every other basename token.  A
+replacement is allowed only after its unordered pair occurs in at least 200
+independent complete material frames.  One-character grid states and the NATO
+alphabet are deliberately excluded: their combinatorics are not a naming
+convention and would turn this into a state sweep.
+"""
+
+import argparse
+import collections
+import os
+import sys
+
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+while ROOT != os.path.dirname(ROOT) and not os.path.isfile(
+    os.path.join(ROOT, "scripts", "snapshot.py")
+):
+    ROOT = os.path.dirname(ROOT)
+sys.path.insert(0, os.path.join(ROOT, "scripts"))
+
+import snapshot
+
+
+# These observed groups are numbering/state alphabets rather than material
+# words.  Excluding the whole alphabet rather than merely a few pairs keeps
+# the candidate set a counterpart relation, not an implicit grid generator.
+GRID_TOKENS = frozenset((
+    "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m",
+    "alfa", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel",
+    "india", "juliett", "kilo", "lima", "mike", "november",
+))
+
+
+def corpus():
+    names = set(snapshot.table_names("fnv1a_xmaterials"))
+    names.update(snapshot.confirmed_names("material"))
+    return {
+        name.strip().lower().replace("\\", "/")
+        for name in names
+        if name.strip() and len(name) <= 240
+    }
+
+
+def frames(names):
+    """Map an exact material spelling with one interior word removed to words."""
+    out = collections.defaultdict(set)
+    for name in names:
+        directory, marker, basename = name.rpartition("/")
+        directory = directory + marker if marker else ""
+        if "." in basename:
+            continue
+        tokens = tuple(basename.split("_"))
+        if len(tokens) < 4 or any(not token for token in tokens):
+            continue
+        for index in range(1, len(tokens) - 1):
+            token = tokens[index]
+            if not token.isalpha() or token in GRID_TOKENS:
+                continue
+            out[(directory, index, tokens[:index], tokens[index + 1:])].add(token)
+    return out
+
+
+def derive(grouped, known, minimum):
+    controls = collections.Counter()
+    for values in grouped.values():
+        values = sorted(values)
+        for index, left in enumerate(values):
+            for right in values[index + 1:]:
+                controls[(left, right)] += 1
+    eligible = {pair for pair, count in controls.items() if count >= minimum}
+    counterparts = collections.defaultdict(set)
+    for left, right in eligible:
+        counterparts[left].add(right)
+        counterparts[right].add(left)
+
+    output = set()
+    for (directory, _, head, tail), values in grouped.items():
+        for value in values:
+            for other in counterparts[value]:
+                if other not in values:
+                    output.add(directory + "_".join(head + (other,) + tail))
+    return output - known, controls, eligible
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--min-controls", type=int, default=200)
+    parser.add_argument("--count", action="store_true")
+    options = parser.parse_args(argv)
+    if options.min_controls < 1:
+        raise SystemExit("--min-controls must be positive")
+    known = corpus()
+    grouped = frames(known)
+    output, controls, eligible = derive(grouped, known, options.min_controls)
+    print(
+        f"{len(known):,} known materials; {len(grouped):,} exact interior frames; "
+        f"{len(eligible):,} pairs at {options.min_controls:,}+ complete-frame controls; "
+        f"{sum(controls[pair] for pair in eligible):,} controls; "
+        f"{len(output):,} unseen candidates",
+        file=sys.stderr,
+    )
+    if not options.count:
+        print("\n".join(sorted(output)))
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/scripts/contributed/bo4_workshop_embedded_literals_20260904-135452.py
+++ b/scripts/contributed/bo4_workshop_embedded_literals_20260904-135452.py
@@ -1,0 +1,26 @@
+"""Extract literal BO4-looking asset labels embedded in the downloaded Workshop mirror."""
+from pathlib import Path
+import re
+
+ROOT = Path('.tmp-steamcmd/steamapps/workshop/content/311210')
+PATTERN = re.compile(rb'(?<![A-Za-z0-9_])((?:i|mtl|xmodel|xanim)_t8_[A-Za-z0-9_./\\-]{2,})')
+
+def main():
+    seen = set()
+    for path in ROOT.rglob('*'):
+        if not path.is_file():
+            continue
+        try:
+            data = path.read_bytes()
+        except OSError:
+            continue
+        for match in PATTERN.finditer(data):
+            raw = match.group(1).decode('ascii', 'ignore').replace('\\', '/')
+            if raw.count('/') > 8 or len(raw) > 180:
+                continue
+            seen.add(raw)
+    for name in sorted(seen):
+        print(name)
+
+if __name__ == '__main__':
+    main()

--- a/scripts/contributed/devraw_alistairs_folly_bo4_20260904-135452.py
+++ b/scripts/contributed/devraw_alistairs_folly_bo4_20260904-135452.py
@@ -1,0 +1,37 @@
+"""Emit original BO4 model basenames from DevRaw's Alistair's Folly export.
+
+The public DevRaw release is a BO4-to-BO3 port, but unlike its surrounding BO3
+scaffolding it retains a separately labelled ``model_export/bo4_xmodels`` tree.
+Only non-placeholder `.xmodel_bin` basenames physically in that tree are
+evidence.  The archive is downloaded from the public Drive link recorded in
+METHODS.md before this generator is run.
+"""
+import os
+import subprocess
+import sys
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+ARCHIVE = os.path.join(ROOT, "borrowed", "devraw_alistairs_folly_bo4.zip")
+
+
+def main():
+    if not os.path.isfile(ARCHIVE):
+        raise SystemExit("download DevRaw Alistair's Folly archive first: " + ARCHIVE)
+    listing = subprocess.check_output(["tar", "-tf", ARCHIVE], text=True, encoding="utf-8")
+    names = set()
+    for path in listing.splitlines():
+        lowered = path.lower()
+        if "/model_export/bo4_xmodels/" not in lowered or not lowered.endswith(".xmodel_bin"):
+            continue
+        name = os.path.basename(lowered).removesuffix(".xmodel_bin")
+        if not name.startswith("xmodel_"):
+            names.add(name)
+    if len(names) < 4:
+        raise SystemExit("DevRaw archive did not expose its expected BO4 xmodel slice")
+    print("DevRaw Alistair's Folly: {} exact BO4 xmodel basenames".format(len(names)), file=sys.stderr)
+    print(*sorted(names), sep="\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/contributed/devraw_bo4_ix_zombie_models_20260904-135452.py
+++ b/scripts/contributed/devraw_bo4_ix_zombie_models_20260904-135452.py
@@ -1,0 +1,32 @@
+"""Emit literal non-opaque model/image labels from DevRaw's BO4 IX export."""
+
+import re
+import sys
+import zipfile
+from pathlib import PurePosixPath
+
+
+ARCHIVE = ".tmp-devraw-bo4-ix-zombie-models"
+ROOT = "model_export/_werelupus/bo4/ix zombie models/"
+SUFFIXES = (".xmodel_bin", ".png", ".tif", ".tiff", ".dds", ".tga")
+OPAQUE = re.compile(r"^(?:x?image|material)_[0-9a-f]+(?:_[a-z])?$")
+
+
+def main() -> None:
+    with zipfile.ZipFile(ARCHIVE) as archive:
+        labels = {
+            PurePosixPath(entry.filename.lower()).stem
+            for entry in archive.infolist()
+            if not entry.is_dir()
+            and entry.filename.lower().startswith(ROOT)
+            and entry.filename.lower().endswith(SUFFIXES)
+            and not PurePosixPath(entry.filename).stem.startswith("$")
+            and not OPAQUE.fullmatch(PurePosixPath(entry.filename.lower()).stem)
+        }
+    print(f"DevRaw BO4 IX export: {len(labels):,} literal labels", file=sys.stderr)
+    for label in sorted(labels):
+        print(label)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/contributed/devraw_cw_die_maschine_export_20260904-135452.py
+++ b/scripts/contributed/devraw_cw_die_maschine_export_20260904-135452.py
@@ -1,0 +1,42 @@
+"""Emit literal non-opaque names from DevRaw's CW Die Maschine model export.
+
+The public archive is a BO3 port, but this intentionally reads only the
+Greyhound-style model_export tree for the exported `c_t9_zmb_ndu_zombie`
+family.  It never emits port placement, GDT, source-data, or `ximage_<hash>`
+placeholder labels.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import PurePosixPath
+
+
+ARCHIVE = 'borrowed/devraw_cw_die_maschine_zombies.rar'
+ROOT = '/model_export/midget_blaster/characters/c_t9_zmb_ndu_zombie/'
+EXTENSIONS = ('.xmodel_bin', '.xanim_bin', '.png', '.tif', '.tiff')
+
+
+def main() -> None:
+    listing = subprocess.check_output(['tar', '-tf', ARCHIVE], text=True)
+    names: set[str] = set()
+    for path in listing.splitlines():
+        normal = path.replace('\\', '/')
+        lower = normal.lower()
+        if ROOT not in lower or not lower.endswith(EXTENSIONS):
+            continue
+        name = PurePosixPath(lower).stem
+        # Greyhound's synthetic image export name means its original label was
+        # unavailable; it cannot be used as source evidence.
+        if name.startswith('ximage_') and all(c in '0123456789abcdef' for c in name[7:]):
+            continue
+        names.add(name)
+    if len(names) < 100:
+        raise SystemExit('archive did not expose the expected literal export corpus')
+    print(f'DevRaw CW Die Maschine export: {len(names):,} literal names', file=sys.stderr)
+    print('\n'.join(sorted(names)))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/contributed/devraw_cw_zombie_pack_export_20260904-135452.py
+++ b/scripts/contributed/devraw_cw_zombie_pack_export_20260904-135452.py
@@ -1,0 +1,42 @@
+"""Emit literal non-opaque asset basenames from DevRaw's CW Zombie Pack.
+
+The archive's `_OwensAssets/t9/` model-export subtree is segregated from BO3
+placement and source-data trees.  Only actual exported model, animation, and
+image basenames are considered; Greyhound's opaque `image_<hash>` / material
+placeholders and `$white` conversion artifacts are excluded.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import PurePosixPath
+
+
+ARCHIVE = 'borrowed/devraw_cw_zombie_pack.zip'
+ROOT = '/model_export/_owensassets/t9/'
+EXTENSIONS = ('.xmodel_bin', '.xanim_bin', '.png', '.tif', '.tiff')
+OPAQUE = re.compile(r'^(?:x?image|material)_[0-9a-f]+(?:_[a-z])?$')
+
+
+def main() -> None:
+    listing = subprocess.check_output(['tar', '-tf', ARCHIVE], text=True)
+    names: set[str] = set()
+    for path in listing.splitlines():
+        normalized = path.replace('\\', '/')
+        lowered = normalized.lower()
+        if ROOT not in lowered or not lowered.endswith(EXTENSIONS):
+            continue
+        name = PurePosixPath(lowered).stem
+        if name.startswith('$') or OPAQUE.fullmatch(name):
+            continue
+        names.add(name)
+    if len(names) < 300:
+        raise SystemExit('archive did not expose the expected literal CW export corpus')
+    print(f'DevRaw CW Zombie Pack: {len(names):,} literal names', file=sys.stderr)
+    print('\n'.join(sorted(names)))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/contributed/devraw_cw_zombie_vox_aliases_20260904-135452.py
+++ b/scripts/contributed/devraw_cw_zombie_vox_aliases_20260904-135452.py
@@ -1,0 +1,25 @@
+"""Literal alias names from DevRaw's downloadable CW Zombie VOX archive.
+
+Only the CSV Name field is emitted.  The FileSpec paths deliberately point at
+the port's `_werelupus` BO3 staging directory and are not native T9 paths.
+"""
+
+import csv
+import io
+import subprocess
+from pathlib import Path
+
+ARCHIVE = Path('borrowed/devraw_cw_zombie_vox.7z')
+CSV_PATH = 'share/raw/sound/aliases/_werelupus/BOCW_zombies_vox.csv'
+
+
+def main() -> None:
+    payload = subprocess.check_output(['tar', '-xOf', str(ARCHIVE), CSV_PATH])
+    rows = csv.DictReader(io.StringIO(payload.decode('utf-8-sig')))
+    names = {row['Name'].strip() for row in rows if row.get('Name', '').strip()}
+    for name in sorted(names):
+        print(name)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/contributed/devraw_t9_skyboxes_literal_images_20260904-135452.py
+++ b/scripts/contributed/devraw_t9_skyboxes_literal_images_20260904-135452.py
@@ -1,0 +1,26 @@
+"""Emit literal image labels physically retained by Nastian's T9 Skyboxes ZIP."""
+
+import sys
+import zipfile
+from pathlib import Path
+
+
+ARCHIVE = Path(".tmp-devraw-t9-skyboxes")
+PREFIX = "nastian - t9 skyboxes/texture_assets/black_ops_cw/skyboxes/"
+
+
+def main() -> None:
+    with zipfile.ZipFile(ARCHIVE) as archive:
+        labels = {
+            Path(entry.filename).stem.lower()
+            for entry in archive.infolist()
+            if not entry.is_dir()
+            and entry.filename.lower().startswith(PREFIX)
+            and entry.filename.lower().endswith(".exr")
+        }
+    for label in sorted(labels):
+        print(label)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/contributed/itsnatoriousb_bocw_perk_literals_20260904-135452.py
+++ b/scripts/contributed/itsnatoriousb_bocw_perk_literals_20260904-135452.py
@@ -1,0 +1,20 @@
+"""Emit exact perk labels from ItsNatoriousB's public BOCW asset directory."""
+
+from __future__ import annotations
+
+import csv
+import re
+from pathlib import Path
+
+
+source = Path("borrowed/bocw_asset_directory/_data/perks.csv")
+native = re.compile(r"^p9_talent_[a-z0-9_]+$")
+with source.open(newline="", encoding="utf-8") as handle:
+    labels = {
+        row[1].strip().lower()
+        for row in csv.reader(handle)
+        if len(row) == 3 and row[2].strip().lower() == "verified" and native.fullmatch(row[1].strip().lower())
+    }
+
+for label in sorted(labels):
+    print(label)

--- a/scripts/contributed/leading_token_counterparts_20260904-135452.py
+++ b/scripts/contributed/leading_token_counterparts_20260904-135452.py
@@ -1,0 +1,93 @@
+"""Controlled leading-basename-token counterparts.
+
+This is the leading-position mirror of the recent whole-frame interior-token
+relation.  It never changes a directory, tail, channel, numeric tag, or the
+number of tokens: only the first *alphabetic* basename token can change, and
+only if the exact retained frame has established that counterpart pairing many
+times in independently known names.  Middle substitutions, terminal roles,
+and token edits therefore do not subsume it.
+"""
+import argparse
+import collections
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+while ROOT != os.path.dirname(ROOT) and not os.path.isfile(
+    os.path.join(ROOT, "scripts", "snapshot.py")
+):
+    ROOT = os.path.dirname(ROOT)
+sys.path.insert(0, os.path.join(ROOT, "scripts"))
+import snapshot
+
+TABLES = ("fnv1a_xmodels", "fnv1a_xmaterials", "fnv1a_ximages", "fnv1a_xanims")
+WORD = re.compile(r"^[a-z]+$")
+MAX_CHOICES = 8
+EXCLUDED = {("i", "mtl"), ("mtl", "sub")}
+
+
+def corpus():
+    names = set(snapshot.table_names(*TABLES))
+    for kind in ("xmodel", "material", "image", "xanim"):
+        names.update(snapshot.confirmed_names(kind))
+    return {n.strip().lower().replace("\\\\", "/") for n in names if n.strip() and len(n) <= 240}
+
+
+def split(name):
+    directory, slash, base = name.rpartition("/")
+    first, sep, tail = base.partition("_")
+    if not slash or not sep or not tail or not WORD.fullmatch(first):
+        return None
+    return directory + slash, first, tail
+
+
+def build(known, minimum, maximum):
+    frames = collections.defaultdict(set)
+    for name in known:
+        parsed = split(name)
+        if parsed:
+            directory, first, tail = parsed
+            frames[(directory, tail)].add(first)
+    frames = {frame: choices for frame, choices in frames.items() if len(choices) <= MAX_CHOICES}
+    controls = collections.Counter()
+    for choices in frames.values():
+        for left in choices:
+            for right in choices:
+                if left < right:
+                    controls[(left, right)] += 1
+    # i<->mtl is the already-closed material/image seam, while mtl<->sub is
+    # its material-prefix analogue.  Both generate a broad prefix sweep, not
+    # a new counterpart convention, so their known controls are excluded.
+    eligible = {
+        pair for pair, count in controls.items()
+        if minimum <= count <= maximum and pair not in EXCLUDED
+    }
+    alternatives = collections.defaultdict(set)
+    for left, right in eligible:
+        alternatives[left].add(right)
+        alternatives[right].add(left)
+    out = set()
+    for (directory, tail), choices in frames.items():
+        for first in choices:
+            for other in alternatives[first]:
+                if other not in choices:
+                    out.add(directory + other + "_" + tail)
+    return out - known, len(eligible), sum(controls[p] for p in eligible)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--count", action="store_true")
+    parser.add_argument("--min-controls", type=int, default=100)
+    parser.add_argument("--max-controls", type=int, default=1000)
+    options = parser.parse_args()
+    known = corpus()
+    out, pairs, controls = build(known, options.min_controls, options.max_controls)
+    print(f"{len(known):,} non-sound names; {pairs:,} eligible leading pairs at {options.min_controls:,}..{options.max_controls:,} controls; {controls:,} exact-frame controls; {len(out):,} unseen candidates", file=sys.stderr)
+    if not options.count:
+        print("\n".join(sorted(out)))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/contributed/migi_bocw_aug_literal_textures_20260904-135452.py
+++ b/scripts/contributed/migi_bocw_aug_literal_textures_20260904-135452.py
@@ -1,0 +1,69 @@
+"""Emit exact BOCW-texture basenames retained in MIGI's public AUG VPK.
+
+This is deliberately not a conversion-path importer.  The release is a
+Source-engine port, but its VPK directory has a small contiguous group of
+literal `weapon_vm_sm_t9powerburst_*` texture filenames.  They are retained
+verbatim from the package; ordinary Source paths, game scripts, and generated
+skin icons are excluded.
+"""
+
+from __future__ import annotations
+
+import struct
+from pathlib import Path
+
+
+ARCHIVE = Path(".tmp-migi-aug/m_bocw_aug.vpk")
+PREFIX = "weapon_vm_sm_t9powerburst_"
+
+
+def c_string(blob: bytes, at: int) -> tuple[str, int]:
+    end = blob.index(0, at)
+    return blob[at:end].decode("utf-8", "replace"), end + 1
+
+
+def vpk_paths(path: Path) -> list[str]:
+    blob = path.read_bytes()
+    if struct.unpack_from("<I", blob, 0)[0] != 0x55AA1234:
+        raise ValueError(f"not a VPK: {path}")
+    version = struct.unpack_from("<I", blob, 4)[0]
+    if version not in (1, 2):
+        raise ValueError(f"unsupported VPK version {version}: {path}")
+    at = 28 if version == 2 else 12
+    tree_end = at + struct.unpack_from("<I", blob, 8)[0]
+    paths: list[str] = []
+    while at < tree_end:
+        extension, at = c_string(blob, at)
+        if not extension:
+            break
+        while True:
+            directory, at = c_string(blob, at)
+            if not directory:
+                break
+            while True:
+                basename, at = c_string(blob, at)
+                if not basename:
+                    break
+                paths.append(f"{directory}/{basename}.{extension}")
+                preload = struct.unpack_from("<H", blob, at + 4)[0]
+                at += 18 + preload
+    return paths
+
+
+def main() -> None:
+    paths = vpk_paths(ARCHIVE)
+    labels = {
+        Path(path).stem.lower()
+        for path in paths
+        if Path(path).stem.lower().startswith(PREFIX)
+    }
+    print(
+        f"MIGI BOCW AUG: {len(paths):,} VPK entries, "
+        f"{len(labels):,} literal T9 texture basenames",
+        file=__import__("sys").stderr,
+    )
+    print("\n".join(sorted(labels)))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/contributed/migi_bocw_grenades_release_audit_20260904-135452.py
+++ b/scripts/contributed/migi_bocw_grenades_release_audit_20260904-135452.py
@@ -1,0 +1,70 @@
+"""Emit literal native T9 material filenames from MIGI's BOCW grenade VPKs.
+
+This public GitHub release is a Source-engine conversion.  The surrounding
+Source paths are deliberately not candidates: only unaltered mtl_wpn_t9_*
+filenames physically retained in the VPK directory trees are emitted.
+"""
+
+from __future__ import annotations
+
+import struct
+import sys
+from pathlib import Path
+
+
+ROOT = Path(".tmp-cw-public-exports/migi_grenades_unpacked")
+
+
+def c_string(blob: bytes, at: int) -> tuple[str, int]:
+    end = blob.index(0, at)
+    return blob[at:end].decode("utf-8", "replace"), end + 1
+
+
+def vpk_paths(path: Path) -> list[str]:
+    blob = path.read_bytes()
+    if struct.unpack_from("<I", blob, 0)[0] != 0x55AA1234:
+        raise ValueError(f"not a VPK: {path}")
+    version = struct.unpack_from("<I", blob, 4)[0]
+    if version not in (1, 2):
+        raise ValueError(f"unsupported VPK version {version}: {path}")
+    at = 28 if version == 2 else 12
+    tree_end = at + struct.unpack_from("<I", blob, 8)[0]
+    paths: list[str] = []
+    while at < tree_end:
+        extension, at = c_string(blob, at)
+        if not extension:
+            break
+        while True:
+            directory, at = c_string(blob, at)
+            if not directory:
+                break
+            while True:
+                basename, at = c_string(blob, at)
+                if not basename:
+                    break
+                paths.append(f"{directory}/{basename}.{extension}")
+                preload = struct.unpack_from("<H", blob, at + 4)[0]
+                at += 18 + preload
+    return paths
+
+
+def main() -> None:
+    labels: set[str] = set()
+    entries = 0
+    for archive in sorted(ROOT.glob("*.vpk")):
+        paths = vpk_paths(archive)
+        entries += len(paths)
+        for name in paths:
+            stem = Path(name).stem.lower()
+            if stem.startswith("mtl_wpn_t9_"):
+                labels.add(stem)
+    print(
+        f"MIGI BOCW grenade release: {entries:,} VPK entries, "
+        f"{len(labels):,} literal native material labels",
+        file=sys.stderr,
+    )
+    print("\n".join(sorted(labels)))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/contributed/migi_bocw_melee_release_audit_20260904-135452.py
+++ b/scripts/contributed/migi_bocw_melee_release_audit_20260904-135452.py
@@ -1,0 +1,57 @@
+"""Audit literal labels retained in the public MIGI BOCW Melee VPK release."""
+
+from __future__ import annotations
+
+import struct
+import sys
+from pathlib import Path
+
+
+def c_string(blob: bytes, at: int) -> tuple[str, int]:
+    end = blob.index(0, at)
+    return blob[at:end].decode("utf-8", "replace"), end + 1
+
+
+def vpk_paths(path: Path) -> list[str]:
+    blob = path.read_bytes()
+    if struct.unpack_from("<I", blob, 0)[0] != 0x55AA1234:
+        raise ValueError(f"not a VPK: {path}")
+    version = struct.unpack_from("<I", blob, 4)[0]
+    if version not in (1, 2):
+        raise ValueError(f"unsupported VPK version {version}: {path}")
+    at = 28 if version == 2 else 12
+    tree_end = at + struct.unpack_from("<I", blob, 8)[0]
+    paths: list[str] = []
+    while at < tree_end:
+        extension, at = c_string(blob, at)
+        if not extension:
+            break
+        while True:
+            directory, at = c_string(blob, at)
+            if not directory:
+                break
+            while True:
+                basename, at = c_string(blob, at)
+                if not basename:
+                    break
+                paths.append(f"{directory}/{basename}.{extension}")
+                preload = struct.unpack_from("<H", blob, at + 4)[0]
+                at += 18 + preload
+    return paths
+
+
+root = Path(sys.argv[1]) if len(sys.argv) == 2 else Path("borrowed/migi_melee_unpacked")
+labels: set[str] = set()
+for archive in sorted(root.glob("*.vpk")):
+    names = vpk_paths(archive)
+    print(f"{archive.name}: {len(names)} entries", file=sys.stderr)
+    for name in names:
+        print(name, file=sys.stderr)
+        stem = Path(name).stem.lower()
+        # These are native-style literal filenames retained by the export.  The
+        # surrounding Source paths and all converted Source labels are excluded.
+        if stem.startswith("mtl_wpn_t9_"):
+            labels.add(stem)
+
+for label in sorted(labels):
+    print(label)

--- a/scripts/contributed/modme_bo4_misty_literal_export_20260904-135452.py
+++ b/scripts/contributed/modme_bo4_misty_literal_export_20260904-135452.py
@@ -1,0 +1,31 @@
+"""Emit literal model/image labels from Shadowily's public BO4 Misty export."""
+
+import re
+import sys
+import zipfile
+from pathlib import PurePosixPath
+
+
+ARCHIVE = ".tmp-modme-misty-bo4.zip"
+ROOT = "model_export/shadowily/xmodels/"
+SUFFIXES = (".xmodel_bin", ".tiff", ".tif", ".png", ".dds", ".tga")
+OPAQUE = re.compile(r"^(?:x?image|material)_[0-9a-f]+(?:_[a-z])?$")
+
+
+def main() -> None:
+    with zipfile.ZipFile(ARCHIVE) as archive:
+        labels = {
+            PurePosixPath(entry.filename.lower()).stem
+            for entry in archive.infolist()
+            if not entry.is_dir()
+            and entry.filename.lower().startswith(ROOT)
+            and entry.filename.lower().endswith(SUFFIXES)
+            and not OPAQUE.fullmatch(PurePosixPath(entry.filename.lower()).stem)
+        }
+    print(f"Modme BO4 Misty export: {len(labels):,} literal labels", file=sys.stderr)
+    for label in sorted(labels):
+        print(label)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/contributed/mountain_defence_cw_sabl_aliases_20260904-135452.py
+++ b/scripts/contributed/mountain_defence_cw_sabl_aliases_20260904-135452.py
@@ -1,0 +1,29 @@
+"""Emit literal Cold War weapon sound-alias labels retained in Mountain Defence's SABL bank.
+
+Run: python contrib/mountain_defence_cw_sabl_aliases_20260904.py | target\\release\\confirm_list.exe - --game BLKOPSCW --sounds --label "Mountain Defence CW SABL aliases" --script contrib\\mountain_defence_cw_sabl_aliases_20260904.py
+Reads: .tmp-steamcmd/steamapps/workshop/content/311210/2565091359/snd/*/*.sabl.
+Writes: one deduplicated, lower-case literal wpn_t9_* alias per stdout line.
+One-off: requires the anonymous Steam Workshop payload from this investigation.
+Measured: 6 distinct exact labels from nine SABL banks before confirmation.
+"""
+
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve()
+while ROOT.parent != ROOT and not (ROOT / "scripts" / "snapshot.py").is_file():
+    ROOT = ROOT.parent
+
+SABL = ROOT / ".tmp-steamcmd" / "steamapps" / "workshop" / "content" / "311210" / "2565091359" / "snd"
+PATTERN = re.compile(rb"wpn_t9_[a-z0-9_]{2,}")
+
+if not SABL.is_dir():
+    raise SystemExit(f"Workshop source is absent: {SABL}")
+
+names = set()
+for path in SABL.rglob("*.sabl"):
+    names.update(match.group().decode("ascii") for match in PATTERN.finditer(path.read_bytes()))
+
+for name in sorted(names):
+    print(name)

--- a/scripts/contributed/pmr360_bocw_m16a1_archive_20260904-135452.py
+++ b/scripts/contributed/pmr360_bocw_m16a1_archive_20260904-135452.py
@@ -1,0 +1,48 @@
+"""Emit literal native asset filenames from pmr360's public BOCW M16A1 export.
+
+The archive is a BO3 port, so placement, GDT and source-data paths are excluded.
+Only original-looking Greyhound export filenames beneath model_export/images and
+sound_assets are candidates; no opaque hash placeholders or reconstructed names
+are emitted.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import PurePosixPath
+
+
+ARCHIVE = ".tmp-cw-public-exports/pmr360_bocw_m16a1.rar"
+MODEL_OR_IMAGE = re.compile(
+    r"^(?:model_export/.+/[^/]+\.xmodel_bin|model_export/.+/images/[^/]+\.png)$",
+    re.IGNORECASE,
+)
+SOUND = re.compile(r"^sound_assets/(t9_weapons/.+)\.wav$", re.IGNORECASE)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--sounds", action="store_true")
+    args = parser.parse_args()
+    listing = subprocess.check_output(["tar", "-tf", ARCHIVE], text=True)
+    names: set[str] = set()
+    for line in listing.splitlines():
+        path = line.replace("\\\\", "/")
+        if args.sounds:
+            match = SOUND.match(path)
+            if match:
+                names.add(match.group(1))
+        elif MODEL_OR_IMAGE.match(path):
+            stem = PurePosixPath(path).stem
+            if not stem.lower().startswith(("ximage_", "image_", "material_", "xmodel_")):
+                names.add(stem)
+    kind = "sound paths" if args.sounds else "model and image names"
+    print(f"pmr360 BOCW M16A1 archive: {len(names):,} literal native {kind}", file=sys.stderr)
+    print("\n".join(sorted(names)))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/contributed/projectdonetsk_t9_hash_comments_20260904-135452.py
+++ b/scripts/contributed/projectdonetsk_t9_hash_comments_20260904-135452.py
@@ -1,0 +1,38 @@
+"""Exact label comments from ProjectDonetsk/T9's CW material registration code.
+
+The source gives both literal spellings and the loader-hash constants, so this
+does not infer names from opaque numbers.  Keep this deliberately tiny: other
+strings in the project are UI, command, or engine vocabulary rather than asset
+labels.
+"""
+
+from pathlib import Path
+
+SOURCE = Path("borrowed/ProjectDonetsk-T9/hook_lib/console.cpp")
+EXPECTED = {
+    '0x4ED973885856E206': 'white',
+    '0xB160909B712F8F9': 'lui_loader_no_offset',
+}
+
+
+def fnv1a(text: str) -> int:
+    value = 0xCBF29CE484222325
+    for byte in text.encode('utf-8'):
+        value = ((value ^ byte) * 0x100000001B3) & 0xFFFFFFFFFFFFFFFF
+    return value
+
+
+def main() -> None:
+    source = SOURCE.read_text(encoding='utf-8')
+    for hashed, label in EXPECTED.items():
+        marker = f'{hashed} = "{label}"'
+        if marker not in source:
+            raise SystemExit(f'missing verified source comment: {marker}')
+        # T9 loader ids clear bit 63; the comment uses that loader form.
+        if (fnv1a(label) & ((1 << 63) - 1)) != int(hashed, 16):
+            raise SystemExit(f'hash mismatch for {label}')
+        print(label)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/contributed/skye_bo4_workshop_sabl_aliases_20260904-135452.py
+++ b/scripts/contributed/skye_bo4_workshop_sabl_aliases_20260904-135452.py
@@ -1,0 +1,29 @@
+"""Emit literal BO4 weapon sound-alias labels retained in Skye's public Workshop pack.
+
+Run: python contrib/skye_bo4_workshop_sabl_aliases_20260904.py | target\\release\\confirm_list.exe - --game BLKOPS04 --sounds --no-fold --label "Skye BO4 Steam Workshop SABL aliases" --script contrib\\skye_bo4_workshop_sabl_aliases_20260904.py
+Reads: .tmp-steamcmd/steamapps/workshop/content/311210/1845221515/snd/*/*.sabl.
+Writes: one deduplicated, lower-case literal wpn_t8_* alias per stdout line.
+One-off: requires the public anonymous Steam Workshop payload downloaded by this investigation.
+Measured: 307 distinct exact labels from nine SABL banks before confirmation.
+"""
+
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve()
+while ROOT.parent != ROOT and not (ROOT / "scripts" / "snapshot.py").is_file():
+    ROOT = ROOT.parent
+
+SABL = ROOT / ".tmp-steamcmd" / "steamapps" / "workshop" / "content" / "311210" / "1845221515" / "snd"
+PATTERN = re.compile(rb"wpn_t8_[a-z0-9_]{2,}")
+
+if not SABL.is_dir():
+    raise SystemExit(f"Workshop source is absent: {SABL}")
+
+names = set()
+for path in SABL.rglob("*.sabl"):
+    names.update(match.group().decode("ascii") for match in PATTERN.finditer(path.read_bytes()))
+
+for name in sorted(names):
+    print(name)

--- a/scripts/contributed/skye_cw_1911_icloud_models_anims_20260904-135452.py
+++ b/scripts/contributed/skye_cw_1911_icloud_models_anims_20260904-135452.py
@@ -1,0 +1,85 @@
+"""Literal model and animation filenames from Skye's public CW 1911 iCloud export.
+
+The source ZIP is `Skye_CW_1911.zip`, shared from the original UGX release page.
+Only basenames physically present as .xmodel_bin/.xanim_bin are included.  Port
+placement paths, GDT text, combined exporter image names, and audio paths are
+intentionally not treated as game labels.
+"""
+
+MODELS = """\
+am_t9_1911
+am_t9_1911_fdw
+vm_t9_1911
+vm_t9_1911_extmag2
+vm_t9_1911_ldw
+vm_t9_1911_ldw_up
+vm_t9_1911_long_slide2
+vm_t9_1911_long_slide2+mix_muzzle
+vm_t9_1911_mag
+vm_t9_1911_mix_handle
+vm_t9_1911_mix_muzzle
+vm_t9_1911_slide
+wm_t9_1911
+wm_t9_1911_extmag2
+wm_t9_1911_grenade
+wm_t9_1911_ldw
+wm_t9_1911_ldw_up
+wm_t9_1911_long_slide2
+wm_t9_1911_long_slide2+mix_muzzle
+wm_t9_1911_mag
+wm_t9_1911_mix_handle
+wm_t9_1911_mix_muzzle
+wm_t9_1911_slide
+""".splitlines()
+
+ANIMS = """\
+am_t9_1911_ads_down
+am_t9_1911_ads_fire
+am_t9_1911_ads_up
+am_t9_1911_crawl_back
+am_t9_1911_crawl_forward
+am_t9_1911_crawl_in
+am_t9_1911_crawl_left
+am_t9_1911_crawl_out
+am_t9_1911_crawl_right
+am_t9_1911_fdw_crawl_back
+am_t9_1911_fdw_crawl_forward
+am_t9_1911_fdw_crawl_in
+am_t9_1911_fdw_crawl_left
+am_t9_1911_fdw_crawl_out
+am_t9_1911_fdw_crawl_right
+am_t9_1911_fdw_first_raise
+am_t9_1911_fdw_inspect
+am_t9_1911_fdw_pullout
+am_t9_1911_fdw_putaway
+am_t9_1911_fdw_slide_idle
+am_t9_1911_fdw_sprint_in
+am_t9_1911_fdw_sprint_loop
+am_t9_1911_fdw_sprint_out
+am_t9_1911_fire
+am_t9_1911_first_raise
+am_t9_1911_idle
+am_t9_1911_inspect
+am_t9_1911_ldw_fire
+am_t9_1911_ldw_idle
+am_t9_1911_ldw_reload
+am_t9_1911_ldw_reload_empty
+am_t9_1911_pullout
+am_t9_1911_putaway
+am_t9_1911_rdw_fire
+am_t9_1911_rdw_idle
+am_t9_1911_rdw_reload
+am_t9_1911_rdw_reload_empty
+am_t9_1911_reload
+am_t9_1911_reload_empty
+am_t9_1911_slide_air_in
+am_t9_1911_slide_in
+am_t9_1911_slide_loop
+am_t9_1911_slide_out
+am_t9_1911_sprint_in
+am_t9_1911_sprint_loop
+am_t9_1911_sprint_out
+""".splitlines()
+
+if __name__ == "__main__":
+    print("\n".join(MODELS + ANIMS))

--- a/scripts/contributed/skye_cw_aug_icloud_models_anims_20260904-135452.py
+++ b/scripts/contributed/skye_cw_aug_icloud_models_anims_20260904-135452.py
@@ -1,0 +1,34 @@
+"""Strict model/animation labels from Skye's public individual CW AUG export.
+
+The ZIP is an original-export-backed BO3 port.  Only verbatim `.xmodel_bin`
+and `.xanim_bin` basenames physically present in its export trees are emitted.
+Placement, GDT/source-data, generated image composites, and audio paths whose
+original full game path is not preserved are deliberately excluded.
+"""
+
+from __future__ import annotations
+
+import sys
+import zipfile
+from pathlib import Path
+
+
+ARCHIVE = Path(".tmp-skye-cw-aug.zip")
+
+
+def main() -> None:
+    with zipfile.ZipFile(ARCHIVE) as archive:
+        names = {
+            Path(path).stem.lower()
+            for path in archive.namelist()
+            if path.endswith((".xmodel_bin", ".xanim_bin"))
+        }
+    print(
+        f"Skye CW AUG: {len(names):,} literal xmodel/xanim basenames",
+        file=sys.stderr,
+    )
+    print("\n".join(sorted(names)))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/contributed/skye_cw_c58_icloud_models_anims_20260904-135452.py
+++ b/scripts/contributed/skye_cw_c58_icloud_models_anims_20260904-135452.py
@@ -1,0 +1,42 @@
+"""Strict filenames from Skye's public, individual CW C58 iCloud export.
+
+Unlike the unavailable bulk Weapon Common bundle, the UGX hub links this archive
+directly.  The iCloud short GUID is resolved through Apple's public CloudKit
+record endpoint; only literal .xmodel_bin and .xanim_bin basenames in its ZIP
+are emitted.  It intentionally excludes paths, GDT/script text, image export
+composites, and audio filenames lacking their original full game path.
+"""
+
+import io
+import json
+import urllib.request
+import zipfile
+
+GUID = "0d4NgRk_us0fyWCg5Gn6f9Piw"
+RESOLVE = "https://ckdatabasews.icloud.com/database/1/com.apple.clouddocs/production/public/records/resolve"
+
+
+def archive_url() -> str:
+    request = urllib.request.Request(
+        RESOLVE,
+        data=json.dumps({"shortGUIDs": [{"value": GUID}]}).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(request, timeout=60) as response:
+        record = json.load(response)["results"][0]["rootRecord"]["fields"]
+    name = json.loads(json.dumps(record["encryptedBasename"]["value"]))
+    # Apple encodes the basename as ordinary base64, not a candidate name.
+    import base64
+    filename = base64.b64decode(name).decode() + "." + record["extension"]["value"]
+    return record["fileContent"]["value"]["downloadURL"].replace("${f}", filename)
+
+
+if __name__ == "__main__":
+    with urllib.request.urlopen(archive_url(), timeout=300) as response:
+        archive = zipfile.ZipFile(io.BytesIO(response.read()))
+    names = {
+        path.rsplit("/", 1)[-1].rsplit(".", 1)[0]
+        for path in archive.namelist()
+        if path.endswith((".xmodel_bin", ".xanim_bin"))
+    }
+    print("\n".join(sorted(names)))

--- a/scripts/contributed/skye_cw_ironhide_icloud_models_anims_20260904-135452.py
+++ b/scripts/contributed/skye_cw_ironhide_icloud_models_anims_20260904-135452.py
@@ -1,0 +1,41 @@
+"""Strict filenames from Skye's public, individual CW .410 Ironhide iCloud export.
+
+The public UGX hub links this archive separately.  Its Apple iCloud short GUID
+is resolved through the public CloudKit record endpoint.  Only exact filenames
+with native export extensions are emitted; no output path, GDT/script text,
+image export composite, or incomplete audio path is made into a candidate.
+"""
+
+import base64
+import io
+import json
+import urllib.request
+import zipfile
+
+GUID = "0f7LEFZ24ypwmvgIVvJXjOJtw"
+RESOLVE = "https://ckdatabasews.icloud.com/database/1/com.apple.clouddocs/production/public/records/resolve"
+
+
+def archive_url() -> str:
+    request = urllib.request.Request(
+        RESOLVE,
+        data=json.dumps({"shortGUIDs": [{"value": GUID}]}).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(request, timeout=60) as response:
+        fields = json.load(response)["results"][0]["rootRecord"]["fields"]
+    filename = base64.b64decode(fields["encryptedBasename"]["value"]).decode()
+    return fields["fileContent"]["value"]["downloadURL"].replace(
+        "${f}", filename + "." + fields["extension"]["value"]
+    )
+
+
+if __name__ == "__main__":
+    with urllib.request.urlopen(archive_url(), timeout=300) as response:
+        archive = zipfile.ZipFile(io.BytesIO(response.read()))
+    names = {
+        path.rsplit("/", 1)[-1].rsplit(".", 1)[0]
+        for path in archive.namelist()
+        if path.endswith((".xmodel_bin", ".xanim_bin"))
+    }
+    print("\n".join(sorted(names)))

--- a/scripts/contributed/skye_cw_lapa_icloud_models_anims_20260904-135452.py
+++ b/scripts/contributed/skye_cw_lapa_icloud_models_anims_20260904-135452.py
@@ -1,0 +1,30 @@
+"""Emit literal model and animation labels retained by Skye's public LAPA archive.
+
+The source is the public iCloud document Skye_CW_LAPA.zip.  Only .xmodel_bin
+and .xanim_bin entry stems are retained.  WAV leaves deliberately remain
+excluded: all are in the port staging directory sound_assets/skye_ports and
+are not original native sound-file paths or aliases.
+"""
+
+import sys
+import zipfile
+from pathlib import Path
+
+
+ARCHIVE = Path(".tmp-skye-cw-lapa.zip")
+NATIVE_SUFFIXES = (".xmodel_bin", ".xanim_bin")
+
+
+def main() -> None:
+    with zipfile.ZipFile(ARCHIVE) as archive:
+        labels = {
+            Path(entry.filename).stem.lower()
+            for entry in archive.infolist()
+            if not entry.is_dir() and entry.filename.lower().endswith(NATIVE_SUFFIXES)
+        }
+    for label in sorted(labels):
+        print(label)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/contributed/skye_cw_m79_icloud_models_anims_20260904-135452.py
+++ b/scripts/contributed/skye_cw_m79_icloud_models_anims_20260904-135452.py
@@ -1,0 +1,41 @@
+"""Strict model/animation filenames from Skye's public CW M79 iCloud export.
+
+The public UGX hub links this as an individual archive.  It does contain WAVs,
+but every one is below the port-only `sound_assets/skye_ports/` staging path;
+without a retained original full game path or explicit alias field they are not
+sound candidates.  Emit only literal .xmodel_bin and .xanim_bin basenames.
+"""
+
+import base64
+import io
+import json
+import urllib.request
+import zipfile
+
+GUID = "091KGhWk0x1d3KPrOMFre7oiQ"
+RESOLVE = "https://ckdatabasews.icloud.com/database/1/com.apple.clouddocs/production/public/records/resolve"
+
+
+def archive_url() -> str:
+    request = urllib.request.Request(
+        RESOLVE,
+        data=json.dumps({"shortGUIDs": [{"value": GUID}]}).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(request, timeout=60) as response:
+        fields = json.load(response)["results"][0]["rootRecord"]["fields"]
+    filename = base64.b64decode(fields["encryptedBasename"]["value"]).decode()
+    return fields["fileContent"]["value"]["downloadURL"].replace(
+        "${f}", filename + "." + fields["extension"]["value"]
+    )
+
+
+if __name__ == "__main__":
+    with urllib.request.urlopen(archive_url(), timeout=300) as response:
+        archive = zipfile.ZipFile(io.BytesIO(response.read()))
+    names = {
+        path.rsplit("/", 1)[-1].rsplit(".", 1)[0]
+        for path in archive.namelist()
+        if path.endswith((".xmodel_bin", ".xanim_bin"))
+    }
+    print("\n".join(sorted(names)))

--- a/scripts/contributed/skye_cw_m82_icloud_models_anims_20260904-135452.py
+++ b/scripts/contributed/skye_cw_m82_icloud_models_anims_20260904-135452.py
@@ -1,0 +1,34 @@
+"""Strict model/animation labels from Skye's public individual CW M82 export.
+
+Only exact `.xmodel_bin` and `.xanim_bin` basenames physically retained in the
+original-export-backed ZIP are emitted.  Port placement, GDT/source data,
+generated image composites, and audio paths without their full native game
+path are excluded rather than reconstructed.
+"""
+
+from __future__ import annotations
+
+import sys
+import zipfile
+from pathlib import Path
+
+
+ARCHIVE = Path(".tmp-skye-cw-m82.zip")
+
+
+def main() -> None:
+    with zipfile.ZipFile(ARCHIVE) as archive:
+        names = {
+            Path(path).stem.lower()
+            for path in archive.namelist()
+            if path.endswith((".xmodel_bin", ".xanim_bin"))
+        }
+    print(
+        f"Skye CW M82: {len(names):,} literal xmodel/xanim basenames",
+        file=sys.stderr,
+    )
+    print("\n".join(sorted(names)))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/contributed/skye_cw_type63_icloud_models_anims_20260904-135452.py
+++ b/scripts/contributed/skye_cw_type63_icloud_models_anims_20260904-135452.py
@@ -1,0 +1,41 @@
+"""Strict model/animation filenames from Skye's public CW Type 63 iCloud export.
+
+The individual package is linked by Skye's UGX BO:CW weapon hub.  Resolve the
+public CloudKit short GUID, enumerate its ZIP, and emit only exact native
+.xmodel_bin and .xanim_bin basenames.  It deliberately rejects all port
+placement paths, source/GDT labels, image composites, and incomplete sounds.
+"""
+
+import base64
+import io
+import json
+import urllib.request
+import zipfile
+
+GUID = "0d5kzCUO63cYSffmG87a3fAsg"
+RESOLVE = "https://ckdatabasews.icloud.com/database/1/com.apple.clouddocs/production/public/records/resolve"
+
+
+def archive_url() -> str:
+    request = urllib.request.Request(
+        RESOLVE,
+        data=json.dumps({"shortGUIDs": [{"value": GUID}]}).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(request, timeout=60) as response:
+        fields = json.load(response)["results"][0]["rootRecord"]["fields"]
+    filename = base64.b64decode(fields["encryptedBasename"]["value"]).decode()
+    return fields["fileContent"]["value"]["downloadURL"].replace(
+        "${f}", filename + "." + fields["extension"]["value"]
+    )
+
+
+if __name__ == "__main__":
+    with urllib.request.urlopen(archive_url(), timeout=600) as response:
+        archive = zipfile.ZipFile(io.BytesIO(response.read()))
+    names = {
+        path.rsplit("/", 1)[-1].rsplit(".", 1)[0]
+        for path in archive.namelist()
+        if path.endswith((".xmodel_bin", ".xanim_bin"))
+    }
+    print("\n".join(sorted(names)))

--- a/scripts/contributed/skye_cw_weapon_common_icloud_models_anims_20260904-135452.py
+++ b/scripts/contributed/skye_cw_weapon_common_icloud_models_anims_20260904-135452.py
@@ -1,0 +1,42 @@
+"""Strict model/animation filenames from Skye's public CW Weapon Common export.
+
+This is the shared support bundle linked separately by Skye's UGX BO:CW hub.
+It is resolved through Apple's public CloudKit endpoint and read directly from
+the public ZIP.  Only literal .xmodel_bin and .xanim_bin basenames are emitted:
+paths, source/GDT files, exporter image composites, and incomplete sound paths
+are deliberately not converted into putative game names.
+"""
+
+import base64
+import io
+import json
+import urllib.request
+import zipfile
+
+GUID = "0d7YBUnLD5XTlnXFFn9e6qNyQ"
+RESOLVE = "https://ckdatabasews.icloud.com/database/1/com.apple.clouddocs/production/public/records/resolve"
+
+
+def archive_url() -> str:
+    request = urllib.request.Request(
+        RESOLVE,
+        data=json.dumps({"shortGUIDs": [{"value": GUID}]}).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(request, timeout=60) as response:
+        fields = json.load(response)["results"][0]["rootRecord"]["fields"]
+    filename = base64.b64decode(fields["encryptedBasename"]["value"]).decode()
+    return fields["fileContent"]["value"]["downloadURL"].replace(
+        "${f}", filename + "." + fields["extension"]["value"]
+    )
+
+
+if __name__ == "__main__":
+    with urllib.request.urlopen(archive_url(), timeout=600) as response:
+        archive = zipfile.ZipFile(io.BytesIO(response.read()))
+    names = {
+        path.rsplit("/", 1)[-1].rsplit(".", 1)[0]
+        for path in archive.namelist()
+        if path.endswith((".xmodel_bin", ".xanim_bin"))
+    }
+    print("\n".join(sorted(names)))

--- a/scripts/contributed/skye_cw_workshop_sabl_aliases_20260904-135452.py
+++ b/scripts/contributed/skye_cw_workshop_sabl_aliases_20260904-135452.py
@@ -1,0 +1,23 @@
+"""Emit literal Cold War weapon sound-alias labels retained in Skye's public Workshop pack.
+
+Run: python contrib/skye_cw_workshop_sabl_aliases_20260904.py | target\\release\\confirm_list.exe - --game BLKOPSCW --sounds --label "Skye CW Steam Workshop SABL aliases" --script contrib\\skye_cw_workshop_sabl_aliases_20260904.py
+Reads: .tmp-steamcmd/steamapps/workshop/content/311210/2753027294/snd/*/*.sabl.
+Writes: one deduplicated, lower-case literal wpn_t9_* alias per stdout line.
+One-off: requires the public anonymous Steam Workshop payload from this investigation.
+Measured: 1,836 distinct exact labels from nine SABL banks before confirmation.
+"""
+from pathlib import Path
+import re
+
+root = Path(__file__).resolve()
+while root.parent != root and not (root / "scripts" / "snapshot.py").is_file():
+    root = root.parent
+sabl = root / ".tmp-steamcmd" / "steamapps" / "workshop" / "content" / "311210" / "2753027294" / "snd"
+if not sabl.is_dir():
+    raise SystemExit(f"Workshop source is absent: {sabl}")
+pat = re.compile(rb"wpn_t9_[a-z0-9_]{2,}")
+names = set()
+for path in sabl.rglob("*.sabl"):
+    names.update(m.group().decode("ascii") for m in pat.finditer(path.read_bytes()))
+for name in sorted(names):
+    print(name)

--- a/scripts/contributed/skye_cw_zrg_icloud_models_anims_20260904-135452.py
+++ b/scripts/contributed/skye_cw_zrg_icloud_models_anims_20260904-135452.py
@@ -1,0 +1,33 @@
+"""Strict model/animation labels from Skye's public individual CW ZRG export.
+
+Only exact `.xmodel_bin` and `.xanim_bin` basenames physically retained in the
+original-export-backed ZIP are emitted.  Its audio leaf filenames live below
+the port staging path, not their original full game paths, and are excluded.
+"""
+
+from __future__ import annotations
+
+import sys
+import zipfile
+from pathlib import Path
+
+
+ARCHIVE = Path(".tmp-skye-cw-zrg.zip")
+
+
+def main() -> None:
+    with zipfile.ZipFile(ARCHIVE) as archive:
+        names = {
+            Path(path).stem.lower()
+            for path in archive.namelist()
+            if path.endswith((".xmodel_bin", ".xanim_bin"))
+        }
+    print(
+        f"Skye CW ZRG 20mm: {len(names):,} literal xmodel/xanim basenames",
+        file=sys.stderr,
+    )
+    print("\n".join(sorted(names)))
+
+
+if __name__ == "__main__":
+    main()

--- a/submissions/Hexeption_BLKOPSCW_20260904-135452/about_20260904-135452.md
+++ b/submissions/Hexeption_BLKOPSCW_20260904-135452/about_20260904-135452.md
@@ -1,0 +1,38 @@
+# Submission 20260904-135452
+
+- game: **BLKOPSCW**
+- from: Hexeption
+- names: 1
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- material: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 47 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260904-135401_plan
+- method: external BO4 xhash cores under uncarried endings ranks 3001-6000
+- what it does: real external BO4 xhash cores crossed with a disjoint measured ending band
+- ran for: 7s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- beginnings: 0
+- endings: 3000
+- stems: 398742
+- ids hunted: 108931
+- candidates tested: 1196624742
+- new: 1
+- sketch beginnings: 
+- sketch stems: 000052eddb08e5db000072ae09156ad4000080369e140a2c00008b81bf985ff600009366d62bbebb0000d86305422c730000d86ce7b41ecb0000e429b662e5770000f8739296b6aa00012331f694355700013380aa5605d300014832fe11463f0001c207889f6dd40001d42da712184b0001f471377477a30001f65a3cad715a000209f2e21832f3000242bb5398103e00028cf6802537780002b24c9de41f950002b6e5b29c8d570002d0632dc242f10002fe9de7e41c8f00031e7244391c2d000340a19ee4a749000355146323b278000357569aef074c00037470f081bae500037838e9997c540003b3bed01f5c4a0003d0bd417cce070003e7b397f5c32c
+- sketch endings: 002e0040dcecd9c9003d77e59779a98600565747d8d0b86b009155852b12521c00b59d420d2dab1f00c1bd148f58d01900d298fc0fafc55900d40d7699347c6000f32166c0de5624013eeebac619b7cd015ed5185c7faf5901a4a1e7925efa3001beb7f2041b31e501d60d65427efcfb0209818c907f3e32020b188a59cda35a020b5891c64b77f60215be549f21a25902189be8f657fcab02225ed670f6d2c60228453e28a9b697023e43e79e3be6fe02647bd0626c2cbd0269a59143a31d030280173f6d0adc58029bf4ec354e519002b6002919cc69ca02bea5c53c30714d030131b53ff58641033adc5aeacc995d034256bd187779e00349c2e64a70504e
+- fingerprint: 319947c87fe7f820
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/Hexeption_BLKOPSCW_20260904-135452/material_20260904-135452.txt
+++ b/submissions/Hexeption_BLKOPSCW_20260904-135452/material_20260904-135452.txt
@@ -1,0 +1,1 @@
+60f371af47665750,set_stencil_masked


### PR DESCRIPTION
**BLKOPSCW** — 1 asset names, confirmed against that game's own loaded assets.

- material: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Hexeption

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260904-135401_plan
- method: external BO4 xhash cores under uncarried endings ranks 3001-6000
- what it does: real external BO4 xhash cores crossed with a disjoint measured ending band
- ran for: 7s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- beginnings: 0
- endings: 3000
- stems: 398742
- ids hunted: 108931
- candidates tested: 1196624742
- new: 1
- sketch beginnings: 
- sketch stems: 000052eddb08e5db000072ae09156ad4000080369e140a2c00008b81bf985ff600009366d62bbebb0000d86305422c730000d86ce7b41ecb0000e429b662e5770000f8739296b6aa00012331f694355700013380aa5605d300014832fe11463f0001c207889f6dd40001d42da712184b0001f471377477a30001f65a3cad715a000209f2e21832f3000242bb5398103e00028cf6802537780002b24c9de41f950002b6e5b29c8d570002d0632dc242f10002fe9de7e41c8f00031e7244391c2d000340a19ee4a749000355146323b278000357569aef074c00037470f081bae500037838e9997c540003b3bed01f5c4a0003d0bd417cce070003e7b397f5c32c
- sketch endings: 002e0040dcecd9c9003d77e59779a98600565747d8d0b86b009155852b12521c00b59d420d2dab1f00c1bd148f58d01900d298fc0fafc55900d40d7699347c6000f32166c0de5624013eeebac619b7cd015ed5185c7faf5901a4a1e7925efa3001beb7f2041b31e501d60d65427efcfb0209818c907f3e32020b188a59cda35a020b5891c64b77f60215be549f21a25902189be8f657fcab02225ed670f6d2c60228453e28a9b697023e43e79e3be6fe02647bd0626c2cbd0269a59143a31d030280173f6d0adc58029bf4ec354e519002b6002919cc69ca02bea5c53c30714d030131b53ff58641033adc5aeacc995d034256bd187779e00349c2e64a70504e
- fingerprint: 319947c87fe7f820

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/bo4_material_interior_counterparts_20260904-135452.py`
- `scripts/contributed/bo4_workshop_embedded_literals_20260904-135452.py`
- `scripts/contributed/devraw_alistairs_folly_bo4_20260904-135452.py`
- `scripts/contributed/devraw_bo4_ix_zombie_models_20260904-135452.py`
- `scripts/contributed/devraw_cw_die_maschine_export_20260904-135452.py`
- `scripts/contributed/devraw_cw_zombie_pack_export_20260904-135452.py`
- `scripts/contributed/devraw_cw_zombie_vox_aliases_20260904-135452.py`
- `scripts/contributed/devraw_t9_skyboxes_literal_images_20260904-135452.py`
- `scripts/contributed/itsnatoriousb_bocw_perk_literals_20260904-135452.py`
- `scripts/contributed/leading_token_counterparts_20260904-135452.py`
- `scripts/contributed/migi_bocw_aug_literal_textures_20260904-135452.py`
- `scripts/contributed/migi_bocw_grenades_release_audit_20260904-135452.py`
- `scripts/contributed/migi_bocw_melee_release_audit_20260904-135452.py`
- `scripts/contributed/modme_bo4_misty_literal_export_20260904-135452.py`
- `scripts/contributed/mountain_defence_cw_sabl_aliases_20260904-135452.py`
- `scripts/contributed/pmr360_bocw_m16a1_archive_20260904-135452.py`
- `scripts/contributed/projectdonetsk_t9_hash_comments_20260904-135452.py`
- `scripts/contributed/skye_bo4_workshop_sabl_aliases_20260904-135452.py`
- `scripts/contributed/skye_cw_1911_icloud_models_anims_20260904-135452.py`
- `scripts/contributed/skye_cw_aug_icloud_models_anims_20260904-135452.py`
- `scripts/contributed/skye_cw_c58_icloud_models_anims_20260904-135452.py`
- `scripts/contributed/skye_cw_ironhide_icloud_models_anims_20260904-135452.py`
- `scripts/contributed/skye_cw_lapa_icloud_models_anims_20260904-135452.py`
- `scripts/contributed/skye_cw_m79_icloud_models_anims_20260904-135452.py`
- `scripts/contributed/skye_cw_m82_icloud_models_anims_20260904-135452.py`
- `scripts/contributed/skye_cw_type63_icloud_models_anims_20260904-135452.py`
- `scripts/contributed/skye_cw_weapon_common_icloud_models_anims_20260904-135452.py`
- `scripts/contributed/skye_cw_workshop_sabl_aliases_20260904-135452.py`
- `scripts/contributed/skye_cw_zrg_icloud_models_anims_20260904-135452.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.