### PR TITLE
[BLKOPS04] findings from Tnt540, 20260904-141719 (1 names)

### DIFF
--- a/submissions/Tnt540_BLKOPS04_20260904-141719/about_20260904-141719.md
+++ b/submissions/Tnt540_BLKOPS04_20260904-141719/about_20260904-141719.md
@@ -1,0 +1,38 @@
+# Submission 20260904-141719
+
+- game: **BLKOPS04**
+- from: Tnt540
+- names: 1
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- sound_alias: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 49 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260904-133342_plan
+- method: BLKOPS04-scoped all-boundary cores x ALL uncarried 2-segment endings, refreshed lists, 2026-09-04
+- what it does: full-corpus all-boundary cores x every 2-segment ending the freshly re-derived data/suffixes.txt cannot express
+- ran for: 5m 14s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- beginnings: 0
+- endings: 493053
+- stems: 174910
+- ids hunted: 139543
+- candidates tested: 86240075140
+- new: 1
+- sketch beginnings: 
+- sketch stems: 00002b1519e1ded400002ee0bf50cc960000ef4a2113a6a70001350db49850c6000196f66cc5bd0a0001aef44909c8860001c4288d1f83f80001d42da712184b0002257ec18410d600033cf2e70d986600033f547a90eb950003b69caf19a9720003df052c8c65a400041bbbb5029bd70004411f5ae467110004a5cf1343b3860004f9caa2916c42000624bd7bcc757200063685031d44230006518ce0f1ed4d00068f4e032473900006b5e60602d68c0007d55dbb0777ea0009fc4ea542379a000a6d6d22ada5ec000b32b8830e99c2000c7c620254ad84000c9eb9db01a880000caad68ac532c4000d02e08a26b568000d2a274f32763e000d4e4e5c704308
+- sketch endings: 00000437e7e3265d0000328fdf29297d0000e35c6c69277d0000f80b42573800000146b28515c0520001b12d08d4449d0001bf49f7ec48d30001c22fe277bbea0001df6ac08d34280002074262ab1450000229682628f65c000271aa0414ec0b0002870773fc5369000296738b8b9dc800029a97070c068c00029f596e78e4ba0002da8ef2e22ceb0002f19f220c9bff0003209c813235e00003283825d3852700036838f2a1aa55000368909aaa7dc600036f9be4acc5f80003880572850df10003b3843a5153f00003c818cfdeb8b10003d39fa7cbfff10003f9b03b31b1a900042e2460797fca000469013a25e6b500047dc1a6225a030004b013cb160f72
+- fingerprint: 35d328d1ff412091
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/Tnt540_BLKOPS04_20260904-141719/sound_alias_20260904-141719.txt
+++ b/submissions/Tnt540_BLKOPS04_20260904-141719/sound_alias_20260904-141719.txt
@@ -1,0 +1,1 @@
+552770ffaeb53c11,vox_engi_ae_smrt_cvr_use_fail


### PR DESCRIPTION
**BLKOPS04** — 1 asset names, confirmed against that game's own loaded assets.

- sound_alias: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Tnt540

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260904-133342_plan
- method: BLKOPS04-scoped all-boundary cores x ALL uncarried 2-segment endings, refreshed lists, 2026-09-04
- what it does: full-corpus all-boundary cores x every 2-segment ending the freshly re-derived data/suffixes.txt cannot express
- ran for: 5m 14s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- beginnings: 0
- endings: 493053
- stems: 174910
- ids hunted: 139543
- candidates tested: 86240075140
- new: 1
- sketch beginnings: 
- sketch stems: 00002b1519e1ded400002ee0bf50cc960000ef4a2113a6a70001350db49850c6000196f66cc5bd0a0001aef44909c8860001c4288d1f83f80001d42da712184b0002257ec18410d600033cf2e70d986600033f547a90eb950003b69caf19a9720003df052c8c65a400041bbbb5029bd70004411f5ae467110004a5cf1343b3860004f9caa2916c42000624bd7bcc757200063685031d44230006518ce0f1ed4d00068f4e032473900006b5e60602d68c0007d55dbb0777ea0009fc4ea542379a000a6d6d22ada5ec000b32b8830e99c2000c7c620254ad84000c9eb9db01a880000caad68ac532c4000d02e08a26b568000d2a274f32763e000d4e4e5c704308
- sketch endings: 00000437e7e3265d0000328fdf29297d0000e35c6c69277d0000f80b42573800000146b28515c0520001b12d08d4449d0001bf49f7ec48d30001c22fe277bbea0001df6ac08d34280002074262ab1450000229682628f65c000271aa0414ec0b0002870773fc5369000296738b8b9dc800029a97070c068c00029f596e78e4ba0002da8ef2e22ceb0002f19f220c9bff0003209c813235e00003283825d3852700036838f2a1aa55000368909aaa7dc600036f9be4acc5f80003880572850df10003b3843a5153f00003c818cfdeb8b10003d39fa7cbfff10003f9b03b31b1a900042e2460797fca000469013a25e6b500047dc1a6225a030004b013cb160f72
- fingerprint: 35d328d1ff412091

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/uncarried_begins_20260823-023757.txt`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.