### PR TITLE
[BLKOPSCW] findings from Hexeption, 20260904-160455 (1 names)

### DIFF
--- a/scripts/contributed/sound_asset_char_slice2_20260904-160455.py
+++ b/scripts/contributed/sound_asset_char_slice2_20260904-160455.py
@@ -1,0 +1,35 @@
+"""Interior character substitutions for the second verified CW sound-asset seed slice."""
+import glob, os, sys
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "scripts"))
+import snapshot
+
+GAME = "BLKOPSCW"
+START, LIMIT = 2000, 2000
+snap = snapshot.read(os.path.join(ROOT, "snapshots", "blkopscw.ids"))
+wanted = {aid for aid, pool in snap.records if snap.pool_name(pool) == "sound_asset"}
+names = set()
+for table in glob.glob(os.path.join(ROOT, "cod-name-db", "csv", "*xsounds*.csv")):
+    with open(table, encoding="utf-8", errors="replace") as h:
+        for line in h:
+            _, _, name = line.partition(",")
+            name = name.strip()
+            if name and snapshot.fnv1a(name) & snapshot.ID_MASK in wanted:
+                names.add(name)
+names.update(snapshot.confirmed_names("sound_asset"))
+seeds = sorted(n.strip() for n in names if n.strip())[START:START + LIMIT]
+alphabet = "0123456789abcdefghijklmnopqrstuvwxyz_-"
+emitted = 0
+for name in seeds:
+    cut = max(name.rfind("/"), name.rfind("\\")) + 1
+    head, base = name[:cut], name[cut:]
+    dot = base.find(".")
+    if dot <= 0:
+        continue
+    core, tail = base[:dot], base[dot:]
+    for i, old in enumerate(core):
+        for char in alphabet:
+            if char != old:
+                print(head + core[:i] + char + core[i + 1:] + tail)
+                emitted += 1
+print(f"{GAME}: seeds {START+1}-{START+len(seeds)}, {len(seeds)} seeds, {emitted} candidates", file=sys.stderr)

--- a/submissions/Hexeption_BLKOPSCW_20260904-160455/about_20260904-160455.md
+++ b/submissions/Hexeption_BLKOPSCW_20260904-160455/about_20260904-160455.md
@@ -1,0 +1,35 @@
+# Submission 20260904-160455
+
+- game: **BLKOPSCW**
+- from: Hexeption
+- names: 1
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- sound_alias: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 52 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260904-160405_list
+- method: CW sound-alias context length completion
+- what it does: a candidate list generated outside the search and confirmed here
+- ran for: 4s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- candidates tested: 353063
+- matched: 1
+- new: 1
+- sketch stems: 00002b1519e1ded400002e64307a24c800006dcf4221638900009b41f982af070000a07d9b5f735c000107bf75cdfc5900018755fd730b0100018765ed8abd080001b8ca657de26d0002911d10cffd910002bd87ba8104c70002c556d14a33310002c8704318b1210003133b49a8794000035ede9efa5e900003b69caf19a97200047559c95793e00004891b00f90e500004a5cf1343b3860005380965ff7f0f000542144d9e1e1800054f66c171a5da0005cf71386d89650005e8a43f73568d0006ad81b9eb41f7000736ac819008b8000776601d4ac21b00079d6707f55b8c0007ce1456653a400007eefc7f4d64740008587f6f5c4c240008a28e6cfebeb7
+- ids hunted: 108885
+- throughput: 0.5M candidates/s
+- fingerprint: d28591fa748b0dae
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/Hexeption_BLKOPSCW_20260904-160455/sound_alias_20260904-160455.txt
+++ b/submissions/Hexeption_BLKOPSCW_20260904-160455/sound_alias_20260904-160455.txt
@@ -1,0 +1,1 @@
+71c645beef5c2ca4,fly_sniper_pwrsemi_bolt_forward


### PR DESCRIPTION
**BLKOPSCW** — 1 asset names, confirmed against that game's own loaded assets.

- sound_alias: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Hexeption

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260904-160405_list
- method: CW sound-alias context length completion
- what it does: a candidate list generated outside the search and confirmed here
- ran for: 4s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- candidates tested: 353063
- matched: 1
- new: 1
- sketch stems: 00002b1519e1ded400002e64307a24c800006dcf4221638900009b41f982af070000a07d9b5f735c000107bf75cdfc5900018755fd730b0100018765ed8abd080001b8ca657de26d0002911d10cffd910002bd87ba8104c70002c556d14a33310002c8704318b1210003133b49a8794000035ede9efa5e900003b69caf19a97200047559c95793e00004891b00f90e500004a5cf1343b3860005380965ff7f0f000542144d9e1e1800054f66c171a5da0005cf71386d89650005e8a43f73568d0006ad81b9eb41f7000736ac819008b8000776601d4ac21b00079d6707f55b8c0007ce1456653a400007eefc7f4d64740008587f6f5c4c240008a28e6cfebeb7
- ids hunted: 108885
- throughput: 0.5M candidates/s
- fingerprint: d28591fa748b0dae

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/sound_asset_char_slice2_20260904-160455.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.