### PR TITLE
[BLKOPS04] findings from Hexeption, 20260904-164021 (2 names)

### DIFF
--- a/scripts/contributed/bo4_sound_alias_context_length_20260904-164021.py
+++ b/scripts/contributed/bo4_sound_alias_context_length_20260904-164021.py
@@ -1,0 +1,28 @@
+"""Context-evidenced token deletion/reinsertion for native BO4 sound aliases."""
+import collections, os, sys
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "scripts"))
+import snapshot
+
+known = {n.strip().lower() for n in snapshot.table_names("fnv1a_soundbanks_aliases", "fnv1a_soundbanks_aliases_v2") if n.strip()}
+known.update(n.strip().lower() for n in snapshot.confirmed_names("sound_alias") if n.strip())
+parsed = [(n, n.split("_")) for n in known if 2 <= len(n.split("_")) <= 14 and all(n.split("_"))]
+between = collections.defaultdict(set)
+for _, tokens in parsed:
+    for pos, token in enumerate(tokens):
+        between[(tuple(tokens[:pos]), tuple(tokens[pos+1:]))].add(token)
+out = set()
+for name, tokens in parsed:
+    for pos in range(len(tokens)):
+        candidate = "_".join(tokens[:pos] + tokens[pos+1:])
+        if candidate and candidate not in known:
+            out.add(candidate)
+    for pos in range(1, len(tokens)):
+        context = (tuple(tokens[:pos]), tuple(tokens[pos:]))
+        for token in between.get(context, ()):
+            candidate = "_".join(tokens[:pos] + [token] + tokens[pos:])
+            if candidate not in known:
+                out.add(candidate)
+print(f"{len(known):,} native BO4 aliases -> {len(out):,} context-length candidates", file=sys.stderr)
+for candidate in sorted(out):
+    print(candidate)

--- a/submissions/Hexeption_BLKOPS04_20260904-164021/about_20260904-164021.md
+++ b/submissions/Hexeption_BLKOPS04_20260904-164021/about_20260904-164021.md
@@ -1,0 +1,35 @@
+# Submission 20260904-164021
+
+- game: **BLKOPS04**
+- from: Hexeption
+- names: 2
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- xanim: 2
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 53 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260904-163920_list
+- method: BO4 animation symmetry
+- what it does: a candidate list generated outside the search and confirmed here
+- ran for: 4s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- candidates tested: 9297
+- matched: 2
+- new: 2
+- sketch stems: 000afe5eb9a544e4000b653296762fca0010fbb56f290b700016a90f8b332b07001a5a3799ccaabd001d7b994fe2b5c3001e4f4b9f6bc5b30021a9eb2e81c3a2002395833f27111c0030771ef326278d003ae1ba057cf9f7003b179acc2b46bd003ff9cb523294860047ea00182cbe68005a13c9a55016910062db33c1b97e7b0069f2c893dbc1da006d246bd66cc5070071401e5cb0f031007afa1c830ce009007fd4063736f44b008035f5535497fb00961f1dfda81552009e4f3acf4a7e1f00aae190ae89661200b0a07b5cb257b900c0cb8e0c392d8300c57ea8f3dfedcf00c780d2d46f95ab00db4993c36515f500df5c46814b6da900e15086831a36a9
+- ids hunted: 139488
+- throughput: 0.2M candidates/s
+- fingerprint: 53bf788bc8b2ee1b
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/Hexeption_BLKOPS04_20260904-164021/xanim_20260904-164021.txt
+++ b/submissions/Hexeption_BLKOPS04_20260904-164021/xanim_20260904-164021.txt
@@ -1,0 +1,2 @@
+725bdfca69361012,pt_health_regen_crouch_wz_loop
+7c60da8ad2077d70,pt_health_regen_crouch_wz_out


### PR DESCRIPTION
**BLKOPS04** — 2 asset names, confirmed against that game's own loaded assets.

- xanim: 2

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Hexeption

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260904-163920_list
- method: BO4 animation symmetry
- what it does: a candidate list generated outside the search and confirmed here
- ran for: 4s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- candidates tested: 9297
- matched: 2
- new: 2
- sketch stems: 000afe5eb9a544e4000b653296762fca0010fbb56f290b700016a90f8b332b07001a5a3799ccaabd001d7b994fe2b5c3001e4f4b9f6bc5b30021a9eb2e81c3a2002395833f27111c0030771ef326278d003ae1ba057cf9f7003b179acc2b46bd003ff9cb523294860047ea00182cbe68005a13c9a55016910062db33c1b97e7b0069f2c893dbc1da006d246bd66cc5070071401e5cb0f031007afa1c830ce009007fd4063736f44b008035f5535497fb00961f1dfda81552009e4f3acf4a7e1f00aae190ae89661200b0a07b5cb257b900c0cb8e0c392d8300c57ea8f3dfedcf00c780d2d46f95ab00db4993c36515f500df5c46814b6da900e15086831a36a9
- ids hunted: 139488
- throughput: 0.2M candidates/s
- fingerprint: 53bf788bc8b2ee1b

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/bo4_sound_alias_context_length_20260904-164021.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.