### PR TITLE
[BLKOPS04] findings from Hexeption, 20260904-192342 (1 names)

### DIFF
--- a/scripts/contributed/uncarried_head_tail_atoms_20260904-192342.py
+++ b/scripts/contributed/uncarried_head_tail_atoms_20260904-192342.py
@@ -1,0 +1,45 @@
+"""Target combinations of uncarried leading heads and frequent uncarried tail atoms."""
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+import snapshot
+
+TABLES = ("fnv1a_xmaterials", "fnv1a_xmaterials_v2", "fnv1a_ximages",
+          "fnv1a_ximages_v2", "fnv1a_xanims", "fnv1a_xmodels",
+          "fnv1a_soundbanks_aliases", "fnv1a_xsounds")
+TAILS = ("futz", "kill", "nag", "hv", "exerts", "greet", "riot", "stab")
+
+def main():
+    known = set()
+    for table in TABLES:
+        known.update(n.strip().lower().replace("\\", "/") for n in snapshot.table_names(table))
+    for pool in ("image", "material", "anim", "model", "sound_alias", "sound_asset"):
+        known.update(n.strip().lower().replace("\\", "/") for n in snapshot.confirmed_names(pool))
+    with (ROOT / "data" / "prefixes.txt").open(encoding="utf-8", errors="replace") as f:
+        carried = {line.strip().lower() for line in f if line.strip()}
+    heads = set()
+    for name in known:
+        if "/" in name or "." in name or "_" not in name:
+            continue
+        head = name.split("_", 1)[0] + "_"
+        if not any(head[:cut] in carried for cut in range(1, len(head) + 1)):
+            heads.add(head)
+    candidates = set()
+    for name in known:
+        if name.split("_", 1)[0] + "_" not in heads:
+            continue
+        base, sep, _ = name.rpartition("_")
+        if not sep or not base:
+            continue
+        for tail in TAILS:
+            cand = base + "_" + tail
+            if cand not in known:
+                candidates.add(cand)
+    print(f"{len(heads):,} uncarried heads x {len(TAILS)} uncarried tail atoms -> {len(candidates):,} candidates", file=sys.stderr)
+    for cand in sorted(candidates):
+        print(cand)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/contributed/uncarried_prefix_local_grids_20260904-192342.py
+++ b/scripts/contributed/uncarried_prefix_local_grids_20260904-192342.py
@@ -1,0 +1,56 @@
+"""Fill locally attested tail grids under prefixes absent from the prefix ceiling."""
+import collections
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+import snapshot
+
+TABLES = (
+    "fnv1a_xmaterials", "fnv1a_xmaterials_v2", "fnv1a_ximages",
+    "fnv1a_ximages_v2", "fnv1a_xanims", "fnv1a_xmodels",
+    "fnv1a_soundbanks_aliases", "fnv1a_xsounds",
+)
+
+def main():
+    known = set()
+    for table in TABLES:
+        known.update(n.strip().lower().replace("\\", "/") for n in snapshot.table_names(table))
+    for pool in ("image", "material", "anim", "model", "sound_alias", "sound_asset"):
+        known.update(n.strip().lower().replace("\\", "/") for n in snapshot.confirmed_names(pool))
+    with (ROOT / "data" / "prefixes.txt").open(encoding="utf-8", errors="replace") as f:
+        carried = {line.strip().lower() for line in f if line.strip()}
+    heads = collections.defaultdict(list)
+    for name in known:
+        if "/" in name or "." in name:
+            continue
+        first = name.split("_", 1)[0] + "_" if "_" in name else ""
+        if first and not any(first[:cut] in carried for cut in range(1, len(first) + 1)):
+            heads[first].append(name)
+    candidates = set()
+    selected = 0
+    for head, names in heads.items():
+        axes = set()
+        tails = collections.Counter()
+        for name in names:
+            rest = name[len(head):]
+            axis, sep, tail = rest.partition("_")
+            if sep and axis and tail:
+                axes.add(axis)
+                tails[tail] += 1
+        shared = {tail for tail, count in tails.items() if count > 1}
+        if len(axes) < 2 or not shared:
+            continue
+        selected += 1
+        for axis in axes:
+            for tail in shared:
+                cand = head + axis + "_" + tail
+                if cand not in known:
+                    candidates.add(cand)
+    print(f"{selected:,} uncarried prefixes, {len(candidates):,} local grid cells", file=sys.stderr)
+    for cand in sorted(candidates):
+        print(cand)
+
+if __name__ == "__main__":
+    main()

--- a/submissions/Hexeption_BLKOPS04_20260904-192342/about_20260904-192342.md
+++ b/submissions/Hexeption_BLKOPS04_20260904-192342/about_20260904-192342.md
@@ -1,0 +1,35 @@
+# Submission 20260904-192342
+
+- game: **BLKOPS04**
+- from: Hexeption
+- names: 1
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- image: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 54 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260904-192300_list
+- method: BO4 complemented basename digits
+- what it does: a candidate list generated outside the search and confirmed here
+- ran for: 3s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- candidates tested: 887359
+- matched: 1
+- new: 1
+- sketch stems: 00000189c3e937bb000004dc139f8a77000007c18aa4e99a00000b4a7d2bb1fd000011ea2f67477a00002a414eacd4b40000385bb94fa50b000062bbe55f4f4c0000732446c89f3a00008183fc58fe55000086bdbff4d522000087d4f43570460000999a59d43fa90000acbf13fbe7e70000b74f89c0d35b0000d2f37c0d118d0000e8cba928adb20000e9b95bc5a0460000ee4f3695a2f10000f45eaf7a5d23000113506d99158600011bf95f50429400011dee0e2e04ee0001222fd9cc469800012860e782aa3000014651748b0ba700015191824ff31700015dc7f359cb7700016988c2ab82f6000195c000d72c4b0001a82e31d753d40001b3842fcbdef7
+- ids hunted: 139486
+- throughput: 8.8M candidates/s
+- fingerprint: 1dc046e7100ed9e4
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/Hexeption_BLKOPS04_20260904-192342/image_20260904-192342.txt
+++ b/submissions/Hexeption_BLKOPS04_20260904-192342/image_20260904-192342.txt
@@ -1,0 +1,1 @@
+5c33b6749a2e4ee9,loot_ui_icon_outfit_tigerstripe_base_pal_com3_battery_outfit_bundle


### PR DESCRIPTION
**BLKOPS04** — 1 asset names, confirmed against that game's own loaded assets.

- image: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Hexeption

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260904-192300_list
- method: BO4 complemented basename digits
- what it does: a candidate list generated outside the search and confirmed here
- ran for: 3s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- candidates tested: 887359
- matched: 1
- new: 1
- sketch stems: 00000189c3e937bb000004dc139f8a77000007c18aa4e99a00000b4a7d2bb1fd000011ea2f67477a00002a414eacd4b40000385bb94fa50b000062bbe55f4f4c0000732446c89f3a00008183fc58fe55000086bdbff4d522000087d4f43570460000999a59d43fa90000acbf13fbe7e70000b74f89c0d35b0000d2f37c0d118d0000e8cba928adb20000e9b95bc5a0460000ee4f3695a2f10000f45eaf7a5d23000113506d99158600011bf95f50429400011dee0e2e04ee0001222fd9cc469800012860e782aa3000014651748b0ba700015191824ff31700015dc7f359cb7700016988c2ab82f6000195c000d72c4b0001a82e31d753d40001b3842fcbdef7
- ids hunted: 139486
- throughput: 8.8M candidates/s
- fingerprint: 1dc046e7100ed9e4

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/uncarried_head_tail_atoms_20260904-192342.py`
- `scripts/contributed/uncarried_prefix_local_grids_20260904-192342.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.