### PR TITLE
[BLKOPSCW] findings from KingslayerKyle, 20260905-150906 (3 names)

### DIFF
--- a/submissions/KingslayerKyle_BLKOPSCW_20260905-150906/about_20260905-150906.md
+++ b/submissions/KingslayerKyle_BLKOPSCW_20260905-150906/about_20260905-150906.md
@@ -1,0 +1,35 @@
+# Submission 20260905-150906
+
+- game: **BLKOPSCW**
+- from: KingslayerKyle
+- names: 3
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- sound_alias: 3
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 1 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260905-150836_list
+- method: sweep of other pools: in-scope sound_alias
+- what it does: a candidate list generated outside the search and confirmed here
+- ran for: 2s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- candidates tested: 4
+- matched: 3
+- new: 3
+- sketch stems: 36bf3b2181a85db4ac4c189c3e290317b78b98551fea78d6f81a601dbfb7c73d
+- ids hunted: 108875
+- throughput: 0.0M candidates/s
+- fingerprint: bcc4af22ec02cb0e
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/KingslayerKyle_BLKOPSCW_20260905-150906/sound_alias_20260905-150906.txt
+++ b/submissions/KingslayerKyle_BLKOPSCW_20260905-150906/sound_alias_20260905-150906.txt
@@ -1,0 +1,3 @@
+1f2f2c9bc14a6694,wpn_pistol_npc_rv_decay_int
+21e091ef1f28a97b,wpn_pistol_plr_rv_decay_int
+249a2778ac3afb27,zmb_s2_requiem_audiolog_5_sfx_swt


### PR DESCRIPTION
**BLKOPSCW** — 3 asset names, confirmed against that game's own loaded assets.

- sound_alias: 3

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @KingslayerKyle

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260905-150836_list
- method: sweep of other pools: in-scope sound_alias
- what it does: a candidate list generated outside the search and confirmed here
- ran for: 2s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- candidates tested: 4
- matched: 3
- new: 3
- sketch stems: 36bf3b2181a85db4ac4c189c3e290317b78b98551fea78d6f81a601dbfb7c73d
- ids hunted: 108875
- throughput: 0.0M candidates/s
- fingerprint: bcc4af22ec02cb0e

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/baked_volume_grid_20260829-061359.py`
- `scripts/contributed/blte_modes_20260829-151441.py`
- `scripts/contributed/borrowed_decorations.py`
- `scripts/contributed/casc_index_20260829-063030.py`
- `scripts/contributed/ceiling_dropped_begins_20260829-064955.py`
- `scripts/contributed/corpus_total_sweep_20260905-133642.py`
- `scripts/contributed/cross_game_verbatim.py`
- `scripts/contributed/family_grid_20260824-000146.py`
- `scripts/contributed/harvest_bo3_20260822-030351.py`
- `scripts/contributed/harvest_bo3_assetlist_20260905-133642.py`
- `scripts/contributed/harvest_bo4.py`
- `scripts/contributed/harvest_decorated_20260824-030747.py`
- `scripts/contributed/harvest_iwd.py`
- `scripts/contributed/harvest_tails_20260824-114138.py`
- `scripts/contributed/heads_slash_20260824-025001.py`
- `scripts/contributed/hex_grid_volumes_20260831-031829.py`
- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/keyword_sweep_20260822-020208.py`
- `scripts/contributed/mtx_bundle_grid.py`
- `scripts/contributed/redecorations_20260829-052705.py`
- `scripts/contributed/speaker_grids_20260822-021342.py`
- `scripts/contributed/survey_builds_20260829-154201.py`
- `scripts/contributed/typed_cross.py`
- `scripts/contributed/uncarried_beginnings_20260823-173831.py`
- `scripts/contributed/uncarried_endings_allboundary_20260829-172236.py`
- `scripts/contributed/unnamed_profile_20260823-182656.py`
- `scripts/contributed/zombie_models_20260821-163108.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.