### PR TITLE
[BLKOPSCW] findings from KingslayerKyle, 20260905-191935 (3 names)

### DIFF
--- a/scripts/contributed/alias_cells_20260905-191935.py
+++ b/scripts/contributed/alias_cells_20260905-191935.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Sound aliases recombined inside the cell the game files them in, not across the whole corpus.
+
+Recombining the named sound corpus against itself is measured dead in both games, under every
+shape anybody has tried -- numbered takes, directory x basename, tail swaps, all-boundary cores,
+cross-game transfer. Those negatives are total and they are not a plumbing failure: the
+vocabulary rebuilds the *known* names almost perfectly and reaches none of the unknown ones.
+
+The reason is that the corpus is not one population. An alias definition table gives every alias
+a zone, a bus, a volume group and a duck group, all in plain text, and those four say what the
+sound *is*: a zombie map's foley, a warzone announcer line, a menu click. Names inside one such
+cell are built from one small vocabulary; names across cells are not related at all. So a
+recombination over the whole corpus spends everything it has on pairs that were never going to
+go together, which is exactly the shape of a total zero.
+
+This recombines strictly inside a cell. Measured on the tables, cells are tight enough for that
+to mean something: of the cells holding both known and unnamed aliases, the single commonest
+two-token prefix covers a median 45-48% of the cell, and the best of them are effectively one
+family -- 661 unnamed aliases sitting in a cell whose 216 known names share **one** prefix
+between them.
+
+A cell's cross product is a cross product, so it is written as a **plan** and handed to the
+compiled engine rather than printed -- one plan per cell, since the three lists differ per cell
+and that is the whole point of the method.
+
+    python alias_cells.py <aliases.csv> --out plans/cells --top 20
+    for p in plans/cells/*.txt: bin\windows\confirm_plan.exe $p
+
+The CSV is the game's alias definition table. Known names come from the published alias tables
+and `all_names/`; every id in the table that no name resolves is what the cell is being mined for.
+"""
+import argparse
+import collections
+import csv
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+MASK = (1 << 63) - 1
+BASIS = 0xCBF29CE484222325
+PRIME = 0x100000001B3
+U64 = (1 << 64) - 1
+
+# What the game files a sound under. Zone is the bank, volume group and duck group are what kind
+# of sound it is; together they are a far better predictor of a name than the corpus at large.
+CELL = ("zone", "volumegroup", "duckgroup")
+
+
+def fnv1a63(s):
+    x = BASIS
+    for c in s.lower().replace("\\", "/").encode("utf-8", "replace"):
+        x = ((x ^ c) * PRIME) & U64
+    return x & MASK
+
+
+def known_names():
+    out = {}
+    for f in ("fnv1a_soundbanks_aliases.csv", "fnv1a_soundbanks_aliases_v2.csv"):
+        p = os.path.join(ROOT, "cod-name-db", "csv", f)
+        if os.path.exists(p):
+            with open(p, encoding="utf-8", errors="replace") as fh:
+                for line in fh:
+                    parts = line.strip().split(",", 1)
+                    if len(parts) == 2 and parts[1]:
+                        out[fnv1a63(parts[1])] = parts[1]
+    for g in ("blkops04", "blkopscw"):
+        p = os.path.join(ROOT, "all_names", g, "sound_alias.txt")
+        if os.path.exists(p):
+            with open(p, encoding="utf-8", errors="replace") as fh:
+                for line in fh:
+                    nm = line.strip().split(",")[-1]
+                    if nm:
+                        out[fnv1a63(nm)] = nm
+    return out
+
+
+def parts(names, depth):
+    """Heads, cores and tails of a cell's names, each cut at whole-token boundaries."""
+    heads, cores, tails = collections.Counter(), collections.Counter(), collections.Counter()
+    for nm in names:
+        t = nm.split("_")
+        for k in range(1, min(depth, len(t) - 1) + 1):
+            heads["_".join(t[:k])] += 1
+            tails["_".join(t[-k:])] += 1
+        for i in range(1, len(t)):
+            for j in range(i + 1, min(i + depth, len(t)) + 1):
+                cores["_".join(t[i:j])] += 1
+    return heads, cores, tails
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("csv")
+    ap.add_argument("--out", default="plans/cells", help="directory to write the plans into")
+    ap.add_argument("--top", type=int, default=20, help="how many cells to write, by unnamed count")
+    ap.add_argument("--depth", type=int, default=3, help="max tokens in a head, core or tail")
+    ap.add_argument("--axis", type=int, default=3000, help="max entries kept per axis")
+    ap.add_argument("--min-known", type=int, default=4)
+    args = ap.parse_args()
+
+    known = known_names()
+    cells = collections.defaultdict(lambda: [set(), set()])
+    with open(args.csv, encoding="utf-8-sig", newline="") as fh:
+        for row in csv.DictReader(fh):
+            n = (row.get("name") or "").strip()
+            if not n:
+                continue
+            a = int(n, 16) & MASK
+            key = tuple((row.get(c) or "").strip() for c in CELL)
+            nm = known.get(a)
+            if nm:
+                cells[key][0].add(nm)
+            else:
+                cells[key][1].add(a)
+
+    live = [(len(u), k) for k, (kn, u) in cells.items() if u and len(kn) >= args.min_known]
+    live.sort(reverse=True)
+    print("cells: %d total, %d worth mining, %d unnamed ids in them"
+          % (len(cells), len(live), sum(n for n, _ in live)), file=sys.stderr)
+
+    os.makedirs(args.out, exist_ok=True)
+    written = 0
+    for n_unnamed, key in live[: args.top]:
+        heads, cores, tails = parts(cells[key][0], args.depth)
+        hs = [h for h, _ in heads.most_common(args.axis)]
+        cs = [c for c, _ in cores.most_common(args.axis * 4)]
+        ts = [t for t, _ in tails.most_common(args.axis)]
+        if not (hs and cs and ts):
+            continue
+        slug = re.sub(r"[^a-z0-9]+", "_", "_".join(key).lower()).strip("_")[:60]
+        base = os.path.join(args.out, slug)
+        rel = base.replace(os.sep, "/")
+        for suffix, axis in (("heads", hs), ("cores", cs), ("tails", ts)):
+            with open("%s.%s.txt" % (base, suffix), "w", encoding="utf-8", newline="\n") as fh:
+                fh.write("\n".join(axis) + "\n")
+        with open("%s.txt" % base, "w", encoding="utf-8", newline="\n") as fh:
+            fh.write("label: alias cell %s\n" % " / ".join(key))
+            fh.write("describe: sound aliases recombined only against the other aliases the game "
+                     "files in the same zone, volume group and duck group -- %d known names in "
+                     "this cell, %d ids in it still unnamed\n\n"
+                     % (len(cells[key][0]), n_unnamed))
+            fh.write("begin: @%s.heads.txt\n" % rel)
+            fh.write("stem:  @%s.cores.txt\n" % rel)
+            fh.write("end:   @%s.tails.txt\n\n" % rel)
+            fh.write("bare: no\nfold: yes\n")
+        written += 1
+        print("  %-52s %6d unnamed  %5d known  %d x %d x %d"
+              % (slug, n_unnamed, len(cells[key][0]), len(hs), len(cs), len(ts)), file=sys.stderr)
+    print("wrote %d plans into %s" % (written, args.out), file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/contributed/alias_edges_20260905-191935.py
+++ b/scripts/contributed/alias_edges_20260905-191935.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Sound aliases named from the aliases they point at.
+
+Both games' alias definition tables carry, for every alias, the other aliases it refers to:
+`secondaryaliasname` (the alias played alongside it) and `stopalias` (the alias that stops it).
+Those columns are hashes, so they name nothing on their own -- but they are *edges*, and an edge
+with a known name at one end and an unknown at the other is a name we are one guess away from.
+
+That is the thing the standing sound negatives said was missing. Recombining the named sound
+corpus against itself is measured dead in both games, under every shape tried: numbered takes,
+directory x basename, tail swaps, all-boundary cores. All of them fail the same way, because the
+named aliases are not a random sample of the pool and the unnamed ones are not built from their
+pieces. An edge is different: it does not ask what the corpus looks like in general, it says
+*this specific unknown alias is the partner of this specific known one*, on the game's own
+authority.
+
+The edit that turns one end of an edge into the other is not guessed either. The same tables hold
+tens of thousands of edges with a known name at **both** ends, and every one of those is a worked
+example:
+
+    mpl_hud_notify_camo        ->  mpl_hud_notify_camo_riff
+    wpn_flame_thrower_start_plr->  wpn_flame_thrower_cooldown
+    uin_aar_bar_fill_tail      ->  uin_aar_bar_fill_main
+    tst_front_left_1           ->  tst_front_right_1
+
+So the grammar is measured from the closed edges and applied to the open ones. A rule is the pair
+of tails that differ after the longest shared run of whole tokens, which covers appending,
+replacing and swapping in one form.
+
+    python alias_edges.py <aliases.csv> --game BLKOPS04 | confirm_list - --game BLKOPS04
+
+The CSV is the game's alias definition table: a `name` column and the reference columns, each
+holding a 64-bit hash. Known names are read from the published alias tables and `all_names/`.
+"""
+import argparse
+import collections
+import csv
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+MASK = (1 << 63) - 1
+BASIS = 0xCBF29CE484222325
+PRIME = 0x100000001B3
+U64 = (1 << 64) - 1
+
+# The columns that hold another alias's hash. `chainaliasname` is in the header of both games'
+# tables and is empty in every row of both, so it is listed and costs nothing.
+EDGE_COLUMNS = ("secondaryaliasname", "chainaliasname", "stopalias")
+
+
+def fnv1a63(s):
+    x = BASIS
+    for c in s.lower().replace("\\", "/").encode("utf-8", "replace"):
+        x = ((x ^ c) * PRIME) & U64
+    return x & MASK
+
+
+def known_names():
+    """Every alias name anybody holds, by id. Both games, since aliases cross between them."""
+    out = {}
+    for f in ("fnv1a_soundbanks_aliases.csv", "fnv1a_soundbanks_aliases_v2.csv"):
+        p = os.path.join(ROOT, "cod-name-db", "csv", f)
+        if os.path.exists(p):
+            with open(p, encoding="utf-8", errors="replace") as fh:
+                for line in fh:
+                    parts = line.strip().split(",", 1)
+                    if len(parts) == 2 and parts[1]:
+                        out[fnv1a63(parts[1])] = parts[1]
+    for g in ("blkops04", "blkopscw"):
+        p = os.path.join(ROOT, "all_names", g, "sound_alias.txt")
+        if os.path.exists(p):
+            with open(p, encoding="utf-8", errors="replace") as fh:
+                for line in fh:
+                    nm = line.strip().split(",")[-1]
+                    if nm:
+                        out[fnv1a63(nm)] = nm
+    return out
+
+
+def rule(a, b):
+    """The (from-tail, to-tail) pair left after the longest shared run of whole tokens.
+
+    Whole tokens rather than characters, so `..._camo` -> `..._camo_riff` yields ("", "_riff")
+    and not ("o", "o_riff"). Returning the tails rather than a diff is what lets the rule be
+    replayed onto a different name that ends the same way.
+    """
+    ta, tb = a.split("_"), b.split("_")
+    i = 0
+    while i < len(ta) and i < len(tb) and ta[i] == tb[i]:
+        i += 1
+    if i == 0:
+        return None
+    fa, fb = "_".join(ta[i:]), "_".join(tb[i:])
+    return ("_" + fa if fa else "", "_" + fb if fb else "")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("csv", help="the game's alias definition table")
+    ap.add_argument("--min-rule", type=int, default=2,
+                    help="how many closed edges a rule must be seen on to be replayed")
+    args = ap.parse_args()
+
+    known = known_names()
+    print("known alias names: %d" % len(known), file=sys.stderr)
+
+    closed = collections.Counter()
+    open_edges = set()
+    with open(args.csv, encoding="utf-8-sig", newline="") as fh:
+        for row in csv.DictReader(fh):
+            n = (row.get("name") or "").strip()
+            if not n:
+                continue
+            a = int(n, 16) & MASK
+            for col in EDGE_COLUMNS:
+                v = (row.get(col) or "").strip()
+                if not v:
+                    continue
+                b = int(v, 16) & MASK
+                ka, kb = known.get(a), known.get(b)
+                if ka and kb:
+                    r = rule(ka, kb)
+                    if r:
+                        closed[r] += 1
+                    r = rule(kb, ka)
+                    if r:
+                        closed[r] += 1
+                elif ka and not kb:
+                    open_edges.add(ka)
+                elif kb and not ka:
+                    open_edges.add(kb)
+
+    rules = [r for r, c in closed.most_common() if c >= args.min_rule]
+    print("closed edges give %d distinct rules, %d kept at >=%d sightings"
+          % (len(closed), len(rules), args.min_rule), file=sys.stderr)
+    print("open edges anchored on a known name: %d" % len(open_edges), file=sys.stderr)
+
+    # An added tail that never replaces anything is worth trying on every anchor, not only on the
+    # ones already ending in its rule's from-tail: appending is the commonest edge in both tables.
+    appends = sorted({to for frm, to in rules if frm == "" and to})
+
+    n = 0
+    seen = set()
+    for anchor in sorted(open_edges):
+        cands = []
+        for frm, to in rules:
+            if frm and anchor.endswith(frm):
+                cands.append(anchor[: len(anchor) - len(frm)] + to)
+        cands.extend(anchor + t for t in appends)
+        for c in cands:
+            if c and c not in seen:
+                seen.add(c)
+                n += 1
+                print(c)
+    print("emitted %d" % n, file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/submissions/KingslayerKyle_BLKOPSCW_20260905-191935/about_20260905-191935.md
+++ b/submissions/KingslayerKyle_BLKOPSCW_20260905-191935/about_20260905-191935.md
@@ -1,0 +1,35 @@
+# Submission 20260905-191935
+
+- game: **BLKOPSCW**
+- from: KingslayerKyle
+- names: 3
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- sound_alias: 3
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 5 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260905-191230_list
+- method: sound aliases named from the aliases they point at
+- what it does: the alias definition table's secondaryaliasname and stopalias columns are edges; edges with a known name at both ends teach the edit, edges with one known end get it applied
+- ran for: 2s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- candidates tested: 38993
+- matched: 3
+- new: 3
+- sketch stems: 00023ac1932dfea90002f866fdb060d20003e47f39bc9bbc0004810b88323f3300081aca721d0a3400096db9d30124110009fa0882cc7dbe000a230b19634ab5000b4086cd0169bb000b4d783b23ce90000c61d8920783490011bca84bc6619b00121cc9b8e6d80000129149758503e9001471318c5aac9e001607cacb3b1fdc001719ff60f3308300171a595a1976ca001734ccc106770400185b0a25935d47001877623485054000197ce601380af8001a48d66eb24d55001b3c2af5b9a95a001d9ca4545fe700001f2f74e34fc9910023a8191ebf758d0025eb5067f164e100286dbdd4fa32b4002d4769f1fa2fb4002e643700126fac002e94881b0ebee3
+- ids hunted: 108859
+- throughput: 0.1M candidates/s
+- fingerprint: e98fff413bf1df6c
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/KingslayerKyle_BLKOPSCW_20260905-191935/sound_alias_20260905-191935.txt
+++ b/submissions/KingslayerKyle_BLKOPSCW_20260905-191935/sound_alias_20260905-191935.txt
@@ -1,0 +1,3 @@
+ab5a62b1adcd220,zmb_tormentor_explode_glass
+e8f8dfc02bd1a99,zmb_tormentor_explode_elec
+5ac7138111c3117c,zmb_tormentor_spawn_swt


### PR DESCRIPTION
**BLKOPSCW** — 3 asset names, confirmed against that game's own loaded assets.

- sound_alias: 3

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @KingslayerKyle

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260905-191230_list
- method: sound aliases named from the aliases they point at
- what it does: the alias definition table's secondaryaliasname and stopalias columns are edges; edges with a known name at both ends teach the edit, edges with one known end get it applied
- ran for: 2s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- candidates tested: 38993
- matched: 3
- new: 3
- sketch stems: 00023ac1932dfea90002f866fdb060d20003e47f39bc9bbc0004810b88323f3300081aca721d0a3400096db9d30124110009fa0882cc7dbe000a230b19634ab5000b4086cd0169bb000b4d783b23ce90000c61d8920783490011bca84bc6619b00121cc9b8e6d80000129149758503e9001471318c5aac9e001607cacb3b1fdc001719ff60f3308300171a595a1976ca001734ccc106770400185b0a25935d47001877623485054000197ce601380af8001a48d66eb24d55001b3c2af5b9a95a001d9ca4545fe700001f2f74e34fc9910023a8191ebf758d0025eb5067f164e100286dbdd4fa32b4002d4769f1fa2fb4002e643700126fac002e94881b0ebee3
- ids hunted: 108859
- throughput: 0.1M candidates/s
- fingerprint: e98fff413bf1df6c

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/alias_cells_20260905-191935.py`
- `scripts/contributed/alias_edges_20260905-191935.py`
- `scripts/contributed/baked_volume_grid_20260829-061359.py`
- `scripts/contributed/blte_modes_20260829-151441.py`
- `scripts/contributed/borrowed_decorations.py`
- `scripts/contributed/boundary_frames_20260905-162828.py`
- `scripts/contributed/casc_index_20260829-063030.py`
- `scripts/contributed/ceiling_dropped_begins_20260829-064955.py`
- `scripts/contributed/corpus_total_sweep_20260905-133642.py`
- `scripts/contributed/cross_game_verbatim.py`
- `scripts/contributed/family_grid_20260824-000146.py`
- `scripts/contributed/harvest_bo3_20260822-030351.py`
- `scripts/contributed/harvest_bo3_assetlist_20260905-133642.py`
- `scripts/contributed/harvest_bo4.py`
- `scripts/contributed/harvest_decorated_20260824-030747.py`
- `scripts/contributed/harvest_iwd.py`
- `scripts/contributed/harvest_tails_20260824-114138.py`
- `scripts/contributed/heads_slash_20260824-025001.py`
- `scripts/contributed/hex_grid_volumes_20260831-031829.py`
- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/keyword_sweep_20260822-020208.py`
- `scripts/contributed/legacy_index_gap_20260905-162828.py`
- `scripts/contributed/loot_icon_grid_20260905-190952.py`
- `scripts/contributed/mtx_bundle_grid.py`
- `scripts/contributed/redecorations_20260829-052705.py`
- `scripts/contributed/speaker_grids_20260822-021342.py`
- `scripts/contributed/survey_builds_20260829-154201.py`
- `scripts/contributed/typed_cross.py`
- `scripts/contributed/uncarried_beginnings_20260823-173831.py`
- `scripts/contributed/uncarried_endings_allboundary_20260829-172236.py`
- `scripts/contributed/unnamed_profile_20260823-182656.py`
- `scripts/contributed/untargeted_cores_20260905-162828.txt`
- `scripts/contributed/untargeted_pool_cores_20260905-162828.py`
- `scripts/contributed/zombie_models_20260821-163108.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.