### PR TITLE
[BLKOPSCW] findings from Hexeption, 20260907-190035 (1 names)

### DIFF
--- a/submissions/Hexeption_BLKOPSCW_20260907-190035/about_20260907-190035.md
+++ b/submissions/Hexeption_BLKOPSCW_20260907-190035/about_20260907-190035.md
@@ -1,0 +1,35 @@
+# Submission 20260907-190035
+
+- game: **BLKOPSCW**
+- from: Hexeption
+- names: 1
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- sound_alias: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 5 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260907-185952_list
+- method: alias token substitutions
+- what it does: a candidate list generated outside the search and confirmed here
+- ran for: 15s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- candidates tested: 3944732
+- matched: 1
+- new: 1
+- sketch stems: 00000165b3d360b2000002af1598dcff00000723113762a2000014c4bc71c27b000016897aa6e2b70000176000c42029000019e81537f17700001aeaa7e1055c00002414a7b3d06b000027bb3f59c5700000291666021cc500002a235b6bc1d300002b1519e1ded400002d2458174d03000031101d4fee5c00003232ee66c11c00003349448b5d6200003dfa16adda360000416b22ed54da0000425d4e68928e00004830d79f972600004d4bae0865cd00004da262c1d5bb0000502744af77f200005417983d4ace0000588da4310cb400005b4e4473dcb400005db634f4e1ed000062b988dc5a6f000065839cdf112100006e19bb8b024a00006fb14e02fd27
+- ids hunted: 108703
+- throughput: 0.4M candidates/s
+- fingerprint: b4fc0c6c952f5e84
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/Hexeption_BLKOPSCW_20260907-190035/sound_alias_20260907-190035.txt
+++ b/submissions/Hexeption_BLKOPSCW_20260907-190035/sound_alias_20260907-190035.txt
@@ -1,0 +1,1 @@
+a3c5d5d69e0fc95,zmb_vocals_tormentor_ambient


### PR DESCRIPTION
**BLKOPSCW** — 1 asset names, confirmed against that game's own loaded assets.

- sound_alias: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Hexeption

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260907-185952_list
- method: alias token substitutions
- what it does: a candidate list generated outside the search and confirmed here
- ran for: 15s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- candidates tested: 3944732
- matched: 1
- new: 1
- sketch stems: 00000165b3d360b2000002af1598dcff00000723113762a2000014c4bc71c27b000016897aa6e2b70000176000c42029000019e81537f17700001aeaa7e1055c00002414a7b3d06b000027bb3f59c5700000291666021cc500002a235b6bc1d300002b1519e1ded400002d2458174d03000031101d4fee5c00003232ee66c11c00003349448b5d6200003dfa16adda360000416b22ed54da0000425d4e68928e00004830d79f972600004d4bae0865cd00004da262c1d5bb0000502744af77f200005417983d4ace0000588da4310cb400005b4e4473dcb400005db634f4e1ed000062b988dc5a6f000065839cdf112100006e19bb8b024a00006fb14e02fd27
- ids hunted: 108703
- throughput: 0.4M candidates/s
- fingerprint: b4fc0c6c952f5e84

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/alias_token_substitutions_20260830-095552.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.