### PR TITLE
[BLKOPSCW] findings from Tnt540, 20260908-064821 (3 names)

### DIFF
--- a/submissions/Tnt540_BLKOPSCW_20260908-064821/about_20260908-064821.md
+++ b/submissions/Tnt540_BLKOPSCW_20260908-064821/about_20260908-064821.md
@@ -1,0 +1,36 @@
+# Submission 20260908-064821
+
+- game: **BLKOPSCW**
+- from: Tnt540
+- names: 3
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- image: 2
+- material: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 35 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260908-064639_list
+- method: family gap filling
+- what it does: a candidate list generated outside the search and confirmed here
+- ran for: 3s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- candidates tested: 114093
+- matched: 3
+- new: 3
+- sketch stems: 00018e46f234bb7f00022d3960fc82ef0002eabc4d365c2600032b55f189cfaf000357ae0071d018000433e747350fbd0004c1523098100300054e9c13d092720005794020657dbd0006bae5626a1a7400076187583476ce00077565d94be1b00008359b16571f0d0008db2783e508d300090c7eefdc900b000916240f80f791000923a553a37e03000953507d68bc3a0009585a9dc688b50009f3e894f18fae0009fcf3def3fb32000a0034e11a86cf000b19efc1fd2f35000bb1c7af62d8a3000bd5555442746e000c1879250ddfe7000c867d23e3f060000cdf7109e7cc1c000d6b1a035443cf000d8bfa9c2c8247000dea0d6add6164000ed7017c89322f
+- ids hunted: 108176
+- throughput: 0.8M candidates/s
+- fingerprint: 24b209b97596767b
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/Tnt540_BLKOPSCW_20260908-064821/image_20260908-064821.txt
+++ b/submissions/Tnt540_BLKOPSCW_20260908-064821/image_20260908-064821.txt
@@ -1,0 +1,2 @@
+12cf1781815855a,i_mtl_p9_zm_platinum_screen_r_04_text_c
+6c741bb4121322f,i_mtl_p9_zm_platinum_screen_r_05_text_c

--- a/submissions/Tnt540_BLKOPSCW_20260908-064821/material_20260908-064821.txt
+++ b/submissions/Tnt540_BLKOPSCW_20260908-064821/material_20260908-064821.txt
@@ -1,0 +1,1 @@
+3143f7684f3fb6ec,mc/mtl_p9_zm_platinum_screen_r_05_text


### PR DESCRIPTION
**BLKOPSCW** — 3 asset names, confirmed against that game's own loaded assets.

- image: 2
- material: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Tnt540

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260908-064639_list
- method: family gap filling
- what it does: a candidate list generated outside the search and confirmed here
- ran for: 3s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- candidates tested: 114093
- matched: 3
- new: 3
- sketch stems: 00018e46f234bb7f00022d3960fc82ef0002eabc4d365c2600032b55f189cfaf000357ae0071d018000433e747350fbd0004c1523098100300054e9c13d092720005794020657dbd0006bae5626a1a7400076187583476ce00077565d94be1b00008359b16571f0d0008db2783e508d300090c7eefdc900b000916240f80f791000923a553a37e03000953507d68bc3a0009585a9dc688b50009f3e894f18fae0009fcf3def3fb32000a0034e11a86cf000b19efc1fd2f35000bb1c7af62d8a3000bd5555442746e000c1879250ddfe7000c867d23e3f060000cdf7109e7cc1c000d6b1a035443cf000d8bfa9c2c8247000dea0d6add6164000ed7017c89322f
- ids hunted: 108176
- throughput: 0.8M candidates/s
- fingerprint: 24b209b97596767b

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/families.py`
- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/mp_shared_tail_grid_20260908-062632.py`
- `scripts/contributed/uncarried_begins_20260823-023757.txt`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.