### PR TITLE
[BLKOPSCW] findings from Tnt540, 20260908-065540 (2 names)

### DIFF
--- a/submissions/Tnt540_BLKOPSCW_20260908-065540/about_20260908-065540.md
+++ b/submissions/Tnt540_BLKOPSCW_20260908-065540/about_20260908-065540.md
@@ -1,0 +1,32 @@
+# Submission 20260908-065540
+
+- game: **BLKOPSCW**
+- from: Tnt540
+- names: 2
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- xmodel: 2
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 36 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260908-065500_variants
+- method: family walking, numbers in place (variants)
+- what it does: each number or letter field of a name already known to be real counted through in place, keeping the width of what was there
+- ran for: 6m 03s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- ids hunted: 108176
+- candidates tested: 10522526779
+- new: 2
+- sketch stems: 0000003d0b47de55000004172557c4db000009ac7953308b000010fbc36d8f27000012af82f269c40000193e87ceefbc00001aa719502d7c00001e1cccd31eec00001f7cf71e4848000023c08dc4a124000027948203cd2f00002c7c8411c63b00002e8caedc668d000032b4dbfef915000033689cd693f5000033f4eab88546000034bcb64c23ae00003d7c0bcf6daa00003e3feaf74564000046d733dba53c000052eddb08e5db0000611a79b91595000064ed3f5f23b300006af15f2fba32000072ae09156ad400007461f8a07236000078bb58212d4d00007965d060178a000082778bc1f3c70000836bd73172550000837c07d21d7b00008bab2a98a97c
+- sketch endings: 
+- fingerprint: ef8ef49550045ea3

--- a/submissions/Tnt540_BLKOPSCW_20260908-065540/xmodel_20260908-065540.txt
+++ b/submissions/Tnt540_BLKOPSCW_20260908-065540/xmodel_20260908-065540.txt
@@ -1,0 +1,2 @@
+34f4452a83a89ef7,p9_mal_display_kit_01_mesh_16x64
+34fe312a83b0d180,p9_mal_display_kit_01_mesh_16x32


### PR DESCRIPTION
**BLKOPSCW** — 2 asset names, confirmed against that game's own loaded assets.

- xmodel: 2

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Tnt540

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260908-065500_variants
- method: family walking, numbers in place (variants)
- what it does: each number or letter field of a name already known to be real counted through in place, keeping the width of what was there
- ran for: 6m 03s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- ids hunted: 108176
- candidates tested: 10522526779
- new: 2
- sketch stems: 0000003d0b47de55000004172557c4db000009ac7953308b000010fbc36d8f27000012af82f269c40000193e87ceefbc00001aa719502d7c00001e1cccd31eec00001f7cf71e4848000023c08dc4a124000027948203cd2f00002c7c8411c63b00002e8caedc668d000032b4dbfef915000033689cd693f5000033f4eab88546000034bcb64c23ae00003d7c0bcf6daa00003e3feaf74564000046d733dba53c000052eddb08e5db0000611a79b91595000064ed3f5f23b300006af15f2fba32000072ae09156ad400007461f8a07236000078bb58212d4d00007965d060178a000082778bc1f3c70000836bd73172550000837c07d21d7b00008bab2a98a97c
- sketch endings: 
- fingerprint: ef8ef49550045ea3


## Tooling this run leaves behind

- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/mp_shared_tail_grid_20260908-062632.py`
- `scripts/contributed/uncarried_begins_20260823-023757.txt`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.