### PR TITLE
[BLKOPSCW] findings from Hexeption, 20260908-152647 (1 names)

### DIFF
--- a/submissions/Hexeption_BLKOPSCW_20260908-152647/about_20260908-152647.md
+++ b/submissions/Hexeption_BLKOPSCW_20260908-152647/about_20260908-152647.md
@@ -1,0 +1,38 @@
+# Submission 20260908-152647
+
+- game: **BLKOPSCW**
+- from: Hexeption
+- names: 1
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- sound_alias: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 44 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260908-151435_plan
+- method: tails of length 4
+- what it does: every known name cut short by 4 character(s), against every 4-character ending over the 37 characters names are measured to end in
+- ran for: 11m 36s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- beginnings: 0
+- endings: 1874161
+- stems: 666738
+- ids hunted: 107282
+- candidates tested: 1249575023556
+- new: 1
+- sketch beginnings: 
+- sketch stems: 000007ed1f55455e00000f04890efb9300001172e79597620000250ce9be540f00002b1519e1ded400002cd4f05adb3f000036a465533c760000426a487f82820000454b857cd62b0000995349583bec0000b4875a0a875b0000f8739296b6aa000132eed8e815540001454298b1844c00014cad6bcdce81000179a1a68181330001813085bb68970001b99d7660f9380001bc0f024251610001dd5d4a4f8aaf0001e6e94e88a18b0001eccc569e4af30002006e1d716340000234680a2464c3000238f013b0fcd50002507aed4304090002d0b9a07a314f0002e8431c6317ed0003010eab0a11a4000303f9d738aedf000317f593d7960b000337c396e563d0
+- sketch endings: 00002dd0176b8e24000033efc2f5b38e000039cc2a666a5700004083d0a24b210000442357349c48000046f629431498000052a0df54cc5d00005512eed4a77f00005bf7a89df10a000062609ea8aa35000063887ffc35540000655e0640f63d00006e2534de6dc5000073b3a4ceff570000843b783c7f0b000091b3edf4632e000092355b1df97500009b128b2568280000a6dff129b1060000a81ae4845bb50000b3dfa37589610000bccb62c692250000c6867b8cd7f30000cb3f2e8e8b0e0000cf501eb0e4db0000e32d85a325b30000e5a51d698e920000e64bdc5524fd0000e9799f1d619a0000fff8a375176300010c3e883a04ac0001182989c807d6
+- fingerprint: aff8861b137467de
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/Hexeption_BLKOPSCW_20260908-152647/sound_alias_20260908-152647.txt
+++ b/submissions/Hexeption_BLKOPSCW_20260908-152647/sound_alias_20260908-152647.txt
@@ -1,0 +1,1 @@
+29e6c06365f78380,fly_step_walk_steinersplit_gore


### PR DESCRIPTION
**BLKOPSCW** — 1 asset names, confirmed against that game's own loaded assets.

- sound_alias: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Hexeption

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260908-151435_plan
- method: tails of length 4
- what it does: every known name cut short by 4 character(s), against every 4-character ending over the 37 characters names are measured to end in
- ran for: 11m 36s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- beginnings: 0
- endings: 1874161
- stems: 666738
- ids hunted: 107282
- candidates tested: 1249575023556
- new: 1
- sketch beginnings: 
- sketch stems: 000007ed1f55455e00000f04890efb9300001172e79597620000250ce9be540f00002b1519e1ded400002cd4f05adb3f000036a465533c760000426a487f82820000454b857cd62b0000995349583bec0000b4875a0a875b0000f8739296b6aa000132eed8e815540001454298b1844c00014cad6bcdce81000179a1a68181330001813085bb68970001b99d7660f9380001bc0f024251610001dd5d4a4f8aaf0001e6e94e88a18b0001eccc569e4af30002006e1d716340000234680a2464c3000238f013b0fcd50002507aed4304090002d0b9a07a314f0002e8431c6317ed0003010eab0a11a4000303f9d738aedf000317f593d7960b000337c396e563d0
- sketch endings: 00002dd0176b8e24000033efc2f5b38e000039cc2a666a5700004083d0a24b210000442357349c48000046f629431498000052a0df54cc5d00005512eed4a77f00005bf7a89df10a000062609ea8aa35000063887ffc35540000655e0640f63d00006e2534de6dc5000073b3a4ceff570000843b783c7f0b000091b3edf4632e000092355b1df97500009b128b2568280000a6dff129b1060000a81ae4845bb50000b3dfa37589610000bccb62c692250000c6867b8cd7f30000cb3f2e8e8b0e0000cf501eb0e4db0000e32d85a325b30000e5a51d698e920000e64bdc5524fd0000e9799f1d619a0000fff8a375176300010c3e883a04ac0001182989c807d6
- fingerprint: aff8861b137467de

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/bo4_cross_title_begins_20260907-200449.txt`
- `scripts/contributed/cw_cross_title_begins_20260907-200449.txt`
- `scripts/contributed/uncarried_ends_20260907-200449.txt`
- `scripts/contributed/cw_uncarried_begins_cross_title_20260907-200449.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.