### PR TITLE
[BLKOPSCW] findings from Hexeption, 20260909-012419 (2 names)

### DIFF
--- a/submissions/Hexeption_BLKOPSCW_20260909-012419/about_20260909-012419.md
+++ b/submissions/Hexeption_BLKOPSCW_20260909-012419/about_20260909-012419.md
@@ -1,0 +1,39 @@
+# Submission 20260909-012419
+
+- game: **BLKOPSCW**
+- from: Hexeption
+- names: 2
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 2
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- material: 1
+- xanim: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 74 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260909-012309_plan
+- method: CW sound uncarried two-segment endings top32000
+- what it does: CW sound cores paired with the 32000 most common uncarried two-segment sound endings
+- ran for: 14s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- beginnings: 0
+- endings: 32000
+- stems: 60406
+- ids hunted: 107238
+- candidates tested: 1933052406
+- new: 4
+- sketch beginnings: 
+- sketch stems: 00002ee0bf50cc960001350db49850c600063685031d44230006518ce0f1ed4d0007d55dbb0777ea0009fc4ea542379a000a6d6d22ada5ec000b32b8830e99c2000c7c620254ad84000d4e4e5c704308000d9cf054b1db20000e0d6443bf44c700110f76cb990dc10012925818e6286c00131ee02c31e69800164f8aa3d6a8a10018f26d946f38e2001a3f8df536b4e2001a5decf535a071001b8656fdaae773001ca7f05f38a262001d4a75b70dbd0d001e2c9de2cd1f41001f4642a4c30c73001fa7e39c94468c00208856d44379ec0022d2ca5ed1656e00237f2be3916d920026007fd114d5620026aef7272f8e7c002849ece595d57a00290e2b761d4cfa
+- sketch endings: 00013f24e9c023120001a71a695e5f360003457123e690fd00072a1bbcfd2b66000b312a37ecda9c000d0fbd17b5b9a8000f15a88f8f021b000f171bc156d3cd0010a7627c8bec7b00147b1823103548001c6c5ea95115d6001c6ca141863c1a001def47b5bc0a0a001f29a3431d1f97002153b0fdbd628a002242b631b0a6a900248f2928a6cc0e002625c8fbc0bc7c002cef8d74b2676f002e213dff14e29c0031c2c94482554b00330a68a663168700350dc4e7feac180035953a12107b39003612a7eeddb92b0037071c73bc6edd003734de49a1d57e0037a91bad6c1e70003a2b49b3ca3941003b555a5b5e404b003fc410fce8ef860047b41205b5ca91
+- fingerprint: 4598c3b11d250bf8
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/Hexeption_BLKOPSCW_20260909-012419/material_20260909-012419.txt
+++ b/submissions/Hexeption_BLKOPSCW_20260909-012419/material_20260909-012419.txt
@@ -1,0 +1,1 @@
+6c9a9a40024a380f,mc/mtl_veh_t9_mil_helicopter_transport_burnstain_a

--- a/submissions/Hexeption_BLKOPSCW_20260909-012419/xanim_20260909-012419.txt
+++ b/submissions/Hexeption_BLKOPSCW_20260909-012419/xanim_20260909-012419.txt
@@ -1,0 +1,1 @@
+5efd1b1b612323de,vm_t9_base_mantle_launcher_additive


### PR DESCRIPTION
**BLKOPSCW** — 2 asset names, confirmed against that game's own loaded assets.

- material: 1
- xanim: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 2
- submitted by: @Hexeption

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260909-012309_plan
- method: CW sound uncarried two-segment endings top32000
- what it does: CW sound cores paired with the 32000 most common uncarried two-segment sound endings
- ran for: 14s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- beginnings: 0
- endings: 32000
- stems: 60406
- ids hunted: 107238
- candidates tested: 1933052406
- new: 4
- sketch beginnings: 
- sketch stems: 00002ee0bf50cc960001350db49850c600063685031d44230006518ce0f1ed4d0007d55dbb0777ea0009fc4ea542379a000a6d6d22ada5ec000b32b8830e99c2000c7c620254ad84000d4e4e5c704308000d9cf054b1db20000e0d6443bf44c700110f76cb990dc10012925818e6286c00131ee02c31e69800164f8aa3d6a8a10018f26d946f38e2001a3f8df536b4e2001a5decf535a071001b8656fdaae773001ca7f05f38a262001d4a75b70dbd0d001e2c9de2cd1f41001f4642a4c30c73001fa7e39c94468c00208856d44379ec0022d2ca5ed1656e00237f2be3916d920026007fd114d5620026aef7272f8e7c002849ece595d57a00290e2b761d4cfa
- sketch endings: 00013f24e9c023120001a71a695e5f360003457123e690fd00072a1bbcfd2b66000b312a37ecda9c000d0fbd17b5b9a8000f15a88f8f021b000f171bc156d3cd0010a7627c8bec7b00147b1823103548001c6c5ea95115d6001c6ca141863c1a001def47b5bc0a0a001f29a3431d1f97002153b0fdbd628a002242b631b0a6a900248f2928a6cc0e002625c8fbc0bc7c002cef8d74b2676f002e213dff14e29c0031c2c94482554b00330a68a663168700350dc4e7feac180035953a12107b39003612a7eeddb92b0037071c73bc6edd003734de49a1d57e0037a91bad6c1e70003a2b49b3ca3941003b555a5b5e404b003fc410fce8ef860047b41205b5ca91
- fingerprint: 4598c3b11d250bf8

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/bik_execution_family_20260908-162405.py`
- `scripts/contributed/bo2_bo3_sab_to_bo4_local_20260908-203313.py`
- `scripts/contributed/bo4_cross_title_begins_20260907-200449.txt`
- `scripts/contributed/bo4_mapset_faction_local_20260908-231825.py`
- `scripts/contributed/bo4_music_sound_assets_local_20260908-231825.py`
- `scripts/contributed/bo4_sound_asset_numeric_family_gaps_20260908-203313.py`
- `scripts/contributed/bo4_source_sound_context_token_subs_local_20260908-231825.py`
- `scripts/contributed/bo4_wpn_sab_local_20260908-203313.py`
- `scripts/contributed/chan_ends_20260909-005914.txt`
- `scripts/contributed/cw_cross_title_begins_20260907-200449.txt`
- `scripts/contributed/cw_operator_vox_grid_local_20260908-231825.py`
- `scripts/contributed/hex_grid_volumes_local_20260908-231825.py`
- `scripts/contributed/repo_asset_literals_20260908-231825.py`
- `scripts/contributed/sound_asset_outer_tokens_local_20260908-203313.py`
- `scripts/contributed/uncarried_head_tail_atoms_local_20260908-231825.py`
- `scripts/contributed/uncarried_prefix_local_grids_local_20260908-231825.py`
- `scripts/contributed/uncarried_volume_heads_20260909-005914.py`
- `scripts/contributed/volume_family_counterparts_20260908-203313.py`
- `scripts/contributed/cw_uncarried_begins_cross_title_20260907-200449.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.