### PR TITLE
[BLKOPSCW] findings from Hexeption, 20260909-013450 (2 names)

### DIFF
--- a/submissions/Hexeption_BLKOPSCW_20260909-013450/about_20260909-013450.md
+++ b/submissions/Hexeption_BLKOPSCW_20260909-013450/about_20260909-013450.md
@@ -1,0 +1,38 @@
+# Submission 20260909-013450
+
+- game: **BLKOPSCW**
+- from: Hexeption
+- names: 2
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- material: 2
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 77 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260909-013328_plan
+- method: CW sound uncarried two-segment endings top128000
+- what it does: CW sound cores paired with the 128000 most common uncarried two-segment sound endings
+- ran for: 25s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- beginnings: 0
+- endings: 128000
+- stems: 60406
+- ids hunted: 107233
+- candidates tested: 7732028406
+- new: 2
+- sketch beginnings: 
+- sketch stems: 00002ee0bf50cc960001350db49850c600063685031d44230006518ce0f1ed4d0007d55dbb0777ea0009fc4ea542379a000a6d6d22ada5ec000b32b8830e99c2000c7c620254ad84000d4e4e5c704308000d9cf054b1db20000e0d6443bf44c700110f76cb990dc10012925818e6286c00131ee02c31e69800164f8aa3d6a8a10018f26d946f38e2001a3f8df536b4e2001a5decf535a071001b8656fdaae773001ca7f05f38a262001d4a75b70dbd0d001e2c9de2cd1f41001f4642a4c30c73001fa7e39c94468c00208856d44379ec0022d2ca5ed1656e00237f2be3916d920026007fd114d5620026aef7272f8e7c002849ece595d57a00290e2b761d4cfa
+- sketch endings: 0000328fdf29297d00013f24e9c0231200017c0dd258c2850001a71a695e5f36000271aa0414ec0b0003457123e690fd0003e8b05c6d91a400050a59d8eaf1730005dcb838b865c10006186a40e686a200061d8f8e46762d00062ac18e0408aa00069c1a6fbfae7b00072a1bbcfd2b66000931978e22ab230009350b2905cadf0009e83747b5eccb000ae3c0cadea750000b312a37ecda9c000bc4ce5ff35f23000c0908c0b9c58b000d0fbd17b5b9a8000d7ece6fa17575000d9afa67b4ed2c000dac17c66fcdb1000e40daa87bc916000f007c166b2186000f15a88f8f021b000f171bc156d3cd000f2b3bdf9458430010a7627c8bec7b00122dba248a0eaa
+- fingerprint: bb727e113873b5eb
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/Hexeption_BLKOPSCW_20260909-013450/material_20260909-013450.txt
+++ b/submissions/Hexeption_BLKOPSCW_20260909-013450/material_20260909-013450.txt
@@ -1,0 +1,2 @@
+2799b66bd6e6ddb4,mc/mtl_veh_t9_mil_offroad_motorcycle_body_a_carpaint_forks_accent_dead
+7d6dc177be7ad921,mc/mtl_veh_t9_mil_offroad_motorcycle_body_a_carpaint_forks_accent_blk


### PR DESCRIPTION
**BLKOPSCW** — 2 asset names, confirmed against that game's own loaded assets.

- material: 2

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Hexeption

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260909-013328_plan
- method: CW sound uncarried two-segment endings top128000
- what it does: CW sound cores paired with the 128000 most common uncarried two-segment sound endings
- ran for: 25s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- beginnings: 0
- endings: 128000
- stems: 60406
- ids hunted: 107233
- candidates tested: 7732028406
- new: 2
- sketch beginnings: 
- sketch stems: 00002ee0bf50cc960001350db49850c600063685031d44230006518ce0f1ed4d0007d55dbb0777ea0009fc4ea542379a000a6d6d22ada5ec000b32b8830e99c2000c7c620254ad84000d4e4e5c704308000d9cf054b1db20000e0d6443bf44c700110f76cb990dc10012925818e6286c00131ee02c31e69800164f8aa3d6a8a10018f26d946f38e2001a3f8df536b4e2001a5decf535a071001b8656fdaae773001ca7f05f38a262001d4a75b70dbd0d001e2c9de2cd1f41001f4642a4c30c73001fa7e39c94468c00208856d44379ec0022d2ca5ed1656e00237f2be3916d920026007fd114d5620026aef7272f8e7c002849ece595d57a00290e2b761d4cfa
- sketch endings: 0000328fdf29297d00013f24e9c0231200017c0dd258c2850001a71a695e5f36000271aa0414ec0b0003457123e690fd0003e8b05c6d91a400050a59d8eaf1730005dcb838b865c10006186a40e686a200061d8f8e46762d00062ac18e0408aa00069c1a6fbfae7b00072a1bbcfd2b66000931978e22ab230009350b2905cadf0009e83747b5eccb000ae3c0cadea750000b312a37ecda9c000bc4ce5ff35f23000c0908c0b9c58b000d0fbd17b5b9a8000d7ece6fa17575000d9afa67b4ed2c000dac17c66fcdb1000e40daa87bc916000f007c166b2186000f15a88f8f021b000f171bc156d3cd000f2b3bdf9458430010a7627c8bec7b00122dba248a0eaa
- fingerprint: bb727e113873b5eb

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/bik_execution_family_20260908-162405.py`
- `scripts/contributed/bo2_bo3_sab_to_bo4_local_20260908-203313.py`
- `scripts/contributed/bo4_cross_title_begins_20260907-200449.txt`
- `scripts/contributed/bo4_mapset_faction_local_20260908-231825.py`
- `scripts/contributed/bo4_music_sound_assets_local_20260908-231825.py`
- `scripts/contributed/bo4_sound_asset_numeric_family_gaps_20260908-203313.py`
- `scripts/contributed/bo4_source_sound_context_token_subs_local_20260908-231825.py`
- `scripts/contributed/bo4_wpn_sab_local_20260908-203313.py`
- `scripts/contributed/chan_ends_20260909-005914.txt`
- `scripts/contributed/cw_cross_title_begins_20260907-200449.txt`
- `scripts/contributed/cw_operator_vox_grid_local_20260908-231825.py`
- `scripts/contributed/hex_grid_volumes_local_20260908-231825.py`
- `scripts/contributed/repo_asset_literals_20260908-231825.py`
- `scripts/contributed/sound_asset_outer_tokens_local_20260908-203313.py`
- `scripts/contributed/uncarried_head_tail_atoms_local_20260908-231825.py`
- `scripts/contributed/uncarried_prefix_local_grids_local_20260908-231825.py`
- `scripts/contributed/uncarried_volume_heads_20260909-005914.py`
- `scripts/contributed/volume_family_counterparts_20260908-203313.py`
- `scripts/contributed/cw_uncarried_begins_cross_title_20260907-200449.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.