### PR TITLE
[BLKOPSCW] findings from Hexeption, 20260909-015239 (2 names)

### DIFF
--- a/submissions/Hexeption_BLKOPSCW_20260909-015239/about_20260909-015239.md
+++ b/submissions/Hexeption_BLKOPSCW_20260909-015239/about_20260909-015239.md
@@ -1,0 +1,39 @@
+# Submission 20260909-015239
+
+- game: **BLKOPSCW**
+- from: Hexeption
+- names: 2
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 1
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- material: 1
+- xanim: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 84 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260909-015117_plan
+- method: CW sound uncarried three-segment endings top128000
+- what it does: CW sound cores paired with the 128000 most common uncarried three-segment sound endings
+- ran for: 21s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- beginnings: 0
+- endings: 128000
+- stems: 36882
+- ids hunted: 107185
+- candidates tested: 4720932882
+- new: 3
+- sketch beginnings: 
+- sketch stems: 0001350db49850c6000196f66cc5bd0a0001aef44909c8860001d42da712184b0002257ec18410d600033cf2e70d98660003ad561d3af4ed0003b69caf19a9720003df052c8c65a40004f9caa2916c42000a6d6d22ada5ec00103704bb2a3db20012925818e6286c001416b90333d31100148f2480d0d92600164f8aa3d6a8a10017b057df414ac200182aeae1fa77ef001a1eff569f0efc001ca7f05f38a262001fa7e39c94468c0020a0a8cbfea1d30021f947810a4f0c0022d2ca5ed1656e0025055ac232bd5f00255304029dfa13002b9cd6d0fcf50e003225b9990e7b4f0032364677297a0800334fe92bc690320035908c029a72b5003800ab940f81ea
+- sketch endings: 00000e56e68ff2ad000014e89d24eb3500004eb4142e348d00019d2016c82e7b00027e48b87969d800029060f893dbf40002b61bdcaac24d0003477c27e27f880003bf92fab8232e00054cc2ce1143730006bd46f94af85b0007ffd3755fdb08000800014fbf96ff00091648fb3c140a00098027a9b89c27000abfcf221cd263000b32cfc5ca23fa000b62aa1032da53000ba805f7eeffa2000be1ca315904b9000c30d0c85c778f000c8abe8ad89ed6000d5661b4cee224000e404bcace059e000e6b3edc6a009e000e99746e60cb0c000e9cf37c034a7f00100ed2161e07d4001054525ae7463900109399f33296ac0010c554ec023cce001169631f00ab5e
+- fingerprint: 70d23f409ff41c97
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/Hexeption_BLKOPSCW_20260909-015239/material_20260909-015239.txt
+++ b/submissions/Hexeption_BLKOPSCW_20260909-015239/material_20260909-015239.txt
@@ -1,0 +1,1 @@
+be7dc655b41ff43,mc/mtl_p9_zm_platinum_conversion_machine_metal_02_blue

--- a/submissions/Hexeption_BLKOPSCW_20260909-015239/xanim_20260909-015239.txt
+++ b/submissions/Hexeption_BLKOPSCW_20260909-015239/xanim_20260909-015239.txt
@@ -1,0 +1,1 @@
+382016207a859902,vm_ges_t9_slide_bare_hands


### PR DESCRIPTION
**BLKOPSCW** — 2 asset names, confirmed against that game's own loaded assets.

- material: 1
- xanim: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 1
- submitted by: @Hexeption

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260909-015117_plan
- method: CW sound uncarried three-segment endings top128000
- what it does: CW sound cores paired with the 128000 most common uncarried three-segment sound endings
- ran for: 21s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- beginnings: 0
- endings: 128000
- stems: 36882
- ids hunted: 107185
- candidates tested: 4720932882
- new: 3
- sketch beginnings: 
- sketch stems: 0001350db49850c6000196f66cc5bd0a0001aef44909c8860001d42da712184b0002257ec18410d600033cf2e70d98660003ad561d3af4ed0003b69caf19a9720003df052c8c65a40004f9caa2916c42000a6d6d22ada5ec00103704bb2a3db20012925818e6286c001416b90333d31100148f2480d0d92600164f8aa3d6a8a10017b057df414ac200182aeae1fa77ef001a1eff569f0efc001ca7f05f38a262001fa7e39c94468c0020a0a8cbfea1d30021f947810a4f0c0022d2ca5ed1656e0025055ac232bd5f00255304029dfa13002b9cd6d0fcf50e003225b9990e7b4f0032364677297a0800334fe92bc690320035908c029a72b5003800ab940f81ea
- sketch endings: 00000e56e68ff2ad000014e89d24eb3500004eb4142e348d00019d2016c82e7b00027e48b87969d800029060f893dbf40002b61bdcaac24d0003477c27e27f880003bf92fab8232e00054cc2ce1143730006bd46f94af85b0007ffd3755fdb08000800014fbf96ff00091648fb3c140a00098027a9b89c27000abfcf221cd263000b32cfc5ca23fa000b62aa1032da53000ba805f7eeffa2000be1ca315904b9000c30d0c85c778f000c8abe8ad89ed6000d5661b4cee224000e404bcace059e000e6b3edc6a009e000e99746e60cb0c000e9cf37c034a7f00100ed2161e07d4001054525ae7463900109399f33296ac0010c554ec023cce001169631f00ab5e
- fingerprint: 70d23f409ff41c97

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/bik_execution_family_20260908-162405.py`
- `scripts/contributed/bo2_bo3_sab_to_bo4_local_20260908-203313.py`
- `scripts/contributed/bo4_cross_title_begins_20260907-200449.txt`
- `scripts/contributed/bo4_mapset_faction_local_20260908-231825.py`
- `scripts/contributed/bo4_music_sound_assets_local_20260908-231825.py`
- `scripts/contributed/bo4_sound_asset_numeric_family_gaps_20260908-203313.py`
- `scripts/contributed/bo4_source_sound_context_token_subs_local_20260908-231825.py`
- `scripts/contributed/bo4_wpn_sab_local_20260908-203313.py`
- `scripts/contributed/chan_ends_20260909-005914.txt`
- `scripts/contributed/cw_cross_title_begins_20260907-200449.txt`
- `scripts/contributed/cw_operator_vox_grid_local_20260908-231825.py`
- `scripts/contributed/hex_grid_volumes_local_20260908-231825.py`
- `scripts/contributed/repo_asset_literals_20260908-231825.py`
- `scripts/contributed/sound_asset_outer_tokens_local_20260908-203313.py`
- `scripts/contributed/uncarried_head_tail_atoms_local_20260908-231825.py`
- `scripts/contributed/uncarried_prefix_local_grids_local_20260908-231825.py`
- `scripts/contributed/uncarried_volume_heads_20260909-005914.py`
- `scripts/contributed/volume_family_counterparts_20260908-203313.py`
- `scripts/contributed/cw_uncarried_begins_cross_title_20260907-200449.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.