### PR TITLE
[BLKOPSCW] findings from Hexeption, 20260909-020434 (1 names)

### DIFF
--- a/submissions/Hexeption_BLKOPSCW_20260909-020434/about_20260909-020434.md
+++ b/submissions/Hexeption_BLKOPSCW_20260909-020434/about_20260909-020434.md
@@ -1,0 +1,38 @@
+# Submission 20260909-020434
+
+- game: **BLKOPSCW**
+- from: Hexeption
+- names: 1
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- sound_alias: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 88 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260909-020229_plan
+- method: CW sound uncarried three-segment endings top512000
+- what it does: CW sound cores paired with the 512000 most common uncarried three-segment sound endings
+- ran for: 40s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- beginnings: 0
+- endings: 323968
+- stems: 36882
+- ids hunted: 107158
+- candidates tested: 11948624658
+- new: 1
+- sketch beginnings: 
+- sketch stems: 0001350db49850c6000196f66cc5bd0a0001aef44909c8860001d42da712184b0002257ec18410d600033cf2e70d98660003ad561d3af4ed0003b69caf19a9720003df052c8c65a40004f9caa2916c42000a6d6d22ada5ec00103704bb2a3db20012925818e6286c001416b90333d31100148f2480d0d92600164f8aa3d6a8a10017b057df414ac200182aeae1fa77ef001a1eff569f0efc001ca7f05f38a262001fa7e39c94468c0020a0a8cbfea1d30021f947810a4f0c0022d2ca5ed1656e0025055ac232bd5f00255304029dfa13002b9cd6d0fcf50e003225b9990e7b4f0032364677297a0800334fe92bc690320035908c029a72b5003800ab940f81ea
+- sketch endings: 00000155434ca6f200000e56e68ff2ad000013d434b4724f000014e89d24eb3500004eb4142e348d000065e10ceb048d0000abc7bd194a51000113bd190403aa000144782229c78a000175f3c2c1573000019d2016c82e7b0001e32129b676ce0001e8a869aae33e00023fec04aa65c1000252e1d7ad5fb100027e48b87969d800029060f893dbf40002aaaa48e6effc0002b61bdcaac24d0002c4d3fb39e29900030639fa7f76b30003477c27e27f880003bf92fab8232e0003bf97337eac8500053e0140fda0f300054cc2ce114373000577b6fd5507c5000665f3040e3d360006bd46f94af85b00076bfda3b9170d0007c21093d0ef910007ffd3755fdb08
+- fingerprint: 39d68ebae48fa2b4
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/Hexeption_BLKOPSCW_20260909-020434/sound_alias_20260909-020434.txt
+++ b/submissions/Hexeption_BLKOPSCW_20260909-020434/sound_alias_20260909-020434.txt
@@ -1,0 +1,1 @@
+16474e80e8a1f9d,zmb_quest_ww_safe_dial_turn


### PR DESCRIPTION
**BLKOPSCW** — 1 asset names, confirmed against that game's own loaded assets.

- sound_alias: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Hexeption

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260909-020229_plan
- method: CW sound uncarried three-segment endings top512000
- what it does: CW sound cores paired with the 512000 most common uncarried three-segment sound endings
- ran for: 40s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- beginnings: 0
- endings: 323968
- stems: 36882
- ids hunted: 107158
- candidates tested: 11948624658
- new: 1
- sketch beginnings: 
- sketch stems: 0001350db49850c6000196f66cc5bd0a0001aef44909c8860001d42da712184b0002257ec18410d600033cf2e70d98660003ad561d3af4ed0003b69caf19a9720003df052c8c65a40004f9caa2916c42000a6d6d22ada5ec00103704bb2a3db20012925818e6286c001416b90333d31100148f2480d0d92600164f8aa3d6a8a10017b057df414ac200182aeae1fa77ef001a1eff569f0efc001ca7f05f38a262001fa7e39c94468c0020a0a8cbfea1d30021f947810a4f0c0022d2ca5ed1656e0025055ac232bd5f00255304029dfa13002b9cd6d0fcf50e003225b9990e7b4f0032364677297a0800334fe92bc690320035908c029a72b5003800ab940f81ea
- sketch endings: 00000155434ca6f200000e56e68ff2ad000013d434b4724f000014e89d24eb3500004eb4142e348d000065e10ceb048d0000abc7bd194a51000113bd190403aa000144782229c78a000175f3c2c1573000019d2016c82e7b0001e32129b676ce0001e8a869aae33e00023fec04aa65c1000252e1d7ad5fb100027e48b87969d800029060f893dbf40002aaaa48e6effc0002b61bdcaac24d0002c4d3fb39e29900030639fa7f76b30003477c27e27f880003bf92fab8232e0003bf97337eac8500053e0140fda0f300054cc2ce114373000577b6fd5507c5000665f3040e3d360006bd46f94af85b00076bfda3b9170d0007c21093d0ef910007ffd3755fdb08
- fingerprint: 39d68ebae48fa2b4

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/bik_execution_family_20260908-162405.py`
- `scripts/contributed/bo2_bo3_sab_to_bo4_local_20260908-203313.py`
- `scripts/contributed/bo4_cross_title_begins_20260907-200449.txt`
- `scripts/contributed/bo4_mapset_faction_local_20260908-231825.py`
- `scripts/contributed/bo4_music_sound_assets_local_20260908-231825.py`
- `scripts/contributed/bo4_sound_asset_numeric_family_gaps_20260908-203313.py`
- `scripts/contributed/bo4_source_sound_context_token_subs_local_20260908-231825.py`
- `scripts/contributed/bo4_wpn_sab_local_20260908-203313.py`
- `scripts/contributed/chan_ends_20260909-005914.txt`
- `scripts/contributed/cw_cross_title_begins_20260907-200449.txt`
- `scripts/contributed/cw_operator_vox_grid_local_20260908-231825.py`
- `scripts/contributed/hex_grid_volumes_local_20260908-231825.py`
- `scripts/contributed/repo_asset_literals_20260908-231825.py`
- `scripts/contributed/sound_asset_outer_tokens_local_20260908-203313.py`
- `scripts/contributed/uncarried_head_tail_atoms_local_20260908-231825.py`
- `scripts/contributed/uncarried_prefix_local_grids_local_20260908-231825.py`
- `scripts/contributed/uncarried_volume_heads_20260909-005914.py`
- `scripts/contributed/volume_family_counterparts_20260908-203313.py`
- `scripts/contributed/cw_uncarried_begins_cross_title_20260907-200449.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.