### PR TITLE
[BLKOPS04] findings from Hexeption, 20260909-030107 (2 names)

### DIFF
--- a/submissions/Hexeption_BLKOPS04_20260909-030107/about_20260909-030107.md
+++ b/submissions/Hexeption_BLKOPS04_20260909-030107/about_20260909-030107.md
@@ -1,0 +1,38 @@
+# Submission 20260909-030107
+
+- game: **BLKOPS04**
+- from: Hexeption
+- names: 2
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- image: 2
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 96 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260909-025927_plan
+- method: tails of length 3
+- what it does: every known name cut short by 3 character(s), against every 3-character ending over the 37 characters names are measured to end in
+- ran for: 28s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- beginnings: 0
+- endings: 50653
+- stems: 686192
+- ids hunted: 137628
+- candidates tested: 34758369568
+- new: 2
+- sketch beginnings: 
+- sketch stems: 000012c311da10ff0000153036e7f04000001ec5aa5a75d0000041e573392669000042af8f2b9720000045e1807a46390000502a97bf06ff000051b7b6e7c3e50000595d5e43b51e00008b630b00272f00009c2abd7015410000b8292d62cf930000c63c8d67601c00012a876c73b4c100014cad6bcdce8100014f172cefd1d000015bf4b3c377a8000161fe7c7fb3bf000179ee9b7479ed0001892d1c54956d00019940fc3e141700019d19b275dbfb0001e9d263b7d55a00024dde3c116c50000253b116c73a2f00026692321156850002727cb126db540002797b0cb0c0e00002bf02439b4c180002c4406d93ab780002cc8b5409c9ed0002d9635732ab9e
+- sketch endings: 0000065093d2ddcb000009a9246decd30000c0ee97a841da000105e496e34f73000221c75929fb3200024e1052ecac1e00046b3d1855840d0005ae639e926f5d000cbc01b480ab4c000cbec3f4c1a1f2000d92810ddcb5dc0010d8212032c16700110b28e22c5b000011482c992f9b36001280f6cd94de880012a5925ed9cdc700148fff58e34676001538998e20f3570015ecc7299627dc00171438b6fbe1d70017285349dcf2ba001798c7451b75ee001916f3aa09d066001a6f64968748f5001cec1662cf3c52001d2cad0ab0964c001e6153b65350ad001f0b5ecc97c959001fdc30529cddff0021ad1c1ec693070021bc0e48915ced0023b92a21dde19a
+- fingerprint: 9215129fcc2e5b09
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/Hexeption_BLKOPS04_20260909-030107/image_20260909-030107.txt
+++ b/submissions/Hexeption_BLKOPS04_20260909-030107/image_20260909-030107.txt
@@ -1,0 +1,2 @@
+460b97af144acde8,i_mtl_veh_decal_racer_logo_diaysler_03_c
+4c80b0af175316a3,i_mtl_veh_decal_racer_logo_diaysler_02_c


### PR DESCRIPTION
**BLKOPS04** — 2 asset names, confirmed against that game's own loaded assets.

- image: 2

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Hexeption

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260909-025927_plan
- method: tails of length 3
- what it does: every known name cut short by 3 character(s), against every 3-character ending over the 37 characters names are measured to end in
- ran for: 28s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- beginnings: 0
- endings: 50653
- stems: 686192
- ids hunted: 137628
- candidates tested: 34758369568
- new: 2
- sketch beginnings: 
- sketch stems: 000012c311da10ff0000153036e7f04000001ec5aa5a75d0000041e573392669000042af8f2b9720000045e1807a46390000502a97bf06ff000051b7b6e7c3e50000595d5e43b51e00008b630b00272f00009c2abd7015410000b8292d62cf930000c63c8d67601c00012a876c73b4c100014cad6bcdce8100014f172cefd1d000015bf4b3c377a8000161fe7c7fb3bf000179ee9b7479ed0001892d1c54956d00019940fc3e141700019d19b275dbfb0001e9d263b7d55a00024dde3c116c50000253b116c73a2f00026692321156850002727cb126db540002797b0cb0c0e00002bf02439b4c180002c4406d93ab780002cc8b5409c9ed0002d9635732ab9e
- sketch endings: 0000065093d2ddcb000009a9246decd30000c0ee97a841da000105e496e34f73000221c75929fb3200024e1052ecac1e00046b3d1855840d0005ae639e926f5d000cbc01b480ab4c000cbec3f4c1a1f2000d92810ddcb5dc0010d8212032c16700110b28e22c5b000011482c992f9b36001280f6cd94de880012a5925ed9cdc700148fff58e34676001538998e20f3570015ecc7299627dc00171438b6fbe1d70017285349dcf2ba001798c7451b75ee001916f3aa09d066001a6f64968748f5001cec1662cf3c52001d2cad0ab0964c001e6153b65350ad001f0b5ecc97c959001fdc30529cddff0021ad1c1ec693070021bc0e48915ced0023b92a21dde19a
- fingerprint: 9215129fcc2e5b09

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/bik_execution_family_20260908-162405.py`
- `scripts/contributed/bo2_bo3_sab_to_bo4_local_20260908-203313.py`
- `scripts/contributed/bo4_cross_title_begins_20260907-200449.txt`
- `scripts/contributed/bo4_mapset_faction_local_20260908-231825.py`
- `scripts/contributed/bo4_music_sound_assets_local_20260908-231825.py`
- `scripts/contributed/bo4_sound_asset_numeric_family_gaps_20260908-203313.py`
- `scripts/contributed/bo4_source_sound_context_token_subs_local_20260908-231825.py`
- `scripts/contributed/bo4_wpn_sab_local_20260908-203313.py`
- `scripts/contributed/chan_ends_20260909-005914.txt`
- `scripts/contributed/cw_cross_title_begins_20260907-200449.txt`
- `scripts/contributed/cw_operator_vox_grid_local_20260908-231825.py`
- `scripts/contributed/hex_grid_volumes_local_20260908-231825.py`
- `scripts/contributed/repo_asset_literals_20260908-231825.py`
- `scripts/contributed/sound_asset_outer_tokens_local_20260908-203313.py`
- `scripts/contributed/uncarried_ends_20260909-025112.txt`
- `scripts/contributed/uncarried_head_tail_atoms_local_20260908-231825.py`
- `scripts/contributed/uncarried_prefix_local_grids_local_20260908-231825.py`
- `scripts/contributed/uncarried_volume_heads_20260909-005914.py`
- `scripts/contributed/volume_family_counterparts_20260908-203313.py`
- `scripts/contributed/cw_uncarried_begins_cross_title_20260907-200449.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.