### PR TITLE
[BLKOPSCW] findings from Hexeption, 20260909-051717 (3 names)

### DIFF
--- a/submissions/Hexeption_BLKOPSCW_20260909-051717/about_20260909-051717.md
+++ b/submissions/Hexeption_BLKOPSCW_20260909-051717/about_20260909-051717.md
@@ -1,0 +1,38 @@
+# Submission 20260909-051717
+
+- game: **BLKOPSCW**
+- from: Hexeption
+- names: 3
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- material: 3
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 100 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260909-051449_plan
+- method: all-boundary sound cores x uncarried sound endings, 5 segment(s), top 100000
+- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
+- ran for: 54s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- beginnings: 0
+- endings: 100000
+- stems: 190826
+- ids hunted: 106889
+- candidates tested: 19082790826
+- new: 3
+- sketch beginnings: 
+- sketch stems: 00002b1519e1ded400002ee0bf50cc960000ef4a2113a6a70001350db49850c6000196f66cc5bd0a0001aef44909c8860001c4288d1f83f80001d42da712184b0002257ec18410d600027ae0cee6de6300033cf2e70d986600033f547a90eb950003ad561d3af4ed0003b69caf19a9720003df052c8c65a400041bbbb5029bd70004411f5ae467110004a5cf1343b3860004f9caa2916c42000624bd7bcc757200063685031d44230006518ce0f1ed4d00068f4e032473900006b5e60602d68c0007d55dbb0777ea000844b2fa104c2f00088364222cf1cd0009595233ae099b0009fc4ea542379a000a6d6d22ada5ec000b32b8830e99c2000c7c620254ad84
+- sketch endings: 00009251736cb79700009dfedd6101880000af8168aabcaa00026a8ad0daf59100029a92e8d933b80002c73c8431647b0004660d5b67ebfb0004c4eab80930220004ca174a05ce12000537248e8b0e7e0005a5af68ceef0f00068b12a3675d7800072a35d0d84eb500077046864384d40007f34776e8215600083c9569936ec9000913c0ce3062b300094acb496e46fe00097401f7e62c6f0009bbc4246821660009f1432718b884000a739e112aae1e000bad932248b753000db8933bbb4711000e02c93a1a2a35000e0613d1742af0000e2f65e04ea0de000e772bf697f051000f976236a0e34d001122ad41e2d9dd0011c0d30b3440690011cec2dc97625b
+- fingerprint: 4399fff2437f144b
+
+**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.

--- a/submissions/Hexeption_BLKOPSCW_20260909-051717/material_20260909-051717.txt
+++ b/submissions/Hexeption_BLKOPSCW_20260909-051717/material_20260909-051717.txt
@@ -1,0 +1,3 @@
+31840445dfac86e,mc/mtl_veh_t9_mil_us_boat_pgb_hexbolt_01_steel_blk_dead
+3d999cfe44601cf7,splm/t9_apo_temple_moss_ext_wall_decal_diffuse
+74ddf1fbd45b40a0,mc/mtl_veh_t9_mil_us_boat_pgb_hexbolt_03_steel_blk_dead


### PR DESCRIPTION
**BLKOPSCW** — 3 asset names, confirmed against that game's own loaded assets.

- material: 3

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Hexeption

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260909-051449_plan
- method: all-boundary sound cores x uncarried sound endings, 5 segment(s), top 100000
- what it does: a targeted beginning + stem + ending search, with all three lists chosen by the plan rather than measured from the whole corpus
- ran for: 54s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- beginnings: 0
- endings: 100000
- stems: 190826
- ids hunted: 106889
- candidates tested: 19082790826
- new: 3
- sketch beginnings: 
- sketch stems: 00002b1519e1ded400002ee0bf50cc960000ef4a2113a6a70001350db49850c6000196f66cc5bd0a0001aef44909c8860001c4288d1f83f80001d42da712184b0002257ec18410d600027ae0cee6de6300033cf2e70d986600033f547a90eb950003ad561d3af4ed0003b69caf19a9720003df052c8c65a400041bbbb5029bd70004411f5ae467110004a5cf1343b3860004f9caa2916c42000624bd7bcc757200063685031d44230006518ce0f1ed4d00068f4e032473900006b5e60602d68c0007d55dbb0777ea000844b2fa104c2f00088364222cf1cd0009595233ae099b0009fc4ea542379a000a6d6d22ada5ec000b32b8830e99c2000c7c620254ad84
- sketch endings: 00009251736cb79700009dfedd6101880000af8168aabcaa00026a8ad0daf59100029a92e8d933b80002c73c8431647b0004660d5b67ebfb0004c4eab80930220004ca174a05ce12000537248e8b0e7e0005a5af68ceef0f00068b12a3675d7800072a35d0d84eb500077046864384d40007f34776e8215600083c9569936ec9000913c0ce3062b300094acb496e46fe00097401f7e62c6f0009bbc4246821660009f1432718b884000a739e112aae1e000bad932248b753000db8933bbb4711000e02c93a1a2a35000e0613d1742af0000e2f65e04ea0de000e772bf697f051000f976236a0e34d001122ad41e2d9dd0011c0d30b3440690011cec2dc97625b
- fingerprint: 4399fff2437f144b

**Next:** a plan is spent at these three lists and no other. Change what it aims at -- a different family, a different pool's stems, the endings that pool actually wears -- rather than widening it: widening is what turned the general search into a method everybody runs and nobody gains from. `scripts/seams.py` says which relations are worth aiming at.


## Tooling this run leaves behind

- `scripts/contributed/bik_execution_family_20260908-162405.py`
- `scripts/contributed/bo2_bo3_sab_to_bo4_local_20260908-203313.py`
- `scripts/contributed/bo4_cross_title_begins_20260907-200449.txt`
- `scripts/contributed/bo4_mapset_faction_local_20260908-231825.py`
- `scripts/contributed/bo4_music_sound_assets_local_20260908-231825.py`
- `scripts/contributed/bo4_sound_asset_numeric_family_gaps_20260908-203313.py`
- `scripts/contributed/bo4_source_sound_context_token_subs_local_20260908-231825.py`
- `scripts/contributed/bo4_wpn_sab_local_20260908-203313.py`
- `scripts/contributed/chan_ends_20260909-005914.txt`
- `scripts/contributed/cw_cross_title_begins_20260907-200449.txt`
- `scripts/contributed/cw_operator_vox_grid_local_20260908-231825.py`
- `scripts/contributed/hex_grid_volumes_local_20260908-231825.py`
- `scripts/contributed/repo_asset_literals_20260908-231825.py`
- `scripts/contributed/sound_asset_outer_tokens_local_20260908-203313.py`
- `scripts/contributed/uncarried_ends_20260909-025112.txt`
- `scripts/contributed/uncarried_head_tail_atoms_local_20260908-231825.py`
- `scripts/contributed/uncarried_prefix_local_grids_local_20260908-231825.py`
- `scripts/contributed/uncarried_volume_heads_20260909-005914.py`
- `scripts/contributed/volume_family_counterparts_20260908-203313.py`
- `scripts/contributed/cw_uncarried_begins_cross_title_20260907-200449.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.