### PR TITLE
[BLKOPSCW] findings from Tnt540, 20260910-054903 (1 names)

### DIFF
--- a/submissions/Tnt540_BLKOPSCW_20260910-054903/about_20260910-054903.md
+++ b/submissions/Tnt540_BLKOPSCW_20260910-054903/about_20260910-054903.md
@@ -1,0 +1,35 @@
+# Submission 20260910-054903
+
+- game: **BLKOPSCW**
+- from: Tnt540
+- names: 1
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- image: 1
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 100 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260910-054506_list
+- method: image channel completion
+- what it does: a candidate list generated outside the search and confirmed here
+- ran for: 6s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPSCW
+- candidates tested: 2618205
+- matched: 3
+- new: 1
+- sketch stems: 0000102ecfb034d9000013b6a770442600001f5059d15ed3000021d60eb05f1c000030905a70ba1d000033f4eab885460000390928de220c00003add22b66a6600003b9f496e1f310000411ce82002be0000456f94434834000052eddb08e5db000054f3951b8a2d0000598d8b071f4b00005cb01562dc1300005d0ed36c5a0300006086707e6ebf0000629afd919599000064c4056c6a8f000067df0de6d53e000072645533decb000082fc0f538339000096e8c6f1189300009af668f959470000a50ef8438ecf0000a522c73772950000ab17d8ced7790000ac84041e550c0000ad7fa18f50200000b30a86ccc3480000b83334faa2bb0000c0b765c8bdfa
+- ids hunted: 108191
+- throughput: 0.8M candidates/s
+- fingerprint: d3d39647f37e7771
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/Tnt540_BLKOPSCW_20260910-054903/image_20260910-054903.txt
+++ b/submissions/Tnt540_BLKOPSCW_20260910-054903/image_20260910-054903.txt
@@ -1,0 +1,1 @@
+24dab8916dadbfa4,i_c_t8_zmb_passenger_female_dresstop1_pink_g


### PR DESCRIPTION
**BLKOPSCW** — 1 asset names, confirmed against that game's own loaded assets.

- image: 1

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Tnt540

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260910-054506_list
- method: image channel completion
- what it does: a candidate list generated outside the search and confirmed here
- ran for: 6s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPSCW
- candidates tested: 2618205
- matched: 3
- new: 1
- sketch stems: 0000102ecfb034d9000013b6a770442600001f5059d15ed3000021d60eb05f1c000030905a70ba1d000033f4eab885460000390928de220c00003add22b66a6600003b9f496e1f310000411ce82002be0000456f94434834000052eddb08e5db000054f3951b8a2d0000598d8b071f4b00005cb01562dc1300005d0ed36c5a0300006086707e6ebf0000629afd919599000064c4056c6a8f000067df0de6d53e000072645533decb000082fc0f538339000096e8c6f1189300009af668f959470000a50ef8438ecf0000a522c73772950000ab17d8ced7790000ac84041e550c0000ad7fa18f50200000b30a86ccc3480000b83334faa2bb0000c0b765c8bdfa
- ids hunted: 108191
- throughput: 0.8M candidates/s
- fingerprint: d3d39647f37e7771

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/image_channels.py`
- `scripts/contributed/image_siblings_20260819-190013.py`
- `scripts/contributed/mp_shared_tail_grid_20260908-062632.py`
- `scripts/contributed/sound_take_gaps_20260909-055456.py`
- `scripts/contributed/uncarried_begins_20260823-023757.txt`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.