### PR TITLE
[BLKOPS04] findings from Kenshin9977, 20260910-140629 (4 names)

### DIFF
--- a/scripts/contributed/bo4_aliases_from_vo_file_stems_20260910-140629.py
+++ b/scripts/contributed/bo4_aliases_from_vo_file_stems_20260910-140629.py
@@ -1,0 +1,18 @@
+"""BO4 sound_alias: the reverse of bo4_vo_files_from_aliases.py - a recovered VO/SFX file stem
+minus its trailing _N is (often) the alias name. Prints the stems of every known/recovered BO4
+sound file, with and without the variant index."""
+import os, re, sys
+here = os.path.dirname(os.path.abspath(__file__)); root = os.path.dirname(here)
+B = chr(92); seen = set()
+srcs = [os.path.join(root, "all_names", "blkops04", "sound_asset.txt"), os.path.join(here, "bo4_mitm2_names_20260910.txt")]
+srcs += [os.path.join(root, "findings", "blkops04", d, "sound_asset.txt") for d in os.listdir(os.path.join(root, "findings", "blkops04")) if d.startswith("run_")]
+for fn in srcs:
+    if not os.path.exists(fn): continue
+    for line in open(fn, encoding="utf-8", errors="replace"):
+        line = line.strip()
+        n = line.split(",", 1)[1] if "," in line else line
+        if B not in n: continue
+        stem = n.rpartition(B)[2].partition(".")[0]
+        for c in (stem, re.sub(r"_\d+$", "", stem)):
+            if c not in seen:
+                seen.add(c); print(c)

--- a/scripts/contributed/bo4_vo_files_aliases_x_dirs_20260910-140629.py
+++ b/scripts/contributed/bo4_vo_files_aliases_x_dirs_20260910-140629.py
@@ -1,0 +1,36 @@
+"""BO4 sound_asset: every known vox_ alias x every VO directory ever observed (+ the zombies map
+dirs), variants "" / _0.._15 / _00.._31, endings sn100 + ln100. Widening of
+bo4_vo_files_from_aliases.py, whose per-alias dir guess (2nd token) misses aliases named after a
+character (vox_mist_*, vox_stuh_*, vox_brun_*...) that live in the map's dir, not the character's."""
+import os, sys
+here = os.path.dirname(os.path.abspath(__file__)); root = os.path.dirname(here)
+B = chr(92)
+aliases = set()
+for line in open(os.path.join(root, "all_names", "blkops04", "sound_alias.txt"), encoding="utf-8"):
+    line = line.strip()
+    if "," in line:
+        a = line.split(",", 1)[1]
+        if a.startswith("vox_") or "_vox_" in a:
+            aliases.add(a)
+dirs = set()
+srcs = [os.path.join(root, "all_names", "blkops04", "sound_asset.txt"), os.path.join(here, "bo4_mitm2_names_20260910.txt")]
+fd = os.path.join(root, "findings", "blkops04")
+srcs += [os.path.join(fd, d, "sound_asset.txt") for d in os.listdir(fd) if d.startswith("run_")]
+for fn in srcs:
+    if not os.path.exists(fn): continue
+    for line in open(fn, encoding="utf-8", errors="replace"):
+        n = line.strip().split(",", 1)[-1]
+        if B + "vox" + B in n:
+            dirs.add(n.rpartition(B)[0])
+for m in ["zod", "zodt8", "escape", "office", "towers", "mansion", "red", "orange", "white", "common", "cmn", "zm_common", "blackout", "wz"]:
+    for mode in ("zmb", "mpl", "wz", "cp"):
+        dirs.add(B.join(["en", "vox", "scripted", mode, m]))
+variants = [""] + ["_%d" % i for i in range(16)] + ["_%02d" % i for i in range(32)]
+tails = [".sn100.pc.snd", ".ln100.pc.snd"]
+print(f"{len(aliases)} aliases x {len(dirs)} dirs x {len(variants)} x {len(tails)}", file=sys.stderr)
+w = sys.stdout.write
+for d in sorted(dirs):
+    for a in aliases:
+        for v in variants:
+            for t in tails:
+                w(d + B + a + v + t + "\n")

--- a/submissions/Kenshin9977_BLKOPS04_20260910-140629/about_20260910-140629.md
+++ b/submissions/Kenshin9977_BLKOPS04_20260910-140629/about_20260910-140629.md
@@ -1,0 +1,35 @@
+# Submission 20260910-140629
+
+- game: **BLKOPS04**
+- from: Kenshin9977
+- names: 4
+- dropped as already published: 0
+- dropped as already claimed by a merged or open submission: 0
+- runs included: 1
+- searched: 6 pool(s): image, material, sound_alias, sound_asset, xanim, xmodel
+- platform: windows x86_64
+- confirmed on: CPU
+- sound_alias: 4
+- expected coincidental matches: 0.000000
+- checked against: the community tables, every merged submission, and the 100 pull request(s) open at the moment of sending
+
+Every name here was confirmed against the game's own loaded assets, and checked against the community tables immediately before sending.
+
+## How these were found
+
+### run_20260910-140016_list
+- method: bo4 sound aliases = recovered sound file stems minus _N
+- what it does: a candidate list generated outside the search and confirmed here
+- ran for: 3s
+- platform: windows x86_64
+- confirmed on: CPU
+- game: BLKOPS04
+- candidates tested: 18353
+- matched: 4
+- new: 4
+- sketch stems: 000066650ac64df10001eb9aa00ec2b500030ae1607bc264000579eb213f48ad000662cdb613fb8b000783c3c8d33f4d000ddc152670e7db000e06c8971ef0c3000fb97ad3970c4000185b4decdacba500185d9903dae2cf001b51744397ea940020802cdabeec340029e7f743652e2a002e6c60554dcfd4002fc14e5756054c0038d3ed97d2c32d004195c5eb9b86020044a0a85112af2d0049bc21707c95a4005236f7447c39d100551c649ca17582005841425ad72f1f0058e110d2e2b34f005d253fa05ce532005e6f2747362151005f2d41c15e7bff006024e85a8e9dbe00667c1a67337fc700672b60defdee3800675e7ef03c4608006c0b08322cf50c
+- ids hunted: 135275
+- throughput: 0.3M candidates/s
+- fingerprint: 731d84d6c0296a73
+
+**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.

--- a/submissions/Kenshin9977_BLKOPS04_20260910-140629/sound_alias_20260910-140629.txt
+++ b/submissions/Kenshin9977_BLKOPS04_20260910-140629/sound_alias_20260910-140629.txt
@@ -1,0 +1,4 @@
+1c2eb3b51845557,vox_anme_bb_sticks_stones_start
+30d9208902cc663e,vox_anme_bb_sticks_stones_start_hardcore
+49823813463afb1f,vox_anbo_bb_sticks_stones_start_hardcore
+60119a2529a4df54,vox_anbo_bb_sticks_stones_start


### PR DESCRIPTION
**BLKOPS04** — 4 asset names, confirmed against that game's own loaded assets.

- sound_alias: 4

**Checked against, at the moment of sending:** the community hash tables (refreshed first), every merged submission in this repository, and every pull request open right now. A name any of those already holds was dropped rather than sent.

- dropped as already published: 0
- dropped as already claimed by a merged or open submission: 0
- submitted by: @Kenshin9977

Files are named with the time they were sent, so nothing collides with an earlier batch. Every hash here is re-verified against the shipped snapshot by CI; nothing is taken on the word of the client that found it.

## How these were found

### run_20260910-140016_list
- method: bo4 sound aliases = recovered sound file stems minus _N
- what it does: a candidate list generated outside the search and confirmed here
- ran for: 3s
- platform: windows x86_64
- confirmed on: CPU
- game: BLKOPS04
- candidates tested: 18353
- matched: 4
- new: 4
- sketch stems: 000066650ac64df10001eb9aa00ec2b500030ae1607bc264000579eb213f48ad000662cdb613fb8b000783c3c8d33f4d000ddc152670e7db000e06c8971ef0c3000fb97ad3970c4000185b4decdacba500185d9903dae2cf001b51744397ea940020802cdabeec340029e7f743652e2a002e6c60554dcfd4002fc14e5756054c0038d3ed97d2c32d004195c5eb9b86020044a0a85112af2d0049bc21707c95a4005236f7447c39d100551c649ca17582005841425ad72f1f0058e110d2e2b34f005d253fa05ce532005e6f2747362151005f2d41c15e7bff006024e85a8e9dbe00667c1a67337fc700672b60defdee3800675e7ef03c4608006c0b08322cf50c
- ids hunted: 135275
- throughput: 0.3M candidates/s
- fingerprint: 731d84d6c0296a73

**Next:** if this paid, feed what it found back into the generator and run it again -- every confirmed name is new vocabulary. If it did not, say so in METHODS.md under the dead ends, which is worth as much as a find.


## Tooling this run leaves behind

- `scripts/contributed/bo4_aliases_from_vo_file_stems_20260910-140629.py`
- `scripts/contributed/bo4_mitm2_gap_fill_20260910-134458.py`
- `scripts/contributed/bo4_mitm2_gen_inputs_20260910-134458.py`
- `scripts/contributed/bo4_mitm2_names_20260910-134458.txt`
- `scripts/contributed/bo4_vo_files_aliases_x_dirs_20260910-140629.py`
- `scripts/contributed/bo4_vo_files_from_aliases_20260910-135933.py`

These are the scripts that produced the names above. They are here so the next contributor inherits the method rather than only its output.